### PR TITLE
Update openapi.yaml

### DIFF
--- a/generator_config.yaml
+++ b/generator_config.yaml
@@ -3,7 +3,7 @@ additionalProperties:
   packageName: "dip_bundestag"
   infoName: "BundesAPI"
   infoEmail: "kontakt@bund.dev"
-  packageVersion: 0.1.0
+  packageVersion: 0.1.1
   packageUrl: "https://github.com/bundesAPI/dip-bundestag-api"
   namespace: "deutschland"
   docLanguage: "de"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6795 +1,1896 @@
-openapi: "3.0.0"
+---
+openapi: "3.0.1"
 info:
-  title: "DIP Bundestag API"
-  version: "1.0.0"
-  description: "Bundestag: Dokumentations- und Informationssystem für Parlamentsmaterialien"
-  contact: 
-    name: "bund.dev"
-    email: "kontakt@bund.dev"
-    url:  "https://bund.dev"
-
+  title: "Deutscher Bundestag - DIP"
+  description: "API des Dokumentations- und Informationssystems für Parlamentsmaterialien"
+  version: "1.2"
+  termsOfService: "https://dip.bundestag.de/%C3%BCber-dip/nutzungsbedingungen"
+  contact:
+    name: "Auskunfts- und Rechercheservice der Parlamentsdokumentation"
+    email: "parlamentsdokumentation@bundestag.de"
 servers:
-  - url: "https://search.dip.bundestag.de/api/v1"
-
+- url: "https://search.dip.bundestag.de/api/v1"
+security:
+- ApiKeyHeader: []
+- ApiKeyQuery: []
 paths:
-  /aktivitaet:
-    get:
-      summary: Liste aller Aktivitäten
-      description: Liste aller Aktivitäten
-      operationId: aktivitaet
-      tags:
-        - aktivitaet
-      parameters:
-        - in: query
-          name: format
-          schema:
-            type: string
-            enum:
-              - json
-              - xml
-          description: Format
-          example: "json"
-          required: false
-        - in: query
-          name: cursor
-          schema: 
-            type: string
-          description: "Position des Cursors zur Anfrage weiterer Entitäten (s. Folgeanfragen nach weiteren Entitäten)."
-          example: AoJwwOKPs1MCNFBsZW5hcnByb3Rva29sbC00NzM5
-          required: false
-        - in: query
-          name: f.id
-          schema:
-            type: integer
-          description: "ID der Entität. Kann wiederholt werden, um mehrere Entitäten zu selektieren (z.B. f.id=84393&f.id=84394)."
-          example: 84394
-          required: false
-        - in: query
-          name: f.datum.start
-          schema:
-            type: string
-          description: "Frühestes Datum der Entität im Format JJJJ-MM-TT. Selektiert Entitäten in einem Datumsbereich basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich aller zugehörigen Dokumente herangezogen."
-          example: 2020-01-01
-        - in: query
-          name: f.datum.end
-          schema:
-            type: string
-          description: "Spätestes Datum der Entität im Format JJJJ-MM-TT. Selektiert Entitäten in einem Datumsbereich basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich aller zugehörigen Dokumente herangezogen."
-          example: 2020-02-28
-        - in: query
-          name: f.drucksache
-          schema:
-            type: integer
-          description: "ID einer verknüpften Drucksache. Selektiert alle Entitäten, die mit der angegebenen Drucksache verknüpft sind. Nur für die Ressourcentypen: aktivitaet, vorgangvorgangsposition."
-          example: 68852
-        - in: query
-          name: f.plenarprotokoll
-          schema:
-            type: integer
-          description: "ID eines verknüpften Plenarprotokolls. Selektiert alle Entitäten, die mit dem angegebenen Plenarprotokoll verknüpft sind. Nur für die Ressourcentypen: aktivitaet, vorgang, vorgangsposition." 
-          example: 908
-        - in: query
-          name: f.zuordnung
-          schema:
-            type: string
-            enum:
-              - BT
-              - BR
-              - BV
-              - EK
-          description: "Zuordnung der Entität zum Bundestag (BT), Bundesrat (BR), Bundesversammlung (BV) oder Europakammer (EK). Nur für die Ressourcentypen: aktivitaet, drucksache."
-          example: BT
-      responses:
-        '200':
-            description: OK
-            content:
-              application/json:
-                schema:
-                  type: object
-                example:
-                  numFound: 1559455
-                  documents:
-                    - id: '1581184'
-                      aktivitaetsart: Kleine Anfrage
-                      typ: Aktivität
-                      vorgangsbezug_anzahl: 1
-                      dokumentart: Drucksache
-                      wahlperiode: 20
-                      datum: '2021-11-02'
-                      titel: Zaklin Nastic, MdB, DIE LINKE
-                      fundstelle:
-                        pdf_url: https://dserver.bundestag.de/btd/20/000/2000007.pdf
-                        id: '258207'
-                        dokumentnummer: 20/7
-                        datum: '2021-11-02'
-                        dokumentart: Drucksache
-                        drucksachetyp: Kleine Anfrage
-                        herausgeber: BT
-                        urheber:
-                          - Fraktion DIE LINKE
-                      vorgangsbezug:
-                        - vorgangsposition: Kleine Anfrage
-                          vorgangstyp: Kleine Anfrage
-                          titel: Politisch motivierte Kriminalität rechts im September 2021
-                          id: '282601'
-                    - id: '1581183'
-                      aktivitaetsart: Kleine Anfrage
-                      typ: Aktivität
-                      vorgangsbezug_anzahl: 1
-                      dokumentart: Drucksache
-                      wahlperiode: 20
-                      datum: '2021-11-02'
-                      titel: Cornelia Möhring, MdB, DIE LINKE
-                      fundstelle:
-                        pdf_url: https://dserver.bundestag.de/btd/20/000/2000007.pdf
-                        id: '258207'
-                        dokumentnummer: 20/7
-                        datum: '2021-11-02'
-                        dokumentart: Drucksache
-                        drucksachetyp: Kleine Anfrage
-                        herausgeber: BT
-                        urheber:
-                          - Fraktion DIE LINKE
-                      vorgangsbezug:
-                        - vorgangsposition: Kleine Anfrage
-                          vorgangstyp: Kleine Anfrage
-                          titel: Politisch motivierte Kriminalität rechts im September 2021
-                          id: '282601'
-                  cursor: AoJwwPLPwPwCMkFrdGl2aXRhZXQtMTU4MTE1Mg==
-        '401':
-          $ref: "#/components/responses/UnauthorizedError"
-        '404':
-          $ref: "#/components/responses/NotFoundError"
-
-  /aktivitaet/{id}:
-    get:
-      summary: Metadaten zu Aktivität
-      description: Metadaten zu Aktivität
-      operationId: aktivitaetId
-      tags:
-        - aktivitaet
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-            example: 908
-          required: true
-          description: ID der Aktivität
-        - in: query
-          name: format
-          schema:
-            type: string
-            enum:
-              - json
-              - xml
-          description: Format
-          example: "json"
-          required: false
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-              example:
-                id: '908'
-                aktivitaetsart: Antrag
-                typ: Aktivität
-                vorgangsbezug_anzahl: 1
-                dokumentart: Drucksache
-                wahlperiode: 16
-                datum: '2005-12-14'
-                titel: Harald Leibrecht, MdB, FDP
-                fundstelle:
-                  pdf_url: https://dserver.bundestag.de/btd/16/002/1600225.pdf
-                  id: '312'
-                  dokumentnummer: 16/225
-                  datum: '2005-12-14'
-                  dokumentart: Drucksache
-                  drucksachetyp: Antrag
-                  herausgeber: BT
-                  urheber:
-                    - Fraktion der FDP
-                vorgangsbezug:
-                  - vorgangsposition: Antrag
-                    vorgangstyp: Antrag
-                    titel: 'Menschenrechte in Usbekistan einfordern (G-SIG: 16010078)'
-                    id: '6286'
-        '401':
-          $ref: "#/components/responses/UnauthorizedError"
-        '404':
-          $ref: "#/components/responses/NotFoundError"
-
-  /drucksache:
-    get:
-      summary: Liste aller Drucksachen
-      description: Liste aller Drucksachen
-      operationId: drucksache
-      tags:
-        - drucksache      
-      parameters:
-        - in: query
-          name: format
-          schema:
-            type: string
-            enum:
-              - json
-              - xml
-          description: Format
-          example: "json"
-          required: false
-        - in: query
-          name: cursor
-          schema: 
-            type: string
-          description: "Position des Cursors zur Anfrage weiterer Entitäten (s. Folgeanfragen nach weiteren Entitäten)."
-          example: AoJwwOKPs1MCNFBsZW5hcnByb3Rva29sbC00NzM5
-          required: false
-        - in: query
-          name: f.id
-          schema:
-            type: integer
-          description: "ID der Entität. Kann wiederholt werden, um mehrere Entitäten zu selektieren (z.B. f.id=84393&f.id=84394)."
-          example: 84394
-          required: false
-        - in: query
-          name: f.datum.start
-          schema:
-            type: string
-          description: "Frühestes Datum der Entität im Format JJJJ-MM-TT. Selektiert Entitäten in einem Datumsbereich basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich aller zugehörigen Dokumente herangezogen."
-          example: 2020-01-01
-        - in: query
-          name: f.datum.end
-          schema:
-            type: string
-          description: "Spätestes Datum der Entität im Format JJJJ-MM-TT. Selektiert Entitäten in einem Datumsbereich basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich aller zugehörigen Dokumente herangezogen."
-          example: 2020-02-28
-        - in: query
-          name: f.zuordnung
-          schema:
-            type: string
-            enum:
-              - BT
-              - BR
-              - BV
-              - EK
-          description: "Zuordnung der Entität zum Bundestag (BT), Bundesrat (BR), Bundesversammlung (BV) oder Europakammer (EK). Nur für die Ressourcentypen: aktivitaet, drucksache."
-          example: BT
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-              example:
-                numFound: 256903
-                documents:
-                  - id: '258210'
-                    drucksachetyp: Verordnung
-                    dokumentart: Drucksache
-                    autoren_anzahl: 0
-                    typ: Dokument
-                    vorgangsbezug_anzahl: 1
-                    dokumentnummer: 20/8
-                    wahlperiode: 20
-                    herausgeber: BT
-                    datum: '2021-11-03'
-                    titel: Verordnung zur Festsetzung des ergänzenden Bundeszuschusses nach § 221a Absatz
-                      3 Satz 3 des Fünften Buches Sozialgesetzbuch für das Jahr 2022 (Bundeszuschussverordnung
-                      2022)
-                    fundstelle:
-                      pdf_url: https://dserver.bundestag.de/btd/20/000/2000008.pdf
-                      id: '258210'
-                      dokumentnummer: 20/8
-                      datum: '2021-11-03'
-                      verteildatum: '2021-11-03'
-                      dokumentart: Drucksache
-                      drucksachetyp: Verordnung
-                      herausgeber: BT
-                      urheber:
-                        - Bundesministerium für Gesundheit
-                    urheber:
-                      - einbringer: false
-                        bezeichnung: BMG
-                        titel: Bundesministerium für Gesundheit
-                    vorgangsbezug:
-                      - id: '282604'
-                        titel: Verordnung zur Festsetzung des ergänzenden Bundeszuschusses nach § 221a Absatz
-                          3 Satz 3 des Fünften Buches Sozialgesetzbuch für das Jahr 2022 (Bundeszuschussverordnung
-                          2022)
-                        vorgangstyp: Rechtsverordnung
-                  - id: '258209'
-                    drucksachetyp: Vorschlag
-                    dokumentart: Drucksache
-                    autoren_anzahl: 0
-                    typ: Dokument
-                    vorgangsbezug_anzahl: 1
-                    dokumentnummer: 782/21
-                    wahlperiode: 20
-                    herausgeber: BR
-                    datum: '2021-11-02'
-                    titel: Benennung eines stellvertretenden Mitglieds für den Beirat der Bundesnetzagentur
-                      für Elektrizität, Gas, Telekommunikation, Post und Eisenbahnen
-                    fundstelle:
-                      pdf_url: https://dserver.bundestag.de/brd/2021/0782-21.pdf
-                      id: '258209'
-                      dokumentnummer: 782/21
-                      datum: '2021-11-02'
-                      dokumentart: Drucksache
-                      drucksachetyp: Vorschlag
-                      herausgeber: BR
-                      urheber: [ ]
-                    vorgangsbezug:
-                      - id: '282603'
-                        titel: Benennung eines stellvertretenden Mitglieds für den Beirat der Bundesnetzagentur
-                          für Elektrizität, Gas, Telekommunikation, Post und Eisenbahnen
-                        vorgangstyp: Besetzung externer Gremien durch BR
-                cursor: AoJwgOLMrvwCMURydWNrc2FjaGUtMjU4MDk3
-        '401':
-          $ref: "#/components/responses/UnauthorizedError"
-        '404':
-          $ref: "#/components/responses/NotFoundError"
-
-  /drucksache/{id}:
-    get:
-      summary: Metadaten zu Drucksache
-      description: Metadaten zu Drucksache
-      operationId: drucksacheId
-      tags:
-        - drucksache
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-            example: 908
-          required: true
-          description: ID der Drucksache
-        - in: query
-          name: format
-          schema:
-            type: string
-            enum:
-              - json
-              - xml
-          description: Format
-          example: "json"
-          required: false
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-              example:
-                id: '908'
-                drucksachetyp: Antrag
-                dokumentart: Drucksache
-                autoren_anzahl: 0
-                typ: Dokument
-                vorgangsbezug_anzahl: 2
-                dokumentnummer: 15/5005
-                wahlperiode: 15
-                herausgeber: BT
-                datum: '2005-03-03'
-                titel: "Rechnung des Bundesrechnungshofes für das Haushaltsjahr 2004 \n- Einzelplan
-                  20 -"
-                fundstelle:
-                  pdf_url: https://dserver.bundestag.de/btd/15/050/1505005.pdf
-                  id: '908'
-                  dokumentnummer: 15/5005
-                  datum: '2005-03-03'
-                  dokumentart: Drucksache
-                  drucksachetyp: Antrag
-                  herausgeber: BT
-                  urheber:
-                    - Präsident des Bundesrechnungshofes
-                urheber:
-                  - einbringer: false
-                    bezeichnung: BRHPräs
-                    titel: Präsident des Bundesrechnungshofes
-                vorgangsbezug:
-                  - id: '1563'
-                    titel: 'Rechnung des Bundesrechnungshofes für das Haushaltsjahr 2004 - Einzelplan
-                    20 - (G-SIG: 16000389)'
-                    vorgangstyp: Entlastung des Bundesrechnungshofes
-                  - id: '89305'
-                    titel: 'Rechnung des Bundesrechnungshofes für das Haushaltsjahr 2004 - Einzelplan
-                    20 - (G-SIG: 15001421)'
-                    vorgangstyp: Entlastung des Bundesrechnungshofes
-        '401':
-          $ref: "#/components/responses/UnauthorizedError"
-        '404':
-          $ref: "#/components/responses/NotFoundError"
-
-  /drucksache-text:
-    get:
-      summary: Liste aller Volltexte der Drucksachen
-      description: Liste aller Volltexte der Drucksachen
-      operationId: drucksacheText
-      tags:
-        - drucksache      
-      parameters:
-        - in: query
-          name: format
-          schema:
-            type: string
-          description: Format (json or xml)
-          example: "json"
-          required: false
-        - in: query
-          name: cursor
-          schema: 
-            type: string
-          description: "Position des Cursors zur Anfrage weiterer Entitäten (s. Folgeanfragen nach weiteren Entitäten)."
-          example: AoJwwOKPs1MCNFBsZW5hcnByb3Rva29sbC00NzM5
-          required: false
-        - in: query
-          name: f.id
-          schema:
-            type: integer
-          description: "ID der Entität. Kann wiederholt werden, um mehrere Entitäten zu selektieren (z.B. f.id=84393&f.id=84394)."
-          example: 84394
-          required: false
-        - in: query
-          name: f.datum.start
-          schema:
-            type: string
-          description: "Frühestes Datum der Entität im Format JJJJ-MM-TT. Selektiert Entitäten in einem Datumsbereich basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich aller zugehörigen Dokumente herangezogen."
-          example: 2020-01-01
-        - in: query
-          name: f.datum.end
-          schema:
-            type: string
-          description: "Spätestes Datum der Entität im Format JJJJ-MM-TT. Selektiert Entitäten in einem Datumsbereich basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich aller zugehörigen Dokumente herangezogen."
-          example: 2020-02-28
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-              example:
-                numFound: 256903
-                documents:
-                  - id: '258210'
-                    drucksachetyp: Verordnung
-                    dokumentart: Drucksache
-                    autoren_anzahl: 0
-                    typ: Dokument
-                    dokumentnummer: 20/8
-                    wahlperiode: 20
-                    herausgeber: BT
-                    datum: '2021-11-03'
-                    titel: Verordnung zur Festsetzung des ergänzenden Bundeszuschusses nach § 221a Absatz
-                      3 Satz 3 des Fünften Buches Sozialgesetzbuch für das Jahr 2022 (Bundeszuschussverordnung
-                      2022)
-                    text: "Deutscher Bundestag Drucksache 20/8 \n20. Wahlperiode 03.11.2021 \nVerordnung
-                      \ndes Bundesministeriums für Gesundheit \nVerordnung zur Festsetzung des ergänzenden
-                      Bundeszuschusses nach  \n§ 221a Absatz 3 Satz 3 des Fünften Buches Sozialgesetzbuch
-                      für das Jahr 2022 \n(Bundeszuschussverordnung 2022) \nA. Problem und Ziel \nNach
-                      Auswertung der Prognose des beim Bundesamt für Soziale Sicherung ge-\nbildeten Schätzerkreises
-                      zu den Einnahmen und Ausgaben der gesetzlichen Kran-\nkenversicherung (GKV) in den
-                      Jahren 2021 und 2022 ergibt sich insbesondere \ndurch die COVID-19-Pandemie in Verbindung
-                      mit der dadurch ausgelösten Wirt-\nschaftskrise ein veränderter Finanzbedarf der
-                      GKV für das Jahr 2022. Ohne zu-\nsätzliche Finanzmittel des Bundes für das Jahr
-                      2022 wären erhebliche Zusatzbei-\ntragssatzsteigerungen zu Lasten der Beitragszahlerinnen
-                      und Beitragszahler in der \nGKV zu erwarten. Zugleich wäre die deutsche Wirtschaft
-                      mit höheren Lohnne-\nbenkosten konfrontiert, während sie mit den wirtschaftlichen
-                      Folgen der Pande-\nmie belastet ist. Um eine Stabilität des durchschnittlichen Zusatzbeitrags
-                      zu errei-\nchen, bedarf es zusätzlich zum Bundeszuschuss nach § 221 Absatz 1 des
-                      Fünften \nBuches Sozialgesetzbuch einer abweichenden Festsetzung des ergänzenden
-                      Bun-\ndeszuschusses an den Gesundheitsfonds einschließlich eines Anteils der landwirt-\nschaftlichen
-                      Krankenversicherung. \nB. Lösung \nDer Gesetzgeber hat mit dem Gesundheitsversorgungsweiterentwicklungsgesetz
-                      \nvom 11. Juli 2021 (BGBl. I S. 2754) in § 221a Absatz 3 Satz 1 des Fünften Buches
-                      \nSozialgesetzbuch einen ergänzenden Bundeszuschuss für das Jahr 2022 in Höhe \nvon
-                      7 Milliarden Euro festgelegt. Das Bundesministerium für Gesundheit wurde \ngemäß
-                      § 221a Absatz 3 Satz 3 des Fünften Buches Sozialgesetzbuch befristet bis \nzum 31.
-                      Dezember 2021 ermächtigt, durch Rechtsverordnung im Einvernehmen \nmit dem Bundesministerium
-                      der Finanzen und mit Zustimmung des Deutschen \nBundestages einen abweichenden ergänzenden
-                      Bundeszuschuss festzusetzen, um \nden durchschnittlichen Zusatzbeitragssatz zur
-                      gesetzlichen Krankenversicherung \nnach § 242a des Fünften Buches Sozialgesetzbuch
-                      im Jahr 2022 bei 1,3 Prozent \nzu stabilisieren. Um dieses Ziel zu erreichen, bedarf
-                      es eines ergänzenden Bun-\ndeszuschusses in Höhe von 14 Milliarden Euro anstatt
-                      7 Milliarden Euro. Abwei-\nchend von § 221a Absatz 3 Satz 1 des Fünften Buches Sozialgesetzbuch
-                      wird der \nergänzende Bundeszuschuss für das Jahr 2022 daher auf einen Betrag von
-                      14 Mil-\nV\norabfassung - w\nird durch die lektorierte Fassung ersetzt. \nDrucksache
-                      20/8 – 2 – Deutscher Bundestag – 20. Wahlperiode \n \n \nliarden Euro festgesetzt.
-                      Der Anteil der landwirtschaftlichen Krankenversiche-\nrung an diesem Betrag ist
-                      gemäß § 221a Absatz 3 Satz 4 zweiter Halbsatz des \nFünften Buches Sozialgesetzbuch
-                      entsprechend dem Verhältnis des der landwirt-\nschaftlichen Krankenversicherung
-                      nach § 221a Absatz 3 Satz 2 des Fünften Bu-\nches Sozialgesetzbuch vom Gesundheitsfonds
-                      zu überweisenden Betrags zum er-\ngänzenden Bundeszuschuss nach § 221a Absatz 3
-                      Satz 1 des Fünften Buches So-\nzialgesetzbuch auf 84 Millionen Euro festzusetzen.
-                      \nDurch die Stabilisierung des durchschnittlichen Zusatzbeitrags zur GKV im Jahr
-                      \n2022 leistet der Bund einen erheblichen Beitrag zur Begrenzung der Sozialversi-\ncherungsbeiträge
-                      auf unter 40 Prozent und damit zur schnelleren Erholung der \ndeutschen Wirtschaft
-                      nach der COVID-19-Pandemie. \nC. Alternativen \nKeine. \nD. Haushaltsausgaben ohne
-                      Erfüllungsaufwand \nDem Bund entstehen im Jahr 2022 Mehrausgaben in Höhe von 7 Milliarden
-                      Euro. \nDer gesetzlichen Krankenversicherung entstehen im Jahr 2022 Mehreinnahmen
-                      \nvon 7 Milliarden Euro. \nE. Erfüllungsaufwand \nE.1 Erfüllungsaufwand für Bürgerinnen
-                      und Bürger \nKeiner. \nE.2 Erfüllungsaufwand für die Wirtschaft \nKeiner. \nDavon
-                      Bürokratiekosten aus Informationspflichten \nKeine. \nE.3 Erfüllungsaufwand der
-                      Verwaltung \nKeiner. \nF. Weitere Kosten \nKeine.  \nV\norabfassung - w\nird durch
-                      die lektorierte Fassung ersetzt. \nDeutscher Bundestag – 20. Wahlperiode – 3 – Drucksache
-                      20/8 \n \nBUNDESREPUBLIK DEUTSCHLAND Berlin, 3. November 2021 \nDIE BUNDESKANZLERIN
-                      \nAn die \nPräsidentin des  \nDeutschen Bundestages \nFrau Bärbel Bas \nPlatz der
-                      Republik 1 \n11011 Berlin \nSehr geehrte Frau Präsidentin, \nhiermit übersende ich
-                      die von der Bundesregierung beschlossene \nVerordnung zur Festsetzung des ergänzenden
-                      Bundeszuschusses \nnach § 221a Absatz 3 Satz 3 des Fünften Buches Sozialgesetzbuch
-                      \nfür das Jahr 2022  \n(Bundeszuschussverordnung 2022) \nmit Begründung und Vorblatt
-                      (Anlage). \nIch bitte, die Zustimmung des Deutschen Bundestages aufgrund des § 221a
-                      \nAbsatz 3 Satz 3 des Fünften Buches Sozialgesetzbuch herbeizuführen. \nFederführend
-                      ist das Bundesministerium für Gesundheit. \nMit freundlichen Grüßen \nDr. Angela
-                      Merkel \nV\norabfassung - w\nird durch die lektorierte Fassung ersetzt.\nDrucksache
-                      20/8 – 4 – Deutscher Bundestag – 20. Wahlperiode \nVerordnung zur Festsetzung des
-                      ergänzenden Bundeszuschusses nach \n§ 221a Absatz 3 Satz 3 des Fünften Buches Sozialgesetzbuch
-                      für das Jahr 2022\n(Bundeszuschussverordnung 2022) \nVom ... \nAuf Grund des § 221a
-                      Absatz 3 Satz 3 und 4 des Fünften Buches Sozialgesetzbuch, der durch Artikel 1 \nNummer
-                      52a Buchstabe b des Gesetzes vom 11. Juli 2021 (BGBl. I S. 2754) eingefügt worden
-                      ist, verordnet das \nBundesministerium für Gesundheit im Einvernehmen mit dem Bundesministerium
-                      der Finanzen unter Berück-\nsichtigung des Beschlusses des Bundestages vom … [einsetzen:
-                      Datum des Beschlusses des Bundestages]: \n§ 1\nErgänzender Bundeszuschuss 2022 \nAbweichend
-                      von § 221a Absatz 3 Satz 1 des Fünften Buches Sozialgesetzbuch wird ein ergänzender
-                      Bun-\ndeszuschuss für das Jahr 2022 in Höhe von 14 Milliarden Euro festgesetzt.
-                      Abweichend von § 221a Absatz 3 Satz \n2 des Fünften Buches Sozialgesetzbuch wird
-                      der von dem Gesundheitsfonds an die landwirtschaftliche Kranken-\nversicherung zu
-                      überweisende Betrag auf 84 Millionen Euro festgesetzt. \n§ 2\nInkrafttreten  \nDiese
-                      Verordnung tritt am Tag nach der Verkündung in Kraft.  \nV\norabfassung - w\nird
-                      durch die lektorierte Fassung ersetzt.\nDeutscher Bundestag – 20. Wahlperiode –
-                      5 – Drucksache 20/8 \nBegründung \nA. Allgemeiner Teil \nI. Zielsetzung und Notwendigkeit
-                      der Regelungen \nNach Auswertung der Prognose des beim Bundesamt für Soziale Sicherung
-                      gebildeten Schätzerkreises zu den \nEinnahmen und Ausgaben der gesetzlichen Krankenversicherung
-                      (GKV) in den Jahren 2021 und 2022 ergibt sich \ninsbesondere durch die COVID-19-Pandemie
-                      in Verbindung mit der dadurch ausgelösten Wirtschaftskrise ein \nveränderter Finanzbedarf
-                      der GKV für das Jahr 2022.Ohne zusätzliche Finanzmittel des Bundes für das Jahr
-                      2022 \nwären erhebliche Zusatzbeitragssatzsteigerungen zu Lasten der Beitragszahlerinnen
-                      und Beitragszahler in der \nGKV zu erwarten. Zugleich wäre die deutsche Wirtschaft
-                      mit höheren Lohnnebenkosten konfrontiert, während \nsie mit den wirtschaftlichen
-                      Folgen der Pandemie belastet ist. Um eine Stabilität des durchschnittlichen Zusatz-\nbeitrags
-                      zu erreichen, bedarf es zusätzlich zum Bundeszuschuss nach § 221 Absatz 1 des Fünften
-                      Buches Sozial-\ngesetzbuch einer abweichenden Festsetzung des ergänzenden Bundeszuschusses
-                      an den Gesundheitsfonds ein-\nschließlich eines Anteils der landwirtschaftlichen
-                      Krankenversicherung. \nDer Gesetzgeber hat mit dem Gesundheitsversorgungsweiterentwicklungsgesetz
-                      vom 11. Juli 2021 (BGBl. I S. \n2754; im Folgenden GVWG) in § 221a Absatz 3 Satz
-                      1 des Fünften Buches Sozialgesetzbuch einen ergänzenden \nBundeszuschuss für das
-                      Jahr 2022 in Höhe von 7 Milliarden Euro festgelegt. Das Bundesministerium für Gesund-\nheit
-                      wurde gemäß § 221a Absatz 3 Satz 3 des Fünften Buches Sozialgesetzbuch befristet
-                      bis zum 31. Dezember \n2021 ermächtigt, durch Rechtsverordnung im Einvernehmen mit
-                      dem Bundesministerium der Finanzen und mit \nZustimmung des Deutschen Bundestages
-                      einen abweichenden ergänzenden Bundeszuschuss festzusetzen,  \nDer Schätzerkreis
-                      aus Finanzexperten des Bundesamts für Soziale Sicherung, des Bundesministeriums
-                      für Ge-\nsundheit und des Spitzenverbands Bund der Krankenkassen hat am 13. Oktober
-                      2021 die Einnahmen und die \nAusgaben der GKV für die Jahre 2021 und 2022 geschätzt.
-                      Die Neufestsetzung des Bundeszuschusses ist erfor-\nderlich, weil sich nach Auswertung
-                      der Prognosen des Schätzerkreises ein veränderter Finanzbedarf der GKV für \ndas
-                      Jahr 2022 ergeben hat, um den durchschnittlichen Zusatzbeitragssatz zur GKV bei
-                      1,3 Prozent zu stabilisieren. \nDer Anteil der landwirtschaftlichen Krankenversicherung
-                      an diesem Betrag ist gemäß § 221a Absatz 3 Satz 4 \nzweiter Halbsatz des Fünften
-                      Buches Sozialgesetzbuch entsprechend dem Verhältnis des der landwirtschaftlichen
-                      \nKrankenversicherung nach § 221a Absatz 3 Satz 2 des Fünften Buches Sozialgesetzbuch
-                      vom Gesundheitsfonds \nzu überweisenden Betrags zum ergänzenden Bundeszuschuss nach
-                      § 221a Absatz 3 Satz 1 des Fünften Buches \nSozialgesetzbuch auf 84 Millionen Euro
-                      festzusetzen. \nDurch die Stabilisierung des durchschnittlichen Zusatzbeitrages
-                      zur GKV im Jahr 2022 leistet der Bund einen \nerheblichen Beitrag zur Begrenzung
-                      der Sozialversicherungsbeiträge auf unter 40 Prozent und damit zur schnel-\nleren
-                      Erholung der deutschen Wirtschaft nach der COVID-19-Pandemie. \nII. Wesentlicher
-                      Inhalt\nMit der Verordnung wird die Höhe des ergänzenden Bundeszuschusses durch
-                      das Bundesministerium für Ge-\nsundheit im Einvernehmen mit dem Bundesministerium
-                      der Finanzen und mit Zustimmung des Deutschen Bun-\ndestages abweichend von § 221a
-                      Absatz 3 Satz 1 des Fünften Buches Sozialgesetzbuch auf einen Betrag von 14 \nMilliarden
-                      Euro festgesetzt. Gleichzeitig wird der Anteil der landwirtschaftlichen Krankenversicherung
-                      am er-\ngänzenden Bundeszuschuss gemäß § 221a Absatz 3 Satz 4 zweiter Halbsatz des
-                      Fünften Buches Sozialgesetzbuch \nauf 84 Millionen Euro angepasst. Durch den ergänzenden
-                      Bundeszuschuss in Höhe von 14 Milliarden Euro wird \nsichergestellt, dass der durchschnittliche
-                      Zusatzbeitragssatz zur GKV nach § 242a des Fünften Buches Sozialge-\nsetzbuch im
-                      Jahr 2022 bei 1,3 Prozent stabilisiert wird. Zugleich sorgt der ergänzende Bundeszuschuss
-                      für Bei-\ntragsstabilität in der landwirtschaftlichen Krankenversicherung.  \nV\norabfassung
-                      - w\nird durch die lektorierte Fassung ersetzt.\nDrucksache 20/8 – 6 – Deutscher
-                      Bundestag – 20. Wahlperiode \nIII. Alternativen\nKeine. \nIV. Regelungskompetenz\nDie
-                      Regelungskompetenz ergibt sich aus § 221a Absatz 3 Satz 3 und 4 des Fünften Buches
-                      Sozialgesetzbuch, der \ndurch Artikel 1 Nummer 52a Buchstabe b des Gesetzes vom
-                      11. Juli 2021 (BGBl. I S. 2754) eingefügt worden \nist. \nV. Vereinbarkeit mit dem
-                      Recht der Europäischen Union und völkerrechtlichen Verträgen \nDie Verordnung ist
-                      mit dem Recht der Europäischen Union und den völkerrechtlichen Verträgen, die die
-                      Bun-\ndesrepublik Deutschland abgeschlossen hat, vereinbar. \nVI. Regelungsfolgen\n1.
-                      Rechts- und Verwaltungsvereinfachung\nKeine. \n2. Nachhaltigkeitsaspekte\nDie Verordnung
-                      steht im Einklang mit dem Leitprinzip der Bundesregierung zur nachhaltigen Entwicklung
-                      hin-\nsichtlich Gesundheit, Lebensqualität, sozialem Zusammenhalt und sozialer Verantwortung
-                      und leistet einen wich-\ntigen Beitrag zur Abmilderung der wirtschaftlichen Folgen
-                      der COVID-19-Pandemie. \n3. Haushaltsausgaben ohne Erfüllungsaufwand\nDem Bund entstehen
-                      im Jahr 2022 Mehrausgaben in Höhe von 7 Milliarden Euro. \nDer GKV entstehen im
-                      Jahr 2022 Mehreinnahmen von 7 Milliarden Euro. \n4. Erfüllungsaufwand\nErfüllungsaufwand
-                      für Bürgerinnen und Bürger \nKeiner. \nErfüllungsaufwand für die Wirtschaft \nKeiner.
-                      \nErfüllungsaufwand der Verwaltung \nKeiner. \n5. Weitere Kosten\nKeine. \n6. Weitere
-                      Regelungsfolgen\nKeine. \nV\norabfassung - w\nird durch die lektorierte Fassung
-                      ersetzt.\nDeutscher Bundestag – 20. Wahlperiode – 7 – Drucksache 20/8 \nB. Besonderer
-                      Teil \nZu § 1 \nNach Auswertung der Prognose des Schätzerkreises zu den Einnahmen
-                      und Ausgaben der GKV in den Jahren \n2021 und 2022 ergibt sich insbesondere durch
-                      die COVID-19-Pandemie in Verbindung mit der dadurch ausge-\nlösten Wirtschaftskrise
-                      ein veränderter Finanzbedarf der GKV für das Jahr 2022. Ohne zusätzliche Finanzmittel
-                      \ndes Bundes für das Jahr 2022 wären erhebliche Zusatzbeitragssatzsteigerungen zu
-                      Lasten der Beitragszahlerinnen \nund Beitragszahler in der GKV zu erwarten. Zugleich
-                      wäre die deutsche Wirtschaft mit höheren Lohnnebenkosten \nkonfrontiert, während
-                      sie mit den wirtschaftlichen Folgen der Pandemie belastet ist. Daher bedarf es zur
-                      Stabili-\nsierung des durchschnittlichen Zusatzbeitrags zur GKV einer abweichenden
-                      Festsetzung des ergänzenden Bun-\ndeszuschusses an den Gesundheitsfonds einschließlich
-                      eines Anteils der landwirtschaftlichen Krankenversiche-\nrung. \nDurch die Regelung
-                      in § 1 Satz 1 wird der ergänzende Bundeszuschuss abweichend von § 221a Absatz 3
-                      Satz 1 \ndes Fünften Buches Sozialgesetzbuch für das Jahr 2022 auf einen Betrag
-                      von 14 Milliarden Euro festgesetzt und \ndamit von der Verordnungsermächtigung nach
-                      § 221a Absatz 3 Satz 3 des Fünften Buches Sozialgesetzbuch \nGebrauch gemacht. Der
-                      neu festgesetzte Betrag tritt an die Stelle des zuvor mit dem GVWG in § 221a Absatz
-                      3 \nSatz 1 des Fünften Buches Sozialgesetzbuch festgesetzten Betrags von 7 Milliarden
-                      Euro. Die Anpassung auf \n14 Milliarden Euro ist erforderlich, um den durchschnittlichen
-                      Zusatzbeitragssatz zur GKV bei 1,3 Prozent zu \nstabilisieren. Der Anteil der landwirtschaftlichen
-                      Krankenversicherung an diesem Betrag ist gemäß § 221a Absatz \n3 Satz 4 zweiter
-                      Halbsatz des Fünften Buches Sozialgesetzbuch entsprechend dem Verhältnis des der
-                      landwirt-\nschaftlichen Krankenversicherung nach § 221a Absatz 3 Satz 2 des Fünften
-                      Buches Sozialgesetzbuch vom Ge-\nsundheitsfonds zu überweisenden Betrags zum ergänzenden
-                      Bundeszuschuss nach § 221a Absatz 3 Satz 1 des \nFünften Buches Sozialgesetzbuch
-                      auf 84 Millionen Euro festzusetzen. \nDurch die Stabilisierung des durchschnittlichen
-                      Zusatzbeitrags zur GKV im Jahr 2022 leistet der Bund einen \nerheblichen Beitrag
-                      zur Begrenzung der Sozialversicherungsbeiträge auf unter 40 Prozent und damit zur
-                      schnel-\nleren Erholung der deutschen Wirtschaft nach der COVID-19-Pandemie. \nZu
-                      § 2 \nDie Verordnung tritt am Tag nach ihrer Verkündung in Kraft. \nV\norabfassung
-                      - w\nird durch die lektorierte Fassung ersetzt."
-                    fundstelle:
-                      pdf_url: https://dserver.bundestag.de/btd/20/000/2000008.pdf
-                      id: '258210'
-                      dokumentnummer: 20/8
-                      datum: '2021-11-03'
-                      verteildatum: '2021-11-03'
-                      dokumentart: Drucksache
-                      drucksachetyp: Verordnung
-                      herausgeber: BT
-                      urheber:
-                        - Bundesministerium für Gesundheit
-                    urheber:
-                      - einbringer: false
-                        bezeichnung: BMG
-                        titel: Bundesministerium für Gesundheit
-                  - id: '258209'
-                    drucksachetyp: Vorschlag
-                    dokumentart: Drucksache
-                    autoren_anzahl: 0
-                    typ: Dokument
-                    dokumentnummer: 782/21
-                    wahlperiode: 20
-                    herausgeber: BR
-                    datum: '2021-11-02'
-                    titel: Benennung eines stellvertretenden Mitglieds für den Beirat der Bundesnetzagentur
-                      für Elektrizität, Gas, Telekommunikation, Post und Eisenbahnen
-                    text: "Bundesrat Drucksache 782/21\n02.11.21\nVertrieb: Bundesanzeiger Verlag GmbH,
-                      Postfach 10 05 34, 50445 Köln \nTelefon (02 21) 97 66 83 40, Fax (02 21) 97 66 83
-                      44, www.betrifft-gesetze.de \nISSN 0720-2946\nVorschlag\nan den Bundesrat\nBenennung
-                      eines stellvertretenden Mitglieds für den Beirat der \nBundesnetzagentur für Elektrizität,
-                      Gas, Telekommunikation, \nPost und Eisenbahnen\nDer Ministerpräsident  Magdeburg,
-                      2. November 2021 \ndes Landes Sachsen-Anhalt\nAn den \nPräsidenten des Bundesrates
-                      \nHerrn Ministerpräsidenten \nBodo Ramelow\nSehr geehrter Herr Präsident,\ndie Landesregierung
-                      von Sachsen-Anhalt hat am 2. November 2021 beschlossen, \nHerrn Staatssekretär Bernd
-                      Schlömer – als Nachfolger von Herrn Staatssekretär \na. D. Klaus Rehda – als stellvertretendes
-                      Mitglied des Beirates bei der Bundes-\nnetzagentur für Elektrizität, Gas, Telekommunikation,
-                      Post und Eisenbahnen \nvorzuschlagen. \nIch bitte Sie, den Benennungsvorschlag gemäß
-                      § 36 Absatz 2 der Geschäftsordnung \ndes Bundesrates auf die Tagesordnung der 1010.
-                      Sitzung des Bundesrates am \n5. November 2021 zu setzen und eine sofortige Sachentscheidung
-                      herbeizuführen. \nMit freundlichen Grüßen  \nDr. Reiner Haseloff"
-                    fundstelle:
-                      pdf_url: https://dserver.bundestag.de/brd/2021/0782-21.pdf
-                      id: '258209'
-                      dokumentnummer: 782/21
-                      datum: '2021-11-02'
-                      dokumentart: Drucksache
-                      drucksachetyp: Vorschlag
-                      herausgeber: BR
-                      urheber: [ ]
-                cursor: AoJwgLH53PwCMURydWNrc2FjaGUtMjU4MTkz
-        '401':
-          $ref: "#/components/responses/UnauthorizedError"
-        '404':
-          $ref: "#/components/responses/NotFoundError"
-
-  /drucksache-text/{id}:
-    get:
-      summary: Volltexte einer Drucksache
-      description: Soweit vorhanden werden zusätzlich die Volltexte einer Drucksache ausgegeben
-      operationId: drucksacheTextId
-      tags:
-        - drucksache      
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-            example: 908
-          required: true
-          description: ID der Drucksache
-        - in: query
-          name: format
-          schema:
-            type: string
-            enum:
-              - json
-              - xml
-          description: Format
-          example: "json"
-          required: false
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-              example:
-                id: '908'
-                drucksachetyp: Antrag
-                dokumentart: Drucksache
-                autoren_anzahl: 0
-                typ: Dokument
-                dokumentnummer: 15/5005
-                wahlperiode: 15
-                herausgeber: BT
-                datum: '2005-03-03'
-                titel: "Rechnung des Bundesrechnungshofes für das Haushaltsjahr 2004 \n- Einzelplan
-                  20 -"
-                text: |-
-                  Deutscher Bundestag Drucksache 15/5005
-                  15. Wahlperiode 03. 03. 2005
-                  Zugeleitet mit Schreiben des Präsidenten des Bundesrechnungshofes vom 28. Februar 2005 gemäß § 101 der Bundeshaus-
-                  haltsordnung mit der Bitte, die Rechnung zu prüfen und die Entscheidung des Deutschen Bundestages über die Entlastung
-                  herbeizuführen.
-                  Antrag
-                  des Präsidenten des Bundesrechnungshofes
-                  Rechnung des Bundesrechnungshofes für das Haushaltsjahr 2004
-                  – Einzelplan 20 –
-                  I n h a l t
-                  Seite
-                  Vorbemerkung ......................................................................................................... 2
-                  Rechnung über den Haushalt des Einzelplans 20 Bundesrechnungshof
-                  für das Haushaltsjahr 2004 ...................................................................................... 9
-                  Drucksache 15/5005 – 2 – Deutscher Bundestag – 15. Wahlperiode
-                  Deutscher Bundestag – 15. Wahlperiode – 3 – Drucksache 15/5005
-                  Drucksache 15/5005 – 4 – Deutscher Bundestag – 15. Wahlperiode
-                  Deutscher Bundestag – 15. Wahlperiode – 5 – Drucksache 15/5005
-                  Drucksache 15/5005 – 6 – Deutscher Bundestag – 15. Wahlperiode
-                  Deutscher Bundestag – 15. Wahlperiode – 7 – Drucksache 15/5005
-                  Drucksache 15/5005 – 8 – Deutscher Bundestag – 15. Wahlperiode
-                  Deutscher Bundestag – 15. Wahlperiode – 9 – Drucksache 15/5005
-                  10
-                  16
-                  Drucksache 15/5005 – 10 – Deutscher Bundestag – 15. Wahlperiode
-                  Deutscher Bundestag – 15. Wahlperiode – 11 – Drucksache 15/5005
-                  Drucksache 15/5005 – 12 – Deutscher Bundestag – 15. Wahlperiode
-                  Deutscher Bundestag – 15. Wahlperiode – 13 – Drucksache 15/5005
-                  Drucksache 15/5005 – 14 – Deutscher Bundestag – 15. Wahlperiode
-                  Deutscher Bundestag – 15. Wahlperiode – 15 – Drucksache 15/5005
-                  Drucksache 15/5005 – 16 – Deutscher Bundestag – 15. Wahlperiode
-                  Deutscher Bundestag – 15. Wahlperiode – 17 – Drucksache 15/5005
-                  Drucksache 15/5005 – 18 – Deutscher Bundestag – 15. Wahlperiode
-
-                  Gesamtherstellung: H. Heenemann GmbH & Co., Buch- und Offsetdruckerei, Bessemerstraße 83–91, 12103 Berlin
-                  Vertrieb: Bundesanzeiger Verlagsgesellschaft mbH, Postfach 13 20, 53003 Bonn, Telefon (02 28) 3 82 08 40, Telefax (02 28) 3 82 08 44
-                  ISSN 0722-8333
-                fundstelle:
-                  pdf_url: https://dserver.bundestag.de/btd/15/050/1505005.pdf
-                  id: '908'
-                  dokumentnummer: 15/5005
-                  datum: '2005-03-03'
-                  dokumentart: Drucksache
-                  drucksachetyp: Antrag
-                  herausgeber: BT
-                  urheber:
-                    - Präsident des Bundesrechnungshofes
-                urheber:
-                  - einbringer: false
-                    bezeichnung: BRHPräs
-                    titel: Präsident des Bundesrechnungshofes
-
-        '401':
-          $ref: "#/components/responses/UnauthorizedError"
-        '404':
-          $ref: "#/components/responses/NotFoundError"
-
-  /person:
-    get:
-      summary: Liste aller Personenstammdaten
-      description: Liste aller Personenstammdaten
-      operationId: person
-      tags:
-        - person      
-      parameters:
-        - in: query
-          name: format
-          schema:
-            type: string
-            enum:
-              - json
-              - xml
-          description: Format
-          example: "json"
-          required: false
-        - in: query
-          name: cursor
-          schema: 
-            type: string
-          description: "Position des Cursors zur Anfrage weiterer Entitäten (s. Folgeanfragen nach weiteren Entitäten)."
-          example: AoJwwOKPs1MCNFBsZW5hcnByb3Rva29sbC00NzM5
-          required: false
-        - in: query
-          name: f.id
-          schema:
-            type: integer
-          description: "ID der Entität. Kann wiederholt werden, um mehrere Entitäten zu selektieren (z.B. f.id=84393&f.id=84394)."
-          example: 84394
-          required: false
-        - in: query
-          name: f.datum.start
-          schema:
-            type: string
-          description: "Frühestes Datum der Entität im Format JJJJ-MM-TT. Selektiert Entitäten in einem Datumsbereich basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich aller zugehörigen Dokumente herangezogen."
-          example: 2020-01-01
-        - in: query
-          name: f.datum.end
-          schema:
-            type: string
-          description: "Spätestes Datum der Entität im Format JJJJ-MM-TT. Selektiert Entitäten in einem Datumsbereich basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich aller zugehörigen Dokumente herangezogen."
-          example: 2020-02-28
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-              example:
-                numFound: 5293
-                documents:
-                  - id: '847'
-                    nachname: Pau
-                    vorname: Petra
-                    typ: Person
-                    wahlperiode: 14
-                    basisdatum: '1998-10-26'
-                    datum: '2021-11-02'
-                    titel: Petra Pau, Bundestagsvizepräs.
-                    person_roles:
-                      - funktion: MdB
-                        fraktion: DIE LINKE
-                        nachname: Pau
-                        vorname: Petra
-                        wahlperiode_nummer:
-                          - 16
-                          - 17
-                          - 18
-                          - 19
-                          - 20
-                      - funktion: MdB
-                        fraktion: fraktionslos
-                        nachname: Pau
-                        vorname: Petra
-                        wahlperiode_nummer:
-                          - 15
-                      - funktion: MdB
-                        fraktion: PDS
-                        nachname: Pau
-                        vorname: Petra
-                        wahlperiode_nummer:
-                          - 14
-                  - id: '2125'
-                    nachname: Domscheit-Berg
-                    vorname: Anke
-                    typ: Person
-                    wahlperiode: 19
-                    basisdatum: '2017-10-24'
-                    datum: '2021-11-02'
-                    titel: Anke Domscheit-Berg, MdB, DIE LINKE
-                cursor: AoJwgOLMrvwCK1BlcnNvbi03MDM2
-        '401':
-          $ref: "#/components/responses/UnauthorizedError"
-        '404':
-          $ref: "#/components/responses/NotFoundError"
-
-  /person/{id}:
-    get:
-      summary: Personenstammdaten
-      description: Personenstammdaten
-      operationId: personId
-      tags:
-        - person            
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-            example: 908
-          required: true
-          description: ID der Person
-        - in: query
-          name: format
-          schema:
-            type: string
-            enum:
-              - json
-              - xml
-          description: Format
-          example: "json"
-          required: false
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-              example:
-                id: '908'
-                nachname: Wolf
-                vorname: Rüdiger
-                typ: Person
-                wahlperiode: 16
-                basisdatum: '2008-03-28'
-                datum: '2013-12-20'
-                titel: Rüdiger Wolf, Staatssekr., Bundesministerium der Verteidigung
-
-        '401':
-          $ref: "#/components/responses/UnauthorizedError"
-        '404':
-          $ref: "#/components/responses/NotFoundError"
-
-  /plenarprotokoll:
-    get:
-      summary: Liste aller Plenarprotokolle
-      description: Liste aller Plenarprotokolle
-      operationId: plenarprotokoll
-      tags:
-        - plenarprotokoll            
-      parameters:
-        - in: query
-          name: format
-          schema:
-            type: string
-            enum:
-              - json
-              - xml
-          description: Format
-          example: "json"
-          required: false
-        - in: query
-          name: cursor
-          schema: 
-            type: string
-          description: "Position des Cursors zur Anfrage weiterer Entitäten (s. Folgeanfragen nach weiteren Entitäten)."
-          example: AoJwwOKPs1MCNFBsZW5hcnByb3Rva29sbC00NzM5
-          required: false
-        - in: query
-          name: f.id
-          schema:
-            type: integer
-          description: "ID der Entität. Kann wiederholt werden, um mehrere Entitäten zu selektieren (z.B. f.id=84393&f.id=84394)."
-          example: 84394
-          required: false
-        - in: query
-          name: f.datum.start
-          schema:
-            type: string
-          description: "Frühestes Datum der Entität im Format JJJJ-MM-TT. Selektiert Entitäten in einem Datumsbereich basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich aller zugehörigen Dokumente herangezogen."
-          example: 2020-01-01
-        - in: query
-          name: f.datum.end
-          schema:
-            type: string
-          description: "Spätestes Datum der Entität im Format JJJJ-MM-TT. Selektiert Entitäten in einem Datumsbereich basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich aller zugehörigen Dokumente herangezogen."
-          example: 2020-02-28
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-              example:
-                numFound: 5422
-                documents:
-                  - id: '5432'
-                    dokumentart: Plenarprotokoll
-                    typ: Dokument
-                    vorgangsbezug_anzahl: 7
-                    dokumentnummer: 20/1
-                    wahlperiode: 20
-                    herausgeber: BT
-                    datum: '2021-10-26'
-                    titel: Protokoll der 1. Sitzung des 20. Deutschen Bundestages
-                    fundstelle:
-                      pdf_url: https://dserver.bundestag.de/btp/20/20001.pdf
-                      id: '5432'
-                      dokumentnummer: 20/1
-                      datum: '2021-10-26'
-                      verteildatum: '2021-10-27'
-                      dokumentart: Plenarprotokoll
-                      herausgeber: BT
-                      urheber: [ ]
-                    vorgangsbezug:
-                      - id: '282546'
-                        titel: Eröffnung konstituierender Sitzungen durch den Alterspräsidenten
-                        vorgangstyp: Geschäftsordnung
-                      - id: '282545'
-                        titel: Weitergeltung von Geschäftsordnungsrecht
-                        vorgangstyp: Geschäftsordnung
-                      - id: '282564'
-                        titel: Eröffnung der 1. Sitzung des 20. Deutschen Bundestages
-                        vorgangstyp: Ansprache/Erklärung/Mitteilung
-                      - id: '282550'
-                        titel: Festlegung der Zahl der Stellvertreterinnen und Stellvertreter des Präsidenten
-                        vorgangstyp: Antrag
-                  - id: '5431'
-                    dokumentart: Plenarprotokoll
-                    typ: Dokument
-                    vorgangsbezug_anzahl: 32
-                    dokumentnummer: '1009'
-                    wahlperiode: 19
-                    herausgeber: BR
-                    datum: '2021-10-08'
-                    titel: Protokoll der 1009. Sitzung des Bundesrates
-                    fundstelle:
-                      pdf_url: https://dserver.bundestag.de/brp/1009.pdf
-                      id: '5431'
-                      dokumentnummer: '1009'
-                      datum: '2021-10-08'
-                      dokumentart: Plenarprotokoll
-                      herausgeber: BR
-                      urheber: [ ]
-                    vorgangsbezug:
-                      - id: '279115'
-                        titel: "Vorschlag für eine Richtlinie des Europäischen Parlaments und des Rates
-                        zur Änderung der Richtlinien 2013/34/EU, 2004/109/EG und 2006/43/EG und der Verordnung
-                        (EU) Nr. 537/2014 hinsichtlich der Nachhaltigkeitsberichterstattung von Unternehmen\r\nKOM(2021)189
-                        endg.; Ratsdok. 8132/21\r\n"
-                        vorgangstyp: EU-Vorlage
-                      - id: '258378'
-                        titel: "Mitteilung der Kommission an das Europäische Parlament und den Rat\r\nGestaltung
-                        der Konferenz zur Zukunft Europas \r\nKOM(2020) 27 endg.; Ratsdok. 5513/20"
-                        vorgangstyp: EU-Vorlage
-                      - id: '279134'
-                        titel: "Mitteilung der Kommission an das Europäische Parlament, den Rat, den Europäischen
-                        Wirtschafts- und Sozialausschuss und den Ausschuss der Regionen \r\nFörderung
-                        eines europäischen Konzepts für künstliche Intelligenz\r\nKOM(2021) 205 endg.;
-                        Ratsdok. 8334/21"
-                        vorgangstyp: EU-Vorlage
-                      - id: '280803'
-                        titel: "Mitteilung der Kommission an das Europäische Parlament, den Rat, den Europäischen
-                        Wirtschafts- und Sozialausschuss und den Ausschuss der Regionen\r\nBericht über
-                        die Rechtsstaatlichkeit 2021\r\nDie Lage der Rechtsstaatlichkeit in der Europäischen
-                        Union\r\nKOM(2021) 700 endg."
-                        vorgangstyp: EU-Vorlage
-                cursor: AoJwwLfbqfICNFBsZW5hcnByb3Rva29sbC01MzMy
-        '401':
-          $ref: "#/components/responses/UnauthorizedError"
-        '404':
-          $ref: "#/components/responses/NotFoundError"
-
-  /plenarprotokoll/{id}:
-    get:
-      summary: Metadaten zu Plenarprotokoll
-      description: Metadaten zu Plenarprotokoll
-      operationId: plenarprotokollId
-      tags:
-        - plenarprotokoll      
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-            example: 908
-          required: true
-          description: ID des Plenarprotokolles
-        - in: query
-          name: format
-          schema:
-            type: string
-            enum:
-              - json
-              - xml
-          description: Format
-          example: "json"
-          required: false
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-              example:
-                id: '908'
-                dokumentart: Plenarprotokoll
-                typ: Dokument
-                vorgangsbezug_anzahl: 6
-                dokumentnummer: 19/1
-                wahlperiode: 19
-                herausgeber: BT
-                datum: '2017-10-24'
-                titel: Protokoll der 1. Sitzung des 19. Deutschen Bundestages
-                fundstelle:
-                  pdf_url: https://dserver.bundestag.de/btp/19/19001.pdf
-                  id: '908'
-                  dokumentnummer: 19/1
-                  datum: '2017-10-24'
-                  verteildatum: '2017-10-25'
-                  dokumentart: Plenarprotokoll
-                  herausgeber: BT
-                  urheber: [ ]
-                vorgangsbezug:
-                  - id: '84344'
-                    titel: Festlegung der Zahl der Stellvertreterinnen und Stellvertreter des Präsidenten
-                    vorgangstyp: Antrag
-                  - id: '84393'
-                    titel: Eröffnung der 1. Sitzung des 19. Deutschen Bundestages
-                    vorgangstyp: Ansprache/Erklärung/Mitteilung
-                  - id: '84352'
-                    titel: Grundsatz der Diskontinuität in der konstituierenden Sitzung des 19. Deutschen
-                      Bundestages
-                    vorgangstyp: Geschäftsordnung
-                  - id: '84396'
-                    titel: Wahl der Stellvertreterinnen und Stellvertreter des Präsidenten
-                    vorgangstyp: Wahl im BT
-
-        '401':
-          $ref: "#/components/responses/UnauthorizedError"
-        '404':
-          $ref: "#/components/responses/NotFoundError"
-
-  /plenarprotokoll-text:
-    get:
-      summary: Liste aller Volltexte der Plenarprotokolle
-      description: Liste aller Volltexte der Plenarprotokolle
-      operationId: plenarprotokollText
-      tags:
-        - plenarprotokoll      
-      parameters:
-        - in: query
-          name: format
-          schema:
-            type: string
-            enum:
-              - json
-              - xml
-          description: Format
-          example: "json"
-          required: false
-        - in: query
-          name: cursor
-          schema: 
-            type: string
-          description: "Position des Cursors zur Anfrage weiterer Entitäten (s. Folgeanfragen nach weiteren Entitäten)."
-          example: AoJwwOKPs1MCNFBsZW5hcnByb3Rva29sbC00NzM5
-          required: false
-        - in: query
-          name: f.id
-          schema:
-            type: integer
-          description: "ID der Entität. Kann wiederholt werden, um mehrere Entitäten zu selektieren (z.B. f.id=84393&f.id=84394)."
-          example: 84394
-          required: false
-        - in: query
-          name: f.datum.start
-          schema:
-            type: string
-          description: "Frühestes Datum der Entität im Format JJJJ-MM-TT. Selektiert Entitäten in einem Datumsbereich basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich aller zugehörigen Dokumente herangezogen."
-          example: 2020-01-01
-        - in: query
-          name: f.datum.end
-          schema:
-            type: string
-          description: "Spätestes Datum der Entität im Format JJJJ-MM-TT. Selektiert Entitäten in einem Datumsbereich basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich aller zugehörigen Dokumente herangezogen."
-          example: 2020-02-28
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-              example:
-                numFound: 5422
-                documents:
-                  - id: '5432'
-                    dokumentart: Plenarprotokoll
-                    typ: Dokument
-                    dokumentnummer: 20/1
-                    wahlperiode: 20
-                    herausgeber: BT
-                    datum: '2021-10-26'
-                    titel: Protokoll der 1. Sitzung des 20. Deutschen Bundestages
-                    text: "Deutscher Bundestag\nStenografischer Bericht\n1. Sitzung\nBerlin, Dienstag,
-                      den 26. Oktober 2021\nI n h a l t :\nAlterspräsident Dr. Wolfgang Schäuble . . .
-                      . . . . . . . . 1 A\nZur Geschäftsordnung:\nDr. Bernd Baumann (AfD) . . . . . .
-                      . . . . . . . . . . . . . . . . . 1 B\nCarsten Schneider (Erfurt) (SPD) . . . .
-                      . . . . . . . . . . . . . 2 A\nMichael Grosse-Brömer (CDU/CSU) . . . . . . . . .
-                      . . . . 3 A\nTagesordnungspunkt 1:\nEröffnung der Sitzung durch den Altersprä-\nsidenten\nDrucksache
-                      20/2 . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 4 B\nAlterspräsident
-                      Dr. Wolfgang Schäuble . . . . . . . . . . . 4 A\nTagesordnungspunkt 2:\nBeschlussfassung
-                      über die\n– Geschäftsordnung des Deutschen Bundes-\ntages\n– Gemeinsame Geschäftsordnung
-                      des Bun-\ndestages und des Bundesrates für den Aus-\nschuss nach Artikel 77 des
-                      Grundgesetzes \n(Vermittlungsausschuss)\n– Geschäftsordnung für den Gemeinsamen
-                      \nAusschuss\n– Geschäftsordnung für das Verfahren nach \nArtikel 115d des Grundgesetzes\nDrucksache
-                      20/1 . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 7 D\nGabriele
-                      Katzmarek (SPD) . . . . . . . . . . . . . . . . . . . . . . . 8 A\nStefan Müller
-                      (Erlangen) (CDU/CSU) . . . . . . . . . . . . 8 C\nBritta Haßelmann (BÜNDNIS 90/
-                      \nDIE GRÜNEN) . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 9
-                      C\nDr. Marco Buschmann (FDP) . . . . . . . . . . . . . . . . . . . . 10 C\nStephan
-                      Brandner (AfD) . . . . . . . . . . . . . . . . . . . . . . . . . 11 B\nJan Korte
-                      (DIE LINKE) . . . . . . . . . . . . . . . . . . . . . . . . . 12 D\nTagesordnungspunkt
-                      3:\nWahl der Präsidentin/des Präsidenten verbun-\nden mit Namensaufruf und Feststellung
-                      der \nBeschlussfähigkeit\nDr. Rolf Mützenich (SPD) . . . . . . . . . . . . . . .
-                      . . . . . . . . 14 B\nAlterspräsident Dr. Wolfgang Schäuble . . . . . . . . . .
-                      14 C\nBärbel Bas (SPD) . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
-                      . . 15 C\nAlterspräsident Dr. Wolfgang Schäuble . . . . . . . . . . 15 C\nTagesordnungspunkt
-                      4:\nAmtsübernahme durch die Präsidentin/den \nPräsidenten mit Ansprache\nPräsidentin
-                      Bärbel Bas . . . . . . . . . . . . . . . . . . . . . . . . . . 15 C\nTagesordnungspunkt
-                      5:\nFestlegung der Zahl der Stellvertreterinnen \nund Stellvertreter der Präsidentin/des
-                      Prä-\nsidenten\nDrucksache 20/5 . . . . . . . . . . . . . . . . . . . . . . . .
-                      . . . . . . . . 18 C\nFabian Jacobi (AfD) . . . . . . . . . . . . . . . . . . .
-                      . . . . . . . . . . 18 D\nTagesordnungspunkt 6:\nWahl der Stellvertreterinnen und
-                      Stellvertreter \nder Präsidentin/des Präsidenten\nAydan Özoğuz (SPD) . . . . . .
-                      . . . . . . . . . . . . . . . . . . . . . 20 B\nYvonne Magwas (CDU/CSU) . . . .
-                      . . . . . . . . . . . . . . . . 20 C\nClaudia Roth (Augsburg) (BÜNDNIS 90/ \nDIE
-                      GRÜNEN) . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 20 C\nWolfgang
-                      Kubicki (FDP) . . . . . . . . . . . . . . . . . . . . . . . . 20 C\nPlenarprotokoll
-                      20/1 \nPetra Pau (DIE LINKE) . . . . . . . . . . . . . . . . . . . . . . . . . 20
-                      D\nTagesordnungspunkt 7:\nNationalhymne . . . . . . . . . . . . . . . . . . . .
-                      . . . . . . . . . . . . . . 21 C\nNächste Sitzung . . . . . . . . . . . . . . .
-                      . . . . . . . . . . . . . . . . . . 21 C\nAnlage 1\nEntschuldigte Abgeordnete .
-                      . . . . . . . . . . . . . . . . . . . . . 23 A\nAnlage 2\nErgebnis und Namensverzeichnis
-                      der Mitglie-\nder des Deutschen Bundestages, die an der \nWahl der Präsidentin des
-                      Deutschen Bundes-\ntages teilgenommen haben\n(Tagesordnungspunkt 3) . . . . . .
-                      . . . . . . . . . . . . . . . . . . . 23 A\nAnlage 3\nErgebnisse und Namensverzeichnis
-                      der Mit-\nglieder des Deutschen Bundestages, die an \nder Wahl der Stellvertreterinnen
-                      und Stellver-\ntreter der Präsidentin des Deutschen Bundes-\ntages teilgenommen
-                      haben\n(Tagesordnungspunkt 6) . . . . . . . . . . . . . . . . . . . . . . . . .
-                      27 A\nDeutscher Bundestag – 20. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den
-                      26. Oktober 2021                                II \n1. Sitzung\nBerlin, Dienstag,
-                      den 26. Oktober 2021\nBeginn: 11.00 Uhr\nAlterspräsident Dr. Wolfgang Schäuble:\nSehr
-                      geehrte Kolleginnen und Kollegen, bitte nehmen \nSie Platz.\nIch begrüße Sie zur
-                      konstituierenden Sitzung des \n20. Deutschen Bundestages. Es entspricht der ständigen
-                      \nÜbung, zu Beginn der konstituierenden Sitzung nach den \nRegelungen der bisherigen
-                      Geschäftsordnung des Deut-\nschen Bundestages zu verfahren.\n§ 1 Absatz 2 der Geschäftsordnung
-                      des Deutschen \nBundestages sieht vor, dass das am längsten dem Bundes-\ntag angehörende
-                      Mitglied, das hierzu bereit ist, den Vor-\nsitz übernimmt, bis der Deutsche Bundestag
-                      eine Prä-\nsidentin oder einen Präsidenten gewählt hat.\nDie Fraktion der AfD widerspricht
-                      dieser Praxis und \nhat beantragt, dass in der ersten Sitzung des Bundestages \ndas
-                      an Jahren älteste Mitglied den Vorsitz führt.\nWird hierzu das Wort gewünscht? –
-                      Herr Kollege \nBaumann.\n(Beifall bei der AfD – Jan Korte [DIE LINKE]: \nEs geht
-                      genauso ätzend los wie beim letzten \nMal!)\nDr. Bernd Baumann (AfD):\nHerr Präsident!
-                      Meine Damen und Herren! Heute kon-\nstituiert sich ein neuer Bundestag. Seit bald
-                      zwei Jahr-\nhunderten ist es fester parlamentarischer Brauch, dass ein \nsogenannter
-                      Alterspräsident diese erste Sitzung eröffnet. \nDas war immer – aus Respekt vor
-                      dem Alter – der älteste \nAbgeordnete von allen. Von der Frankfurter Paulskirche
-                      \nbis zum Parlament des Kaiserreichs, von der Weimarer \nRepublik bis zum wiedervereinigten
-                      Deutschland, sogar \nbis tief hinein in die Regierungszeit Merkels – alle \nReichstage,
-                      alle Bundestage hielten sich an diese Regel.\nIn fast zwei Jahrhunderten hat nur
-                      ein Parlament es \ngewagt, mit dieser Tradition zu brechen. Das war – man \nmuss
-                      es deutlich sagen – 1933 nach der Machtergreifung \nmit einem Präsidenten Hermann
-                      Göring. Soll das Ihr Vor-\nbild sein?\n(Beifall bei der AfD – Dr. Marco Buschmann
-                      \n[FDP]: Das ist die gleiche Rede! – Zurufe von \nder SPD und dem BÜNDNIS 90/DIE
-                      \nGRÜNEN: Oh!)\nDavor hatte ich Sie schon 2017 gewarnt. Das ist keine \ngute Tradition.
-                      Kommen Sie wieder zurück auf den seit \nJahrhunderten bewährten Weg aller deutschen
-                      Demokra-\nten.\n(Beifall bei der AfD – Jan Korte [DIE LINKE]: \nGöring ist aber
-                      Ihre Tradition!)\nWarum wollen Sie diese Regel heute wieder durch-\nbrechen? Ist
-                      doch klar: Wie vor vier Jahren kommt auch \nheute der älteste und erfahrenste Abgeordnete
-                      und damit \nder legitime Alterspräsident aus den Reihen der AfD. \nAkzeptieren Sie
-                      das. Erkennen Sie das endlich an.\n(Beifall bei der AfD)\nEs gibt noch einen Grund,
-                      warum Sie sich weigern. \nDenn der Älteste und Erfahrenste in diesem neu gewähl-\nten
-                      Parlament ist Alexander Gauland, über ein halbes \nJahrhundert in der deutschen
-                      Politik, auch an führenden \nStellen, 40 Jahre davon in der CDU, und in den vergan-\ngenen
-                      vier Jahren der mächtigste und wortgewaltigste \nOppositionsführer hier im Hause,
-                      meine Damen und Her-\nren.\n(Beifall bei der AfD – Lachen bei Abge-\nordneten der
-                      SPD, des BÜNDNISSES 90/DIE \nGRÜNEN und der LINKEN)\nDen legitimen Alterspräsidenten
-                      Gauland wollen Sie \nverhindern. Genauso gehen Sie beim Amt des Vizeprä-\nsidenten
-                      vor. Auch das verweigern Sie uns seit vielen \nJahren, ein wichtiges, ein zentrales
-                      Amt, das alle anderen \nFraktionen bekommen und das laut der Geschäftsord-\nnung
-                      auch der AfD zusteht. Beides, die Verweigerung \ndes Alterspräsidenten wie auch
-                      des Vizepräsidenten, ist \nnicht nur eine Missachtung der AfD als gleichberechtigte
-                      \nFraktion hier im Hause, schlimmer noch: Es ist auch eine \nMissachtung, eine Herabsetzung
-                      von Millionen Wählern, \neine Beleidigung jedes einzelnen, eine Verhöhnung der \nDemokratie,
-                      meine Damen und Herren.\n(Beifall bei der AfD)\nDeutscher Bundestag – 20. Wahlperiode
-                      – 1. Sitzung. Berlin, Dienstag, den 26. Oktober 2021                                                                                                                                                                                                      1\n(A)
-                      \n(B) \n(C) \n(D) \nAm Umgang von Regierungs- und Parlamentsmehr-\nheit mit der
-                      Opposition zeigt sich der Zustand einer \nDemokratie. Eigentlich müsste die EU-Kommission
-                      \numgehend ein Rechtsstaatsverfahren eröffnen –\n(Lachen bei Abgeordneten der SPD,
-                      der CDU/ \nCSU und des BÜNDNISSES 90/DIE \nGRÜNEN)\nnicht gegen Ungarn, nicht gegen
-                      Polen, meine Damen \nund Herren, sondern gegen Deutschland wegen offen-\nsichtlicher
-                      und fortgesetzter Benachteiligung der Oppo-\nsition in diesem Haus.\n(Beifall bei
-                      der AfD)\nWir werden nachher sehen, wie es bei der Wahl des \nVizepräsidenten weitergeht.
-                      Mit Michael Kaufmann tritt \nein sehr renommierter Hochschulprofessor an. Selbst
-                      der \nlinke Ministerpräsident in Thüringen hat ihn gewählt, und \nnicht mal Frau
-                      Merkel hat das rückgängig gemacht.\n(Beifall bei der AfD)\nAlterspräsident Dr. Wolfgang
-                      Schäuble:\nAls Nächstem erteile ich das Wort dem Kollegen \nCarsten Schneider, SPD.\n(Beifall
-                      bei der SPD sowie bei Abgeordneten \ndes BÜNDNISSES 90/DIE GRÜNEN und der \nLINKEN)\nCarsten
-                      Schneider (Erfurt) (SPD):\nHerr Präsident! Sehr geehrte Damen und Herren! Heu-\nte
-                      ist in der Tat ein besonderer Tag für die Demokratie. \nNach der freien Wahl des
-                      deutschen Volkes stehen wir \nheute hier als Abgeordnete des Deutschen Bundestages,
-                      \num uns als Bundestag zu konstituieren.\nVon diesem Bundestag geht die Macht in
-                      Deutschland \naus. Wir werden – die einen mit Ja, die anderen mit Nein – \neinen
-                      Bundeskanzler wählen. Dazu gibt es eine Neue-\nrung – das gehört zur Demokratie
-                      dazu und zeichnet sie \naus –, und zwar, dass drei Parteien miteinander eine Koa-\nlition
-                      anstreben, die bisher noch nie miteinander koaliert \nhaben. Es zeichnet diesen
-                      Bundestag und dieses Land \naus, dass eine große Partei, nämlich die Union, die
-                      lange \nan der Macht war, diese friedlich und fair übergibt. Ich \nmöchte mich ganz
-                      besonders bei der Unionsfraktion für \ndie faire Zusammenarbeit der letzten Jahre
-                      bedanken. \nVielen Dank!\n(Beifall bei der SPD sowie bei Abgeordneten \nder CDU/CSU
-                      und des BÜNDNISSES 90/DIE \nGRÜNEN)\nIch sage das, bevor ich zur AfD und dem Antrag
-                      kom-\nme, auch in Richtung der amtierenden Bundeskanzlerin \nund der Minister. Ich
-                      sehe Minister Altmaier hier, den ich \nals Verhandler in der Arbeitsgruppe Wirtschaft
-                      vor weni-\ngen Tagen angerufen habe, um mit ihm darüber zu spre-\nchen, welche Dinge
-                      er uns mitgeben kann und dass er uns \ndas Haus für Informationen öffnet.\n(Dr.
-                      Gottfried Curio [AfD]: Sprechen Sie zur \nSache!)\nDas geschieht. Das ist Demokratie
-                      in Deutschland: faire \nÜbergabe von Macht, Akzeptanz von Wahlergebnissen.\nSie,
-                      liebe AfD, haben die Wahl verloren.\n(Beifall bei der SPD sowie bei Abgeordneten
-                      \nder CDU/CSU, des BÜNDNISSES 90/DIE \nGRÜNEN, der FDP und der LINKEN)\nSie haben
-                      an Stimmen verloren, an Zustimmung in \nDeutschland.\nZur Demokratie gehört, dass
-                      sich dieser Bundestag, die \nAbgeordneten eine Geschäftsordnung geben. Das ist der
-                      \nUnterschied zur Weimarer Republik, die hier zu zitieren \nSie, Herr Baumann, sich
-                      erdreistet haben; Sie haben sich \nerdreistet, hier von 1933 zu zitieren. Das ist
-                      eine Frech-\nheit.\n(Beifall bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN,
-                      der FDP und der \nLINKEN – Dr. Bernd Baumann [AfD]: Die \nhaben sich an Regeln gehalten,
-                      Sie nicht!)\nDie Verfassung der Weimarer Republik war gut. Es gab \nnur zu wenig
-                      Demokraten, die sie unterstützt haben, und \nes gab zu viele, die sie von innen
-                      heraus bekämpft und \ndiffamiert haben.\n(Zuruf des Abg. Dr. Gottfried Curio [AfD])\nIhre
-                      Truppe hat dazugehört. Ihre Vorgänger haben \ndazugehört.\n(Beifall bei der SPD,
-                      dem BÜNDNIS 90/DIE \nGRÜNEN, der FDP und der LINKEN sowie bei \nAbgeordneten der
-                      CDU/CSU – Dr. Bernd \nBaumann [AfD]: Sie machen den Nazi-\nvergleich! – Dr. Alice
-                      Weidel [AfD]: Es wird \nimmer besser!)\nWir schlagen vor, dass Alterspräsident,
-                      so wie es die \nGeschäftsordnung des letzten Bundestages vorgesehen \nhat, derjenige
-                      ist, der an Dienstjahren die meiste Zeit \nhier im Bundestag verbracht hat. Ich
-                      könnte mir gar \nkeinen besseren Alterspräsidenten vorstellen als \nDr. Wolfgang
-                      Schäuble.\n(Beifall bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN und der
-                      FDP \nsowie bei Abgeordneten der LINKEN)\nIch habe ihn persönlich schätzen gelernt
-                      als Bundes-\nfinanzminister in der Eurokrise. Ich habe ihn schätzen \ngelernt hier
-                      in der Zusammenarbeit als Präsident. Nie-\nmand verfügt über so viel Erfahrung,
-                      um diese erste Sit-\nzung des Bundestages zu leiten und einen fairen Über-\ngang
-                      zu garantieren.\nVon daher: Wir lehnen Ihren Antrag strikt ab und sind \nfür Herrn
-                      Dr. Schäuble.\nVielen Dank.\n(Beifall bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE
-                      GRÜNEN und der FDP \nsowie bei Abgeordneten der LINKEN)\nAlterspräsident Dr. Wolfgang
-                      Schäuble:\nJetzt erteile ich das Wort dem Kollegen Michael \nGrosse-Brömer.\n(Beifall
-                      bei Abgeordneten der CDU/CSU)\nDeutscher Bundestag – 20. Wahlperiode – 1. Sitzung.
-                      Berlin, Dienstag, den 26. Oktober 2021                                2 \nDr. Bernd
-                      Baumann \n(A) \n(B) \n(C) \n(D) \nLiebe Kolleginnen und Kollegen, da meine Funktion
-                      \nals Alterspräsident im Moment noch umstritten ist, kann \nich auf die Einhaltung
-                      der Geschäftsordnung nicht so \ndrängen, wie ich es die letzten vier Jahre getan
-                      habe. \nAlso überfordern Sie mich bitte nicht.\n(Dr. Bernd Baumann [AfD]: Das hätte
-                      ich \nvorher wissen sollen!)\nBitte, Herr Grosse-Brömer.\n(Beifall bei der CDU/CSU
-                      sowie bei Abge-\nordneten der SPD, des BÜNDNISSES 90/DIE \nGRÜNEN und der FDP)\nMichael
-                      Grosse-Brömer (CDU/CSU):\nSehr geehrter Herr Präsident! Lieber Herr Baumann, \nSie
-                      haben Herrn Gauland vorgeschlagen. Wer das dun-\nkelste Kapitel unserer Geschichte
-                      als „Fliegenschiss“ \nbezeichnet, der hat sich schon dadurch disqualifiziert, \nhier
-                      jemals als Alterspräsident aufzutreten.\n(Beifall bei der CDU/CSU, der SPD, dem
-                      \nBÜNDNIS 90/DIE GRÜNEN, der FDP und der \nLINKEN – Stephan Brandner [AfD]: Das
-                      war \nein falsches Zitat, Herr Grosse-Brömer! Er hat \nnicht „Fliegenschiss“ gesagt!)\nSondern?\n(Zurufe
-                      von der FDP und der AfD: \n„Vogelschiss“!)\n„Vogelschiss“ macht die Sache jetzt
-                      ausnahmsweise nicht \nbesser. Aber vielen Dank für den Hinweis.\n(Heiterkeit und
-                      Beifall bei Abgeordneten der \nCDU/CSU, der SPD und des BÜND-\nNISSES 90/DIE GRÜNEN)\nBei
-                      der AfD ist immer viel von Ausgrenzung die Rede. \nDie einzige Ausgrenzung, die
-                      hier stattfindet, ist die \nSelbstausgrenzung aus den Reihen der AfD, insbesonde-\nre
-                      von denen, die „überzeugte Parlamentarier“ sind. Wir \nhaben Sie die vergangenen
-                      vier Jahre erlebt, und eigent-\nlich haben Sie nichts unversucht gelassen, diesem
-                      Par-\nlament zu schaden.\nAuch Ihr Antrag heute ist nicht besser. Insbesondere –
-                      \ndas ist die Kontinuität in Ihrem Vorgehen – ist er wieder \nschlampig begründet.
-                      Da steht zum Beispiel, die Rege-\nlung zum Alterspräsidenten würde Kolleginnen und
-                      Kol-\nlegen aus den neuen Bundesländern benachteiligen, weil \ndiese erst nach 1990
-                      kandidieren konnten. Wenn Sie mal \nin die Liste der dienstältesten Kolleginnen
-                      und Kollegen \ngeschaut hätten, was Sie im Gegensatz zu mir offenbar \nnicht getan
-                      haben,\n(Jan Korte [DIE LINKE]: Das stimmt!)\ndann hätten Sie festgestellt, dass
-                      auf Wolfgang Schäuble \nnur Mitglieder folgen, die nach 1990 in diesen Bundestag
-                      \neingezogen sind.\n(Heiterkeit bei Abgeordneten der CDU/CSU)\nAlso ist die Begründung
-                      schon in der Sache völlig \nunschlüssig. Im Übrigen folgt an dritter Stelle der
-                      Kolle-\nge Gregor Gysi. Also, eine Schlechterstellung der ost-\ndeutschen Kolleginnen
-                      und Kollegen ist für mich spontan \njetzt nicht erkennbar.\n(Beifall bei der CDU/CSU,
-                      der SPD, dem \nBÜNDNIS 90/DIE GRÜNEN, der FDP und der \nLINKEN – Jan Korte [DIE
-                      LINKE]: Das ist \nwahr!)\nOb das mit Herrn Gysi jetzt eine gute Idee wäre, ist eine
-                      \nandere Geschichte. Aber es ist erst mal so.\n(Zuruf des Abg. Jan Korte [DIE LINKE])\nHerr
-                      Dr. Schäuble, ich möchte die Gelegenheit nutzen, \nzu sagen: Die Regelung des Alterspräsidenten
-                      hat sich \nbewährt. Es ist eine besondere Freude, dass Sie heute \nals Alterspräsident
-                      diese Sitzung eröffnet haben.\n(Beifall bei der CDU/CSU sowie bei Abge-\nordneten
-                      des BÜNDNISSES 90/DIE GRÜ-\nNEN)\nIch möchte die Gelegenheit nutzen, im Namen meiner
-                      \nFraktion herzlich Dank zu sagen für Ihre Tätigkeit als \nBundestagspräsident in
-                      den letzten Jahren. Sie haben die-\nses Amt besonnen, unparteiisch und würdig ausgeführt.
-                      \nSie haben den Bundestag gegen Angriffe von außen und \nvon innen verteidigt, und
-                      Ihnen war vor allem der faire \nAusgleich von Mehrheit und Opposition immer ein
-                      \nbesonderes Anliegen. Dafür herzlichen Dank!\n(Beifall bei der CDU/CSU, der SPD,
-                      dem \nBÜNDNIS 90/DIE GRÜNEN und der FDP \nsowie bei Abgeordneten der LINKEN)\nAls
-                      Letztes kurz ein Hinweis, weil wir gerade von \nfairem Ausgleich von Mehrheit und
-                      Opposition sprechen: \nAuch Carsten Schneider danke ich herzlich für die gute \nZusammenarbeit
-                      in den letzten Jahren. Das haben wir gut \nhingekriegt. Jetzt sind wir in anderer
-                      Position. Mal \ngucken, wie es läuft. Aber ich glaube, wir haben gute \nGrundlagen,
-                      weiterhin vernünftig gemeinsam zu arbei-\nten.\nMit Blick auf fairen Übergang, den
-                      auch ich mir wün-\nsche, und fairen Ausgleich von Mehrheit und Opposition \nmöchte
-                      ich doch eines sagen: Gleich nach der Wahl eine \ntraditionelle Sitzordnung im Plenum
-                      mit der Brechstange \nändern zu wollen, ist kein guter Stil, finde ich.\n(Beifall
-                      bei der CDU/CSU – Widerspruch bei \nAbgeordneten der FDP)\nIch spüre einen Hauch
-                      von Arroganz der Macht. Aber ich \nbin auch überzeugt, dass die Opposition, insbesondere
-                      \ndie Liberalen, so klug sind, davon abzusehen,\n(Christian Lindner [FDP]: Die Opposition
-                      \nspricht von Arroganz der Macht!)\ntraditionelle Gepflogenheiten dieses Parlamentes
-                      – kaum \nin der Mehrheit – aus Eigennutz zu ändern.\n(Christian Lindner [FDP]: Wahlrecht,
-                      sage ich \nnur! Wahlrecht pur als Opposition!)\nIch bin da sehr sicher. Ich setze
-                      auf die Einsichtsfähigkeit \nund Klugheit der FDP, die bewährte Tradition in diesem
-                      \nHause zu erhalten.\nLiebe Kolleginnen und Kollegen, wir lehnen den \nAntrag der
-                      AfD aus, wie ich finde, guten Gründen ab.\n(Beifall bei der CDU/CSU sowie bei Abge-\nordneten
-                      der SPD und des BÜNDNISSES 90/ \nDIE GRÜNEN)\nDeutscher Bundestag – 20. Wahlperiode
-                      – 1. Sitzung. Berlin, Dienstag, den 26. Oktober 2021                                                                                                                                                                                                      3\nAlterspräsident
-                      Dr. Wolfgang Schäuble \n(A) \n(B) \n(C) \n(D) \nAlterspräsident Dr. Wolfgang Schäuble:\nGibt
-                      es weitere Wortmeldungen? – Das ist nicht der \nFall. Dann lasse ich über den Antrag
-                      der Fraktion der \nAfD auf Drucksache 20/2 abstimmen. Wer stimmt für \nden Antrag
-                      der AfD? – Wer stimmt dagegen? – Wer \nenthält sich? – Das ist offenbar niemand.
-                      Dann ist der \nAntrag der AfD gegen die Stimmen der AfD mit den \nStimmen des übrigen
-                      Hauses abgelehnt.\n(Beifall bei Abgeordneten der SPD, der CDU/ \nCSU, des BÜNDNISSES
-                      90/DIE GRÜNEN \nund der FDP)\nDamit verbleibt es dabei, dass nach § 1 Absatz 2 der
-                      \nGeschäftsordnung das am längsten dem Bundestag ange-\nhörende Mitglied den Vorsitz
-                      übernimmt. Michael \nGrosse-Brömer hat eben schon eindrucksvoll dargelegt, \ndass
-                      offensichtlich ich das bin.\n(Heiterkeit bei der CDU/CSU sowie bei \nAbgeordneten
-                      der SPD)\nIch freue mich, den Vorsitz zu übernehmen, und füge \ngleich für eventuell
-                      noch kommende Geschäftsordnungs-\ndebatten hinzu, dass ich ab jetzt wieder darauf
-                      achte, dass \nbei Reden zur Geschäftsordnung wirklich nur zur \nGeschäftsordnung
-                      gesprochen wird.\n(Beifall bei Abgeordneten der CDU/CSU)\nAlterspräsident Dr. Wolfgang
-                      Schäuble\nJetzt rufe ich auf den Tagesordnungspunkt 1:\nEröffnung der Sitzung durch
-                      den Alterspräsiden-\nten\nDrucksache 20/2\nIch eröffne als Alterspräsident die erste
-                      Sitzung der \n20. Wahlperiode. Ich begrüße unseren Bundespräsiden-\nten, Herrn Dr.
-                      Frank-Walter Steinmeier. Herr Bundesprä-\nsident, wir freuen uns, dass Sie heute
-                      da sind.\n(Beifall)\nDann begrüße ich die Bundeskanzlerin, Frau \nDr. Angela Merkel,
-                      die heute auf ungewohntem Platz \nsitzt.\n(Beifall)\nIch heiße die ehemalige Präsidentin
-                      des Deutschen \nBundestages, Frau Dr. Rita Süssmuth, herzlich willkom-\nmen,\n(Beifall)\nebenso
-                      die ehemalige Präsidentin der ersten frei gewähl-\nten Volkskammer der DDR, Frau
-                      Dr. Sabine Bergmann- \nPohl.\n(Beifall)\nStellvertretend für das Diplomatische Korps
-                      begrüße \nich seine Exzellenz den Apostolischen Nuntius und alle \nweiteren Ehrengäste,
-                      die auf der Tribüne an dieser Sit-\nzung teilnehmen.\n(Beifall)\nLiebe Kolleginnen
-                      und Kollegen, die anhaltende pan-\ndemische Lage erzwingt auch, dass diese Sitzung
-                      in Voll-\npräsenz nur unter Geltung zusätzlicher Infektionsschutz-\nmaßnahmen stattfinden
-                      kann. Die Fraktionen hatten sich \nursprünglich darauf verständigt, dass für diese
-                      Sitzung \nein 3-G-Konzept gilt. Das bedeutet, dass Zutritt zum \nPlenarsaal in der
-                      unteren Ebene ausschließlich diejenigen \nPersonen haben, die vollständig gegen
-                      das SARS-CoV-2- \nVirus geimpft sind, von einer Coronaerkrankung genesen \noder
-                      aktuell negativ getestet sind.\nDer Geimpft-, Genesenen- oder Getestetenstatus ist
-                      \nnach Maßgabe meiner Anordnung zur Anwendung der \n3-G-Regel bei der Durchführung
-                      der konstituierenden \nSitzung vom 14. Oktober 2021 als Zutrittsberechtigung \nzur
-                      unteren Ebene des Plenarsaals und zur West- und zur \nAbgeordnetenlobby nachzuweisen.
-                      Für die heutige Sit-\nzung gelten als Nachweis für Ihren Status auch die Hand-\ngelenkbänder,
-                      die Sie zuvor erhalten haben.\nDiejenigen Abgeordneten, die einen solchen Nachweis
-                      \nnicht erbringen oder trotz Nachweis mit Abstand sitzen \nmöchten, haben die Möglichkeit,
-                      unter Wahrung des \nAbstandsgebots auf den Tribünen an der Sitzung teil-\nzunehmen.
-                      Mikrofone sind dort vorhanden. Auch die \nspäter folgenden Wahlen finden für diese
-                      Abgeordneten \nauf der Tribüne statt.\nBitte beachten Sie, dass weiterhin die Pflicht
-                      zum Tra-\ngen einer medizinischen Mund-Nasen-Bedeckung gilt. \nSie kann am Sitzplatz,
-                      am Rednerpult und an den Saal-\nmikrofonen abgelegt werden. Sofern Sie hier im Plenum
-                      \neinschließlich der West- und der Abgeordnetenlobby \ngegen diese Zutrittsregel,
-                      die Nachweispflicht, die Pflicht \nzum Tragen einer medizinischen Mund-Nasen-Be-\ndeckung
-                      sowie das für die Abgeordneten auf den Tribü-\nnenplätzen geltende Abstandsgebot
-                      verstoßen, kann dies \nmit den Mitteln des parlamentarischen Ordnungsrechts \ngeahndet
-                      werden.\nDie Fraktion der AfD widerspricht nunmehr der \nAnwendung des 3-G-Konzepts.\n(Claudia
-                      Roth [Augsburg] [BÜNDNIS 90/DIE \nGRÜNEN]: Meine Güte!)\nDarüber stimmen wir jetzt
-                      ab. Wer stimmt für die Anwen-\ndung des von mir eben beschriebenen 3-G-Konzepts?
-                      – \nWer stimmt dagegen? – Wer enthält sich? – Dann ist \ndieses Konzept als Teil
-                      unserer parlamentarischen Ord-\nnung gegen die Stimmen der AfD mit den Stimmen des
-                      \nübrigen Hauses so beschlossen.\nNach Absprache mit den Fraktionen benenne ich
-                      als \nvorläufige Schriftführerinnen und Schriftführer die \nDamen und Herren Abgeordneten
-                      Gökay Akbulut, \nNorbert Altenkamp, Artur Auernhammer, Silvia Breher, \nLeni Breymaier,
-                      Sandra Bubendorfer-Licht, Astrid \nDamerow, Dr. Karamba Diaby, Esther Dilcher, Michael
-                      \nDonth, Thomas Erndl, Kay Gottschalk, Erhard Grundl, \nMariana Harder-Kühnel, Peter
-                      Heidt, Marc \nHenrichmann, Thomas Hitschler, Dr. Bettina Hoffmann, \nMichael Kießling,
-                      Norbert Kleinwächter, Jens Koeppen, \nChristian Kühn (Tübingen), Markus Kurth, Ulrich
-                      \nLechte, Paul Lehrieder, Isabel Mackensen-Geis, \nDorothee Martin, Claudia Moll,
-                      Petra Nicolaisen, Jan \nNolte, Josef Oster, Tabea Rößner, Felix Schreiner, \nMichael
-                      Schrodi, Katrin Staffler, Mathias Stein, \nDeutscher Bundestag – 20. Wahlperiode
-                      – 1. Sitzung. Berlin, Dienstag, den 26. Oktober 2021                                4
-                      \n(A) \n(B) \n(C) \n(D) \nBenjamin Strasser, Jessica Tatti, Dr. Hermann-Josef \nTebroke,
-                      Kerstin Vieregge, Marja-Liisa Völlers, \nWolfgang Wiehle, Gülistan Yüksel.\nIch
-                      bitte die Abgeordneten Gülistan Yüksel und Jens \nKoeppen, neben mir Platz zu nehmen.\n(Zurufe
-                      von der AfD: Maske! 3-G-Regel!)\nDenken Sie an die Maske.\nLiebe Kolleginnen und
-                      Kollegen! Dass wir im Reichs-\ntagsgebäude tagen, ist ja eigentlich keiner Erwähnung
-                      \nwert. Und dennoch ist es heute eine Besonderheit. Wir \nkommen trotz der pandemischen
-                      Beschränkungen erst-\nmals wieder alle gemeinsam im Plenum zusammen. Das \nmacht
-                      eine überfraktionelle Verständigung möglich, die \nwir eben mit großer Mehrheit
-                      bestätigt haben.\n(Beifall bei Abgeordneten der CDU/CSU, des \nBÜNDNISSES 90/DIE
-                      GRÜNEN und der \nFDP)\nIn der vergangenen Legislaturperiode hat dieses Haus \nsogar,
-                      wenn nötig, einen überfraktionellen Konsens her-\nstellen können, um die Handlungsfähigkeit
-                      des Par-\nlaments zu sichern. Die Bürgerinnen und Bürger schauen \nauf uns. Ihre
-                      Erwartungen an das Parlament sind zu Recht \ngroß. Wir sollten weiter alles tun,
-                      um dem gemeinsam \ngerecht zu werden.\nDie heutige Abstimmung sollte nicht die letzte
-                      gewe-\nsen sein, in der wir mit überwältigender Mehrheit über \ndie Fraktionsgrenzen
-                      hinweg entscheiden. Wenn uns das \netwa beim Wahlrecht gelänge, wäre ich nach der
-                      auch für \nmich persönlich bitteren Erfahrung der vergangenen \nLegislaturperiode
-                      bestimmt nicht traurig.\n(Beifall bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE
-                      GRÜNEN und der FDP \nsowie bei Abgeordneten der AfD und der \nLINKEN)\nEine Wahlrechtsreform,
-                      die diesen Namen verdient, ist \nallerdings keinen Deut leichter geworden. Und trotzdem
-                      \nduldet sie ersichtlich keinen Aufschub. Mehr möchte ich \ndazu nicht sagen, außer
-                      dass jedenfalls nach meinem Ver-\nständnis bei einer Entscheidung dieser Tragweite
-                      eigent-\nlich keine politische Kraft im Parlament aus der Mitver-\nantwortung für
-                      eine tragfähige Lösung entlassen werden \nsollte.\nKonsens, liebe Kolleginnen und
-                      Kollegen, wird in die-\nsem Haus auch zukünftig nicht die Regel sein, und das \nsollte
-                      es auch nicht. Hier ist der Ort, an dem wir streiten \ndürfen, an dem wir streiten
-                      sollen, aber fair und nach \nRegeln, leidenschaftlich, aber auch mit der Gelassenheit,
-                      \ndie einer erregten Öffentlichkeit Beispiel geben kann. \nWenn wir das Prinzip
-                      der Repräsentation stärken wollen, \ndann müssen wir uns immer wieder um die Faszination
-                      \nder großen, strittigen Debatte bemühen. Das Parlament ist \nimmer auch eine politische
-                      Bühne und nicht bloß eine \nnotarielle Veranstaltung, um Koalitionsverträge abzuar-\nbeiten,
-                      zumal sich die Entwicklungen einer vernetzten \nWelt mit ihren wechselnden Herausforderungen
-                      nicht \nan Koalitionsverträge halten, wie wir erfahren haben.\nUmso mehr kommt es
-                      auf das Parlament an – als der \nRaum, in dem die Vielfalt an Meinungen offen zur
-                      Spra-\nche kommt. Das wird noch wichtiger, weil in unserer \nGesellschaft die Bereitschaft
-                      sinkt, gegensätzliche Stand-\npunkte auszuhalten, Widerspruch überhaupt zuzulassen,
-                      \nweil der Drang nach Konformität in der Gruppe wächst, \num von sich fernzuhalten,
-                      was dem eigenen Empfinden \nund Denken widerspricht.\nWir sollten den Streit in
-                      der Mitte der Gesellschaft \nsuchen und ihn öffentlich hier im Parlament austragen,
-                      \nindem wir deutlich machen, dass nie eine Seite allein \nrecht hat, dass um der
-                      Sache willen miteinander gerungen \nwerden muss. Politik ist ja kein Selbstzweck.
-                      Wir dienen \nnicht dem Eigeninteresse einer gesellschaftlichen Gruppe \noder einer
-                      Meinungsblase, sondern wir dienen der \nGemeinschaft. Am Ende unserer Debatten stehen
-                      Ent-\nscheidungen, für die wir die Verantwortung tragen, durch \nMehrheiten, die
-                      wechseln können. Das erleben wir gera-\nde.\nOhne Kompromisse geht das nicht, erst
-                      recht nicht bei \nMehrheitsverhältnissen wie nach dieser Wahl. Aber \nsuchen wir
-                      auch nicht immer nur den kleinsten gemein-\nsamen Nenner, indem wir im Detail streiten.
-                      Trauen wir \nuns etwas zu, ob in Regierungsverantwortung oder als \nOpposition;
-                      sonst geht verloren, was die Demokratie \neben auch dringend braucht: politische
-                      Führung.\nSie verlangt von uns als Abgeordnete den Blick für die \nwirklich großen
-                      Aufgaben und die Fähigkeit, das gesell-\nschaftliche Interesse auf diese großen
-                      Aufgaben zu \nlenken, Orientierung zu geben. Dazu müssen wir bereit \nsein, den
-                      Menschen auch etwas zuzumuten. Nicht nur \nAntworten geben, die gern gehört werden,
-                      sondern \nLösungen entwickeln und zur Diskussion stellen für die \nAufgaben, die
-                      wir als drängend erachten, und davon die \nBürger überzeugen: Dazu verpflichtet
-                      uns unser Mandat.\nDas mitunter zähe Ringen um gesellschaftliche Mehr-\nheiten sollten
-                      wir gerade auch denjenigen nahebringen, \ndie mit Blick auf den Klimawandel von
-                      der Trägheit \ndemokratischer Prozesse enttäuscht sind und sofortiges \nHandeln
-                      fordern. Ihre Motive sind nachvollziehbar, aber \nwissenschaftliche Erkenntnis allein
-                      ist noch keine Politik \nund schon gar nicht demokratische Mehrheit. Wer Ziele \nund
-                      Mittel absolut setzt, bringt sie gegen das demokrati-\nsche Prinzip in Stellung.
-                      Übrigens kann die Wissenschaft \ngenauso wenig letzte Gewissheit liefern, und in
-                      der \nDemokratie gibt es sowieso nicht die eine richtige Ent-\nscheidung. Genau
-                      damit müssen wir umgehen.\n(Beifall bei der CDU/CSU, der FDP und der \nAfD sowie
-                      bei Abgeordneten der SPD und des \nBÜNDNISSES 90/DIE GRÜNEN)\nZu Beginn der Pandemie
-                      haben wir ja erlebt, wie groß \nin einer Gefahrensituation das Bedürfnis nach klaren
-                      \npolitischen Vorgaben ist; wir brauchten wissenschaftli-\nchen Rat. Doch der Stand
-                      der Virologie und der Medizin \nwar damals noch recht unsicher, weil es eben ein
-                      neues \nPhänomen war. Die wissenschaftliche Logik, die nicht \nnur auf Konsens,
-                      sondern gerade auf Ambiguität, Zweifel \nund Widerspruch beruht, geriet in ein Spannungsverhält-\nnis
-                      zu den drängenden politischen Notwendigkeiten. Par-\nlament und Regierung mussten
-                      handeln. Und wir mussten \nDeutscher Bundestag – 20. Wahlperiode – 1. Sitzung. Berlin,
-                      Dienstag, den 26. Oktober 2021                                                                                                                                                                                                      5\nAlterspräsident
-                      Dr. Wolfgang Schäuble \n(A) \n(B) \n(C) \n(D) \ntrotz des unsicheren Erkenntnisstands
-                      und im Wissen um \ndie Vorläufigkeit wissenschaftlicher Forschung rasch \nEntscheidungen
-                      treffen und dabei verschiedene Diszipli-\nnen hören: die Soziologie, die Ökonomie,
-                      Psychologie \nund Pädagogik, auch den Ethikrat. Denn natürlich galt \nes, die ethisch-moralische
-                      Dimension genauso wie die \nverfassungsrechtlichen Aspekte unserer Maßnahmen \nmit
-                      zu bedenken. Wir haben auch die unterschiedlichen \nArgumente von Interessengruppen
-                      einbezogen.\nIn dieser Situation wurde ja wieder besonders deutlich: \nPolitik ist
-                      immer ein schwieriger Abwägungsprozess, ein \nAustarieren widerstreitender Interessen.
-                      Dabei darf sie \nden Blick auf das große Ganze nie verlieren. Das ist \nPolitik:
-                      das Ringen um Mehrheiten, die Suche nach \nLösungen, nach bestem Wissen und Gewissen
-                      Entschei-\ndungen treffen und sie dann auch verantworten. Es \nberührt unser Selbstverständnis
-                      als Demokraten. Aber \nwir müssen stets neu beweisen, die großen Herausforde-\nrungen
-                      unserer Zeit im Rahmen von Rechtsstaatlichkeit, \nFreiheit und Demokratie bewältigen
-                      zu können.\nIn der Coronapandemie ist es im Großen und Ganzen \ngelungen, auch unter
-                      enormem Entscheidungsdruck kon-\ntroverse Debatten zu führen und widerstrebende
-                      Werte \nund Interessen gegeneinander abzuwägen, auch wenn \nsich im Einzelnen Kritik
-                      immer üben lässt. Die parlamen-\ntarische Demokratie hat eine beispiellose Bewährungs-\nprobe
-                      bestanden, und diese Erfahrung kann uns Mut \nmachen für andere globale Herausforderungen.\n(Beifall
-                      bei Abgeordneten der SPD)\nDie parlamentarische Demokratie wird im Wettbewerb \nmit
-                      autoritären Systemen bestehen, wenn wir als Gesetz-\ngeber die Weichen so stellen,
-                      dass unsere Regierungs-\nform neben ihrer Wertegebundenheit auch durch Effi-\nzienz
-                      überzeugt. Aber hüten wir uns gleichzeitig vor der \nVersuchung, alles regeln zu
-                      wollen. Politik weiß nicht \nalles besser. Wenn Politik meint, sie habe keine Grenzen,
-                      \nist das mindestens genauso gefährlich, wie wenn andere \nglauben, sie seien keinen
-                      Begrenzungen unterworfen.\n(Beifall bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE
-                      GRÜNEN und der FDP \nsowie bei Abgeordneten der AfD)\nDas Prinzip unserer freiheitlichen
-                      Ordnung ist, dass sie \nbegrenzt ist.\nDer Souverän hat mit seiner Wahlentscheidung
-                      vom \n26. September die parteipolitische Vielfalt im Bundestag \nbestätigt und neue
-                      Mehrheiten ermöglicht. Für 279 Abge-\nordnete beginnt heute ein neues Leben als
-                      Parlamentarier. \nBehaupte noch einer, die parlamentarische Demokratie \nkönne sich
-                      nicht personell erneuern: Fast 40 Prozent aller \nMitglieder unseres Hauses bringen
-                      ihre Lebenswege, \nandere berufliche Hintergründe, persönliche Erfahrungen \nund
-                      Meinungen erstmals hier ein.\nGestatten Sie mir gerade an Sie, unsere neuen Kolle-\nginnen
-                      und Kollegen, gewandt eine persönliche Bemer-\nkung: Mit diesem Mandat, das Ihnen
-                      auf Zeit verliehen \nist – bei dem man im Übrigen nie genau wissen kann, wie \nlange
-                      diese Zeit dann wirklich dauert –, kommt eine \naußergewöhnliche und erfüllende
-                      Arbeit auf Sie zu und \nzugleich eine strapaziöse und vereinnahmende Zeit. Bei \nallem
-                      politischen Elan: Die Arbeit auf offener Bühne ver-\nlangt, das Private zu schützen.
-                      Seine Integrität wahrt, wer \nweiterhin zuhören kann und seinen inneren Kompass
-                      \nnicht verliert, wer sich in Kollegialität und Fairness übt, \nwer sich über die
-                      Verhaltensregeln, die wir uns geben, \nhinaus den Sinn dafür bewahrt, was anständig
-                      ist und – \nwomöglich noch stärker – was unanständig ist. Früher \nhätte man gesagt:
-                      Was sich gehört und was nicht.\n(Beifall bei der SPD, der CDU/CSU, dem \nBÜNDNIS
-                      90/DIE GRÜNEN und der FDP \nsowie bei Abgeordneten der AfD und der \nLINKEN)\nWir
-                      alle repräsentieren als Abgeordnete das Volk. Wir \nvertreten die legitimen Interessen
-                      unserer Wähler und \nParteien. Aber: Wir haben immer auch das Gemeinwohl \nim Blick
-                      zu behalten. Verwechseln wir Repräsentation \nnicht mit Repräsentativität. Jeder
-                      Einzelne von uns bildet \nnicht einfach einen Teil des Volkes ab. Artikel 38 GG
-                      ist \neindeutig: Abgeordnete – jeder Abgeordnete! – sind \n„Vertreter des ganzen
-                      Volkes“. Auch wenn sich natürlich \ndie gewachsene Vielfalt unserer Gesellschaft
-                      in der \nVolksvertretung wiederfinden soll: Der Bundestag wird \nnie ein exaktes
-                      Spiegelbild der Bevölkerung sein. Wer \nRepräsentation mit Repräsentativität gleichsetzt,
-                      wird \neine Fülle eklatanter Abweichungen finden: in berufli-\ncher, in regionaler,
-                      in kultureller oder religiöser Hinsicht. \nUnd er leistet dem irrigen Verständnis
-                      Vorschub, dass \ngesellschaftliche Gruppen nur durch ihre eigenen Ange-\nhörigen
-                      vertreten werden könnten.\n(Beifall bei der AfD sowie bei Abgeordneten \nder CDU/CSU
-                      und der FDP)\nAber bei wem wollen wir dann anfangen? Und wo endet \ndas? Ein Parlament,
-                      das zwar die Vielfalt abbildet, aber \ndarüber keine Mehrheiten schaffen kann, ist
-                      eben kein \nParlament!\nUnsere repräsentative Demokratie beruht auf der poli-\ntischen
-                      Gleichheit aller Bürgerinnen und Bürger – ohne \nRücksicht auf ihre soziokulturellen
-                      Merkmale. Als Par-\nlamentarier muss sich eine Juristin aus der Finanzverwal-\ntung
-                      mit Fragen der Landwirtschaft vertraut machen und \nder Handwerksmeister Entscheidungen
-                      über eine Pflege-\nreform treffen. Darin besteht das Mandat von Abgeord-\nneten.
-                      Als gewählte Repräsentanten vertreten wir die \nRepräsentierten nicht durch unsere
-                      Person, sondern durch \nunsere Politik. Durch sie sollten alle Menschen politisch
-                      \nGehör finden. Der Bundestag bündelt Interessen, und er \nträgt damit Verantwortung
-                      für den Zusammenhalt in \nunserem Land. Deshalb sollten wir uns immer wieder \nselbst
-                      hinterfragen, ob wir, ob unsere Parteien der Vielfalt \nan Interessen und Meinungen
-                      genügend Gehör verschaf-\nfen und auch ob die Erwartung der Bevölkerung, an \nGestaltungsprozessen
-                      selbst teilhaben zu können, ausrei-\nchend erfüllt wird.\nIn der vergangenen Legislaturperiode
-                      hat sich das Par-\nlament mit einem Bürgerrat für eine Form der delibera-\ntiven
-                      Demokratie geöffnet. Ich denke, dieser Bundestag \nwäre gut beraten, sich noch einmal
-                      intensiv mit den Vor-\nteilen, aber auch den Grenzen dieser Art von Bürgerbe-\nteiligung
-                      zu befassen, zumal Bürgerräte einen Raum \nschaffen, in dem unterschiedliche Menschen
-                      zusammen-\nkommen, einander kennenlernen und sich austauschen \nDeutscher Bundestag
-                      – 20. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 26. Oktober 2021                                6
-                      \nAlterspräsident Dr. Wolfgang Schäuble \n(A) \n(B) \n(C) \n(D) \nmüssen. Miteinander.
-                      Vereinzelungsorte haben wir ja \nschließlich mehr als genug. Mehr Mitsprache heißt
-                      nicht \nautomatisch mehr Partizipation und auch nicht zwangs-\nläufig mehr Akzeptanz
-                      für die am Ende im Parlament \ngetroffenen Entscheidungen. Dabei leistet die repräsenta-\ntive
-                      Demokratie, was auf keinem anderen Weg vergleich-\nbar gelingt: nicht nur die Vertretung
-                      mobilisierbarer Inte-\nressen, sondern auch der Ausgleich widerstreitender \nInteressen,
-                      nicht nur fordern, sondern auch gestalten, \nnicht nur entscheiden, sondern auch
-                      verantworten. Davon \nwerden wir die Bürger jedoch nur überzeugen, wenn wir \nunsere
-                      Rolle aktiv wahrnehmen. Es braucht ein selbst-\nbewusstes Parlament, und es braucht
-                      selbstbewusste Par-\nlamentarier.\nDas fordert viel von uns. Da ist der Wille des
-                      Wählers, \naber auch die Eigenständigkeit des Gewählten und die \nAbhängigkeit des
-                      einen vom anderen. Da ist der Drang, \nsich profilieren zu wollen, und gleichzeitig
-                      die Notwen-\ndigkeit, als Fraktion Geschlossenheit zu zeigen. Da ist \ndas Selbstverständnis
-                      der Fraktion auf Eigenständigkeit \nund in Regierungsverantwortung der Druck, stabile
-                      par-\nlamentarische Mehrheiten zu sichern. Diesem Span-\nnungsfeld können wir nicht
-                      ausweichen. Aber wir sollten \nuns dessen bewusst sein und uns um die richtige Balance
-                      \nbemühen. Denn wir tragen Verantwortung dafür, das Par-\nlament gegenüber wachsenden
-                      plebiszitären Ansprüchen \nzu stärken. Und im Übrigen liegt es an uns, wie weit
-                      wir \nunsere Gestaltungsspielräume als Gesetzgeber einengen \nlassen durch eine
-                      Rechtsprechung, die bisweilen mindes-\ntens an die Grenzen ihres Mandats geht.\n(Beifall
-                      bei der CDU/CSU, dem BÜNDNIS 90/ \nDIE GRÜNEN, der FDP und der AfD sowie des \nAbg.
-                      Carsten Schneider [Erfurt] [SPD])\nDazu gehört für mich dann allerdings auch, Verantwor-\ntung,
-                      die politisch wahrzunehmen ist, nicht auf Gerichte \nabzuwälzen.\n(Beifall bei der
-                      CDU/CSU, der FDP und dem \nBÜNDNIS 90/DIE GRÜNEN sowie bei \nAbgeordneten der SPD
-                      und der AfD)\nBei unseren Entscheidungen sind wir heute im Übrigen \nstärker denn
-                      je in globale Zusammenhänge eingebunden. \nDie komplexen Herausforderungen lassen
-                      sich nicht \nmehr allein im Nationalstaat bewältigen. Deshalb werden \nwir in einer
-                      Welt des rasanten Wandels den Bürgerinnen \nund Bürgern auch nur dann Halt geben
-                      können, wenn wir \nEuropa stärken und zusammenhalten. Dazu braucht es \nunsere Bereitschaft,
-                      die anderen besser verstehen zu wol-\nlen, die Interessen, Erfahrungen, die historischen
-                      und \nkulturellen Prägungen der anderen zu kennen und zu res-\npektieren. Ich habe
-                      in den Jahren, in denen ich diesem \nHaus und verschiedenen Regierungen angehören
-                      durfte, \ndie Erfahrung gemacht: Parlamente können hier ergän-\nzend zur Regierung
-                      manches bewirken. Als Abgeordnete \nsind wir es ja gewohnt, unterschiedliche Sichtweisen,
-                      \nwiderstreitende, aber legitime Interessen auszuhandeln.\nWir haben vor drei Jahren
-                      mit der Deutsch-Französi-\nschen Parlamentarischen Versammlung eine weltweit \neinzigartige
-                      binationale Kammer geschaffen, die in der \nPandemie eindrucksvoll bewiesen hat,
-                      wozu sie in der \nLage ist. Wir können stolz darauf sein, und wir sollten \ndarauf
-                      aufbauen.\n(Beifall bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN und der
-                      FDP \nsowie des Abg. Matthias W. Birkwald [DIE \nLINKE])\nVergessen wir darüber
-                      aber bitte auch nicht die besondere \nMittlerrolle, die Deutschland für unsere mittelost-
-                      und \nosteuropäischen Nachbarn zukommt – auch und gerade \ndiesem Parlament. Leisten
-                      wir unseren Beitrag dazu, dass \nsich die Spaltungen in Europa nicht weiter vertiefen.\n(Beifall
-                      bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN und der FDP \nsowie bei Abgeordneten
-                      der LINKEN)\nNoch ein persönliches Wort zum Schluss. Ich habe in \nden vergangenen
-                      vier Jahren in diesem Haus ein frakti-\nonsübergreifendes hohes Maß an Unterstützung
-                      und Res-\npekt im Amt des Bundestagspräsidenten erfahren – dafür \nbin ich dankbar
-                      –, und ich erhoffe und erbitte es auch für \nmeine Nachfolgerin, die wir heute in
-                      dieses Amt wählen.\n(Beifall bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN,
-                      der FDP und der \nLINKEN sowie bei Abgeordneten der AfD)\nAls Abgeordnete haben
-                      wir alle die gleichen Rechte; \ndarüber hat der Präsident/die Präsidentin zu wachen,
-                      mit \naller Kraft. Aber wir haben auch alle die gleichen Pflich-\nten. Am Verhalten
-                      jedes Einzelnen von uns – auch das \nmussten wir zuletzt wieder erfahren – hängt
-                      die Würde \ndieses Hauses. Wir haben es in der Hand, ob die Bür-\ngerinnen und Bürger
-                      dieser Volksvertretung das schen-\nken, worauf die parlamentarische Demokratie aufbaut,
-                      \nnämlich ihr Vertrauen.\nIch danke Ihnen.\n(Anhaltender Beifall im ganzen Hause
-                      – Die \nAnwesenden erheben sich)\n– Bringen Sie mich bitte nicht zu sehr in Rührung.\nJetzt
-                      rufe ich den Tagesordnungspunkt 2 auf:\nBeschlussfassung über die\n– Geschäftsordnung
-                      des Deutschen Bundes-\ntages\n– Gemeinsame Geschäftsordnung des Bundes-\ntages und
-                      des Bundesrates für den Ausschuss \nnach Artikel 77 des Grundgesetzes (Vermitt-\nlungsausschuss)\n–
-                      \ Geschäftsordnung für den Gemeinsamen \nAusschuss\n–  Geschäftsordnung für das
-                      Verfahren nach \nArtikel 115d des Grundgesetzes\nDrucksache 20/1\nEs liegt ein Antrag
-                      der Fraktion der SPD zur Weiter-\ngeltung der Geschäftsordnung des Deutschen Bundes-\ntages
-                      sowie weiterer Geschäftsordnungen vor. Dazu lie-\ngen weiterhin zwei Änderungsanträge
-                      der Fraktion der \nAfD vor.\nDeutscher Bundestag – 20. Wahlperiode – 1. Sitzung.
-                      Berlin, Dienstag, den 26. Oktober 2021                                                                                                                                                                                                      7\nAlterspräsident
-                      Dr. Wolfgang Schäuble \n(A) \n(B) \n(C) \n(D) \nMir ist mitgeteilt worden, dass
-                      das Wort gewünscht \nwird. Das Wort hat die Kollegin Gabriele Katzmarek, \nSPD.\n(Beifall
-                      bei der SPD)\nGabriele Katzmarek (SPD):\nSehr geehrter Herr Alterspräsident! So
-                      muss ich es \njetzt sagen, genau; ich muss mich daran gewöhnen.\nAlterspräsident
-                      Dr. Wolfgang Schäuble:\nNicht lange.\nGabriele Katzmarek (SPD):\nNicht lange; da
-                      haben Sie schon recht. – Liebe Kolle-\nginnen und Kollegen! Meine sehr geehrten
-                      Damen und \nHerren! Die Übernahme der Geschäftsordnung ist eine \nder ersten wichtigen
-                      Entscheidungen, die wir heute zu \nBeginn der Wahlperiode treffen müssen. Die Geschäfts-\nordnung
-                      ist Grundlage für unsere gemeinsame Arbeit. Sie \nhat sich über viele Wahlperioden
-                      bewährt und wird uns \nauch durch die neue Wahlperiode tragen. Es ist gute Tra-\ndition,
-                      dass wir die Geschäftsordnung am Anfang einer \nWahlperiode mit breiter parlamentarischer
-                      Mehrheit \nübernehmen, und das sollten wir auch heute tun.\nSie ist nicht in Stein
-                      gemeißelt – das wissen diejenigen, \ndie bereits in der letzten Wahlperiode hier
-                      im Bundestag \ntätig waren –, sondern die Geschäftsordnung ist immer \nein, ich
-                      sage mal, lebendiges Dokument, das sich den \nGegebenheiten des Parlamentarismus,
-                      aber auch den \nGegebenheiten der Arbeit hier im Deutschen Bundestag \nanpassen
-                      muss. Das muss eine Geschäftsordnung dann \nauch immer wieder in ihrer Entwicklung
-                      nachvollziehen. \nWir haben dieses bereits in der letzten Wahlperiode \nbewiesen
-                      und einige grundlegende Änderungen be-\nschlossen, vor allem und vorangestellt die
-                      überfällige \nReform der Verhaltensregeln.\nWir begrüßen auch ausdrücklich die Initiative
-                      des \nscheidenden Präsidenten Herrn Schäuble, die Geschäfts-\nordnung in dieser
-                      Wahlperiode einer Generalüberholung \nzu unterziehen. Wir sind gerne bereit, diese
-                      Impulse auf-\nzunehmen, und laden auch alle anderen Fraktionen dazu \nein, diesen
-                      Weg mit uns gemeinsam zu gehen. Die Vor-\nschläge der Opposition sind ernst zu nehmen.
-                      Wir möch-\nten sie aufgreifen und möchten gemeinsam mit Ihnen \ndarüber diskutieren,
-                      wie eine Geschäftsordnung über-\narbeitet werden und in der nächsten Zeit auch wirken
-                      \nkann.\nWir plädieren allerdings auch dafür, dass wir die in der \nletzten Legislaturperiode
-                      eingeführten Regelungen für \ndas digitale Tagen von Ausschüssen – vorerst zeitlich
-                      \nmöglichst kurz – beibehalten; das können Sie auch unse-\nrem Antrag entnehmen.
-                      Und wir plädieren dafür, das \neingeführte coronabedingte Absenken der Quoren, das
-                      \nnotwendig war für die Beschlussfähigkeit des Deutschen \nBundestages, in die neue
-                      Geschäftsordnung nicht mehr \naufzunehmen.\nIch bitte, wir bitten Sie um Zustimmung
-                      zum vorlie-\ngenden Antrag zur Weitergeltung der Geschäftsordnung, \ndamit wir in
-                      der erforderlichen Zeit, die wir dann haben, \ndie notwendigen Änderungen gemeinsam
-                      diskutieren \nund hier verabschieden können.\nHerzlichen Dank.\n(Beifall bei der
-                      SPD sowie bei Abgeordneten \ndes BÜNDNISSES 90/DIE GRÜNEN und der \nFDP)\nAlterspräsident
-                      Dr. Wolfgang Schäuble:\nStefan Müller, CDU/CSU, hat als Nächster das Wort.\n(Beifall
-                      bei der CDU/CSU)\nStefan Müller (Erlangen) (CDU/CSU):\nHerr Präsident! Liebe Kolleginnen
-                      und Kollegen! Die \nKonstituierung des Bundestages ist ein Festtag der \nDemokratie.
-                      Und wenn man sich auf der Welt mal \numsieht und sich anschaut, wie die Situation
-                      anderswo \nist, dann muss und darf man festhalten: Dass hier und \nheute ein unabhängiges,
-                      ein frei gewähltes, starkes Par-\nlament zusammenkommt, ist ein Geschenk – ein \nGeschenk,
-                      auf das wir stolz sein und für das wir dankbar \nsein können, liebe Kolleginnen
-                      und Kollegen.\n(Beifall bei der CDU/CSU sowie bei Abge-\nordneten der SPD, des BÜNDNISSES
-                      90/DIE \nGRÜNEN und der FDP)\nIch sage das deswegen, weil Demokratie ja immer auch
-                      \nein Streit nach Regeln ist, und diese Regeln geben wir uns \nmit der Geschäftsordnung,
-                      die wir gleich beschließen. \nDiese Geschäftsordnung hat sich insgesamt bewährt,
-                      \nunser parlamentarisches Miteinander zu organisieren; \ndeswegen werden wir den
-                      Antrag der SPD auch unter-\nstützen. Dieses Bewähren gilt insbesondere auch für
-                      die \nKernaufgaben, die dieses Parlament hat, nämlich die \nGesetzgebung und die
-                      Regierungskontrolle.\nNatürlich kann man der Auffassung sein, dass manche \nder
-                      Regeln, die schon einige Jahrzehnte alt sind – die \nGeschäftsordnung ist, glaube
-                      ich, in den 80er-Jahren \nzum letzten Mal wirklich grundlegend überarbeitet wor-\nden
-                      –, nicht mehr zeitgemäß sind; darüber herrscht, so \ndenke ich jedenfalls, auch
-                      fraktionsübergreifend Über-\neinstimmung.\nFrau Kollegin Katzmarek hat es gerade
-                      angesprochen: \nBundestagspräsident Wolfgang Schäuble hat vor Kurzem \nangeregt,
-                      diese Regeln einer Überarbeitung zu unterzie-\nhen. Dem Vorschlag, das im zuständigen
-                      Geschäftsord-\nnungsausschuss zu tun, schließen wir uns ausdrücklich \nan.\nNicht
-                      überarbeitungsbedürftig ist die Geschäftsord-\nnung für uns allerdings bei der Wahl
-                      des Bundeskanzlers. \nWir werden ja gleich auch über Änderungsanträge der \nAfD
-                      entscheiden; deswegen möchte ich dazu auch gerne \nStellung nehmen und die Position
-                      der CDU/CSU hier \nvortragen. Wir glauben, diese Regelungen haben sich in \nder
-                      Vergangenheit bewährt.\nUm es in aller Klarheit zu sagen: Eine Kanzlerwahl \ndient
-                      nicht der persönlichen Profilierung einer Fraktion, \nsondern sie dient dazu, diesem
-                      Land eine stabile Regie-\nDeutscher Bundestag – 20. Wahlperiode – 1. Sitzung. Berlin,
-                      Dienstag, den 26. Oktober 2021                                8 \nAlterspräsident
-                      Dr. Wolfgang Schäuble \n(A) \n(B) \n(C) \n(D) \nrung zu geben. Deshalb soll ja nach
-                      dem Willen der \nMütter und Väter des Grundgesetzes eine solche Wahl \nnur auf die
-                      Tagesordnung dürfen, wenn erkennbar ist, \ndass sich für eine erfolgreiche Kanzlerwahl
-                      auch eine \nerkennbare Mehrheit im Bundestag organisiert hat. Daran \norientiert
-                      sich auch unsere Geschäftsordnung: Der Bun-\ndespräsident macht einen Wahlvorschlag;
-                      scheitert dieser \nVorschlag, muss ein neuer Vorschlag von mindestens \neinem Viertel
-                      der Abgeordneten im Bundestag unter-\nzeichnet sein.\nGenau da setzt die AfD an,
-                      möchte das ändern, möchte \ngewissermaßen eine Sonderregel für sich selbst einfüh-\nren.
-                      Man stellt sich die Frage, warum das jetzt ausgerech-\nnet am heutigen Tag stattfindet,
-                      wo die Kanzlerwahl gar \nnicht zur Diskussion steht.\n(Beatrix von Storch [AfD]:
-                      Aber die \nGeschäftsordnung!)\nWer sich einmal die letzte Wahlperiode anschaut,
-                      der \nweiß ganz genau: Es geht gar nicht um die Sache, sondern \nes geht darum,
-                      für Social Media die richtigen Videoclips \nzu produzieren. Es geht darum, hier
-                      die große politische \nBühne zu haben, um sich inszenieren zu können; es geht \num
-                      nicht mehr und nicht weniger.\n(Beifall bei der CDU/CSU, der SPD, dem \nBÜNDNIS
-                      90/DIE GRÜNEN, der FDP und der \nLINKEN)\nDie AfD versucht seit mittlerweile vier
-                      Jahren, die \nBundestagssitzungen für ihren parteipolitischen Klamauk \nzu missbrauchen.
-                      Wir werden nicht zulassen,\n(Zuruf von der AfD: Frechheit!)\ndass Sie das auch bei
-                      der Kanzlerwahl so machen.\nDie AfD möchte als Fraktion Misstrauensanträge ohne
-                      \nMindestzahl von Unterstützern stellen können. Hier gilt \ndas Gleiche: Dies ist
-                      der Plenarsaal des Bundestages, \nnicht der Spielplatz für Ihre destruktive Propaganda.\n(Beifall
-                      bei der CDU/CSU, der SPD, dem \nBÜNDNIS 90/DIE GRÜNEN und der \nLINKEN sowie bei
-                      Abgeordneten der FDP)\nEs würde Ihnen bei diesen Misstrauensanträgen nur \ndarum
-                      gehen, permanentes Misstrauen in die Institutio-\nnen und in unseren Staat zu säen.
-                      Das werden wir nicht \nzulassen. Deswegen werden wir als CDU/CSU Ihre \nAnträge
-                      ablehnen.\n(Beifall bei der CDU/CSU sowie bei Abge-\nordneten der SPD und der FDP
-                      – Dr. Alice \nWeidel [AfD]: Dafür haben Sie auch die \nQuittung gekriegt! – Jan
-                      Korte [DIE LINKE]: \nDas war ganz gut! – Gegenruf der Abg. \nDr. Alice Weidel [AfD]:
-                      Na ja!)\nAlterspräsident Dr. Wolfgang Schäuble:\nBritta Haßelmann, Bündnis 90/Die
-                      Grünen, hat als \nNächste das Wort.\n(Beifall beim BÜNDNIS 90/DIE GRÜNEN)\nBritta
-                      Haßelmann (BÜNDNIS 90/DIE GRÜNEN):\nSehr geehrter Herr Alterspräsident Wolfgang
-                      \nSchäuble! Sehr geehrte Kolleginnen und Kollegen! Es \nist in der Tat wichtig und
-                      notwendig, dass wir uns gleich \nzu Beginn dieser konstituierenden Sitzung einen
-                      Rahmen \ngeben. Dieser Rahmen als Grundlage für die Zusammen-\narbeit ist unsere
-                      Geschäftsordnung. Das ist wichtig und \nnotwendig für uns, damit klar ist, wie die
-                      Arbeit des \nParlamentes funktionieren kann. Manche haben einen \nsolchen Rechtsrahmen
-                      nötiger als andere; aber für uns \nalle ist er verbindlich.\n(Beifall beim BÜNDNIS
-                      90/DIE GRÜNEN \nund bei der SPD sowie bei Abgeordneten der \nFDP und der LINKEN)\nLiebe
-                      Kolleginnen und Kollegen, meine Damen und \nHerren, das ist gut und richtig. Der
-                      Antrag, den die \nSPD vorgelegt hat, reagiert an einigen Stellen auch auf \ndie
-                      aktuelle Situation. So regelt § 126a der Geschäfts-\nordnung in der pandemischen
-                      Zeit eine Ausnahme für \ndie Beschlussfähigkeit des Deutschen Bundestages. Die-\nse
-                      heben wir mit dem heutigen Tag auf. Es ist richtig und \nnotwendig, das zu tun;
-                      denn wir haben vereinbart, bis auf \nsehr wenige dort oben, dass wir in einem 3-G-Regime
-                      \ndurchaus auch in größerer Anzahl hier tagen können. \nDeshalb erübrigt sich also
-                      auch die Frage, ob wir auch \nin einer kleineren Anzahl beschlussfähig sind. Also,
-                      das \nmacht Sinn, meine Damen und Herren.\n(Beifall beim BÜNDNIS 90/DIE GRÜNEN \nund
-                      bei der SPD sowie bei Abgeordneten der \nCDU/CSU)\nWir werden auch im weiteren Prozess
-                      noch über einige \nÄnderungen der Geschäftsordnung reden.\nLiebe Kolleginnen und
-                      Kollegen, vor allen Dingen \nspreche ich jetzt die Neuen hier im Haus an: Natürlich
-                      \nist eine Geschäftsordnung auch etwas wahnsinnig Leben-\ndiges; denn sie ist ja
-                      nicht statisch. Wir haben in den \nletzten Monaten schon oft darüber geredet, an
-                      welcher \nStelle wir Änderungen brauchen. Wollen wir zum Bei-\nspiel beim Fragerecht
-                      noch etwas ändern? Wollen wir uns \nandere Regeln in bestimmten Umgängen mit den
-                      Frak-\ntionen geben? All das wird in den nächsten Wochen und \nMonaten im Geschäftsordnungsausschuss
-                      und abschlie-\nßend hier diskutiert. Deshalb ist es richtig und gut, zu \nsagen:
-                      Das machen wir dann im Geschäftsordnungsaus-\nschuss und bereiten das für das Parlament
-                      vor. – Dennoch \nliegen heute zwei Änderungsanträge vor. Von mir aus \nnehmen wir
-                      die auch mit in den Geschäftsordnungsaus-\nschuss. Da können wir noch einmal über
-                      den Sinn und \nUnsinn dieser Änderungsanträge der AfD diskutieren.\nIch will in
-                      der Sache trotzdem ganz kurz etwas dazu \nsagen: Was soll dieser Änderungsantrag
-                      im Hinblick auf \ndie Absenkung der Anzahl der Abgeordneten,\n(Stephan Brandner
-                      [AfD]: Das erkläre ich \nIhnen gleich!)\nden Bundeskanzler, die Bundeskanzlerin
-                      mit einem Vier-\ntel der Mitglieder dieses Hauses wählen zu können? Mei-\nne Damen
-                      und Herren, wer nachdenken kann – das hilft in \ndieser Situation –,\nDeutscher
-                      Bundestag – 20. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 26. Oktober 2021
-                      \                                                                                                                                                                                                     9\nStefan
-                      Müller (Erlangen) \n(A) \n(B) \n(C) \n(D) \n(Beifall bei Abgeordneten des BÜNDNIS-\nSES
-                      90/DIE GRÜNEN)\nweiß, dass wir bei sehr, sehr vielen Gesetzgebungsver-\nfahren hier
-                      im Haus die Kanzler/-innenmehrheit brau-\nchen. Wo sollte also der Sinn liegen,
-                      meine Damen und \nHerren, ausgerechnet bei der Wahl eines Kanzlers oder \neiner
-                      Kanzlerin zu sagen: „Dafür reicht ein Viertel“, \naußer der Tatsache, dass sich
-                      die Abgeordneten der AfD \ndamit erneut ausleben wollen: Woche für Woche, Monat
-                      \nfür Monat?\n(Dr. Alice Weidel [AfD]: Sie haben den Antrag \nnicht verstanden!)\nIch
-                      finde, es gibt keine sachlich guten Gründe, und das \nParlament sollte dem keine
-                      Zustimmung geben, meine \nDamen und Herren.\n(Beifall beim BÜNDNIS 90/DIE GRÜNEN,
-                      \nbei der SPD, der CDU/CSU, der FDP und der \nLINKEN)\nEs ist doch albern. Wir brauchen
-                      369 Abgeordnete für \neine Kanzler-/Kanzlerinnenmehrheit bei besonders rele-\nvanten
-                      Fragen. Aber mit einem Viertel der Abgeordneten \nsoll man den Kanzler oder die
-                      Kanzlerin vorschlagen \nkönnen? Das ist doch absurd. Und die Ankündigung, \ndass
-                      ein gewisser Herr Brandner das vorstellen will, \nmacht es nicht besser, meine Damen
-                      und Herren.\n(Beifall beim BÜNDNIS 90/DIE GRÜNEN \nsowie bei Abgeordneten der SPD
-                      und der CDU/ \nCSU)\nAlso ich schlage vor: Wir nehmen das mit. – Meine \nHaltung
-                      dazu ist klar, und ich habe gehört: Anderen \ngeht es ähnlich.\nDer zweite Änderungsantrag
-                      im Hinblick auf die Fra-\nge, ob wir demnächst parlamentarische Initiativen oder
-                      \nAnträge, so wie es die Lebenswirklichkeit vieler Men-\nschen abbildet, auch gendern.
-                      Das scheint den Horizont \nmancher Abgeordneter in der AfD zu übersteigen.\n(Zuruf
-                      der Abg. Beatrix von Storch [AfD])\nSie merken: Die Stimmung wird auch anders. Man
-                      hält es \nkaum aus.\n(Beifall bei Abgeordneten des BÜNDNIS-\nSES 90/DIE GRÜNEN)\nIch
-                      sage nur, meine Damen und Herren: Kommen Sie \ndoch einfach in der Lebenswirklichkeit
-                      an.\n(Enrico Komning [AfD]: Das ist Ihre \nLebenswirklichkeit!)\nMachen Sie es doch,
-                      wie Sie es wollen, aber schreiben \nSie nicht allen anderen vor, was sie zu denken,
-                      zu tun und \nzu reden haben.\n(Beifall beim BÜNDNIS 90/DIE GRÜNEN, \nbei der SPD
-                      und der LINKEN sowie bei \nAbgeordneten der CDU/CSU und der FDP)\nInsofern nehmen
-                      wir das gerne mit in die Diskussion \nim Geschäftsordnungsausschuss. Ich denke,
-                      wir starten \nheute einfach einmal ganz gut durch, und das ohne die \nÄnderungsanträge
-                      der AfD.\nVielen Dank.\n(Beifall beim BÜNDNIS 90/DIE GRÜNEN, \nbei der SPD und der
-                      LINKEN sowie bei \nAbgeordneten der CDU/CSU und der FDP)\nAlterspräsident Dr. Wolfgang
-                      Schäuble:\nNächster Redner ist der Kollege Dr. Marco \nBuschmann, FDP.\n(Beifall
-                      bei der FDP)\nDr. Marco Buschmann (FDP):\nSehr geehrter Herr Präsident! Meine lieben
-                      Kollegin-\nnen und Kollegen! Als ich gestern insbesondere die neu-\nen Kolleginnen
-                      und Kollegen meiner Fraktion auf den \nheutigen Tag eingestimmt habe, habe ich von
-                      einem wei-\nhevollen Tag gesprochen, einem Tag, der so ein bisschen \nähnlich ist
-                      wie Taufe oder Erstkommunion,\n(Jan Korte [DIE LINKE]: Oder Jugendweihe!)\nweil
-                      man etwas ganz Neues in seinem Leben erlebt. – \nMan kann auch, Herr Kollege Korte,
-                      Jugendweihe sagen.\n(Heiterkeit und Beifall bei der FDP)\nEntscheidend ist aber,
-                      dass wir heute das ausstrahlen, \nwas die Bürgerinnen und Bürger erwarten, nämlich
-                      einen \nwürdigen Umgang mit der Verantwortung, die sie uns \nallen übertragen haben.
-                      Zu diesem würdigen Umgang \ngehört der Streit nach Regeln. Das hat der scheidende
-                      \nPräsident vorhin gesagt. Diese Regeln geben wir uns \njetzt, und es spricht für
-                      die Kultur unseres Parlamentaris-\nmus, dass wir einen sehr breiten Konsens haben,
-                      was den \nübergroßen Teil der richtigen und angemessenen Regeln \nfür diesen Streit
-                      angeht. Deshalb unterstützen wir auch \nden Antrag der größten Fraktion des Hauses,
-                      die diesen \nAntrag traditionell einbringt, den Frau Katzmarek hier \ngerade vorgetragen
-                      hat. – Das ist die erste Bemerkung, \ndie ich machen wollte.\nDie zweite Bemerkung
-                      ist: Auch wir begrüßen es, dass \nwir die Geschäftsordnung einer Modernisierung
-                      unterzie-\nhen. Wir haben in der Coronazeit gelernt, dass es über-\nhaupt nicht
-                      wehtut, Kolleginnen oder Kollegen digital \nzuzuschalten, Sachverständige digital
-                      zuzuschalten. Vie-\nles, was lange Zeit als unwürdig, außergewöhnlich oder \nnicht
-                      umsetzbar galt, ist mit dem kleinen Vorbehalt, dass \nes technisch noch immer nicht
-                      ganz reibungslos klappt, \nüberhaupt nicht schlimm. Es ist ein Gewinn für viele
-                      \nKolleginnen und Kollegen. Ich freue mich auf eine De-\nbatte zur grundlegenden
-                      Modernisierung der Geschäfts-\nordnung.\nMit meiner dritten Bemerkung möchte ich
-                      auf einen \nder beiden bereits angesprochenen Änderungsanträge der \nAfD eingehen.
-                      Was technisch ein wenig auf leisen Sohlen \ndaherkommt, nämlich die Absenkung des
-                      Quorums für \neinen Antrag sowohl zur Wahl als auch – darum geht es in \nWahrheit
-                      wirklich – zur Abwahl eines Bundeskanzlers, \nist in Wahrheit eine völlige Umkehrung
-                      des Charakters \ndieses Instruments. Die Abwahl des Bundeskanzlers, wie \nsie unser
-                      Grundgesetz vorsieht, ist eine Antwort auf unse-\nre Geschichte. Die Abwahl eines
-                      Bundeskanzlers kann \nnur erfolgen durch die Neuwahl eines Kanzlers. Es ist \ndas
-                      berühmte konstruktive Misstrauensvotum. Das kon-\nstruktive Misstrauensvotum ist
-                      eine Antwort auf unsere \nDeutscher Bundestag – 20. Wahlperiode – 1. Sitzung. Berlin,
-                      Dienstag, den 26. Oktober 2021                                10 \nBritta Haßelmann
-                      \n(A) \n(B) \n(C) \n(D) \nGeschichte, weil es in der Weimarer Republik ganz ein-\nfach
-                      war, eine Mehrheit gegen etwas zu organisieren. Es \nwar leicht, eine Mehrheit zu
-                      haben, die sich darauf einigt, \ndass man unzufrieden ist mit dem Bestehenden, dass
-                      man \nsich aus der Verneinung heraus definiert. Aber es war \neben schwer, eine
-                      Mehrheit zu organisieren, die sich für \netwas ausspricht, für etwas, das man gemeinsam
-                      in der \nMehrheit für das Bessere hält. Dadurch kam es zustande, \ndass reihenweise
-                      Regierungen in der Weimarer Republik \naus dem Amt gejagt wurden, dass die Bürgerinnen
-                      und \nBürger damals das Vertrauen in die Institutionen ver-\nloren. Und das hat
-                      mit dazu beigetragen, dass der Weg \nin die Diktatur geebnet wurde.\nDaraus haben
-                      die Mütter und Väter des Grundgesetzes \neine Lehre gezogen, dass nämlich die Beseitigung
-                      eines \ngewählten Bundeskanzlers aus dem Amt durch das Par-\nlament nur möglich
-                      ist, wenn es eben nicht nur eine \nMehrheit gegen etwas gibt, sondern auch eine
-                      Mehrheit \nfür etwas, das man gemeinsam für das Bessere hält.\nDie Quoren der Geschäftsordnung,
-                      um ein solches Ver-\nfahren einzuleiten, stellen uns allen gemeinsam deshalb \neine
-                      Prüffrage. Die Prüffrage lautet: Wie wollt ihr denn \neine Kanzlermehrheit zustande
-                      bekommen, wenn nicht \nmal ein Viertel dieses Hauses bereit wäre, das Verfahren
-                      \ndafür einzuleiten? Diese Prüffrage stellt den Ausnah-\nmecharakter dieses Verfahrens
-                      sicher; denn was nicht \nsein soll, ist, dass aus diesem Ausnahmeinstrument des
-                      \nkonstruktiven Misstrauensvotums ein plenartägliches \nKampfinstrument wird, das
-                      jede Sitzungswoche im \nZweifelsfall gezogen wird, um das Vertrauen in die \ndemokratischen
-                      Institutionen unseres Grundgesetzes zu \nunterhöhlen.\n(Beifall bei der FDP, der
-                      SPD, der CDU/CSU, \ndem BÜNDNIS 90/DIE GRÜNEN und der \nLINKEN)\nUnd wer Erfahrung
-                      mit der Fraktion, die diesen Ände-\nrungsantrag stellt, hier in den letzten vier
-                      Jahren gesam-\nmelt hat, weiß genau, dass das Ziel ist: das Vertrauen in \ndie demokratisch
-                      legitimierten Institutionen unseres \nGrundgesetzes zu unterspülen, indem aus einem
-                      Ausnah-\nmeinstrument ein plenartägliches Kampfinstrument \ngemacht wird. Und dabei
-                      machen die Freien Demokraten \nnicht mit.\nIch danke Ihnen.\n(Beifall bei der FDP,
-                      der SPD, der CDU/CSU \nund dem BÜNDNIS 90/DIE GRÜNEN sowie \nbei Abgeordneten der
-                      LINKEN)\nAlterspräsident Dr. Wolfgang Schäuble:\nNächster Redner ist der Kollege
-                      Stephan Brandner, \nAfD.\n(Beifall bei der AfD)\nStephan Brandner (AfD):\nHerr Alterspräsident!
-                      Lassen Sie mich zunächst Dank \naussprechen für Ihre eindrucksvolle und ausgewogene
-                      \nRede zu Beginn dieser Sitzung, die so ausgewogen und \neindrucksvoll war, dass
-                      teilweise nur Applaus der AfD zu \nvernehmen war.\n(Beifall bei der AfD)\nVielen
-                      Dank noch mal dafür, dass Sie uns vor Augen \ngeführt haben, wo die Herausforderungen
-                      in der Zukunft \nliegen.\nMeine Damen und Herren, lassen Sie uns kurz über die \nrechtliche
-                      Flankierung des vor uns gemeinsam liegenden \nLebensabschnittes in den nächsten
-                      vier Jahren, also der \n20. Wahlperiode, reden. Das Regelwerk, über das ja \nschon
-                      hier gesprochen wurde, ist unter anderem die \nGeschäftsordnung, die sich zwar im
-                      Großen und Ganzen \nganz nett liest, gleichwohl aber in der vergangenen Wahl-\nperiode
-                      von Ihnen zur Bekämpfung der Opposition – und \ndamit meine ich die AfD, die einzige
-                      Opposition; denn \nSie alle regieren ja irgendwo irgendwie mit – missbraucht \nwurde:\n(Beifall
-                      bei Abgeordneten der AfD)\nsei es der Sündenfall zum Alterspräsidenten – Bernd \nBaumann
-                      hatte das angesprochen –, sei es die unpar-\nlamentarische Verhinderung des Bundestagsvizeprä-\nsidenten
-                      – damit können Sie ja heute Schluss machen \nund mal wieder zu richtigen Parlamentariern
-                      werden –, \nseien es durchgepeitschte Gesetze im Rahmen der Par-\nteienfinanzierung,
-                      seien es fragwürdige Omnibusgesetze, \ndie völlig Verschiedenes vermischen, nämlich
-                      Fluthilfe \nbeispielsweise mit Coronamaßnahmen. Es gibt viel zu \ntun, viel zu regeln,
-                      viel zu ändern an der Geschäftsord-\nnung; das haben meine Vorredner ja ausgeführt.\nMeine
-                      Damen und Herren, wir sind heute in der begin-\nnenden 20. Wahlperiode, in der konstituierenden
-                      Sitzung, \nweshalb wir uns auf zwei wichtige und wesentliche Din-\nge beschränken
-                      wollen:\nZum einen – und das ist die Mehrheitsmeinung im \ndeutschen Volke – geht
-                      es um die Lesbarkeit von Druck-\nsachen durch Verzicht auf die sogenannte Gendersprache.
-                      \nDie deutliche Mehrheit unserer Bürger – ungefähr zwei \nDrittel – lehnt den Orwell’schen
-                      Sprachunsinn ab,\n(Beifall bei der AfD)\nganz unabhängig davon, um wen es sich handelt.
-                      Männer \nund Frauen lehnen das ab. Sie wollen keine Sternchen, sie \nwollen keine
-                      Binnen-Is, sie wollen keine Doppelpunkte, \nsie wollen keine Schräg- und keine Unterstriche,\n(Claudia
-                      Roth [Augsburg] [BÜNDNIS 90/DIE \nGRÜNEN]: Sie wollen keine AfD!)\nund sie wollen
-                      keine künstlichen Stotterpausen. Also, Sie \nkönnen was für unser Volk, für die
-                      Mehrheit des Volkes, \ntun. Handeln wir im Sinne der großen Mehrheit unserer \nBürger!
-                      Handeln Sie im Sinne der großen Mehrheit unse-\nrer Bürger! Und lassen wir einen
-                      solchen Quatsch im \nDeutschen Bundestag einfach in Zukunft sein!\n(Beifall bei
-                      der AfD)\nFrau Haßelmann, Sie können natürlich gendern und \nkünstlich stottern,
-                      wie Sie wollen – zu Hause, in Ihren \nFraktionssitzungen oder auf Ihren Parteitagen
-                      –, aber im \nDeutschen Bundestag sollte Vernunft walten. Dazu dient \nunser erster
-                      Antrag.\nMeine Damen und Herren, der zweite Antrag steht \nganz einfach unter dem
-                      Motto: Mehr Demokratie wagen.\nDeutscher Bundestag – 20. Wahlperiode – 1. Sitzung.
-                      Berlin, Dienstag, den 26. Oktober 2021                                                                                                                                                                                                     11\nDr.
-                      Marco Buschmann \n(A) \n(B) \n(C) \n(D) \n(Beifall bei Abgeordneten der AfD – Lachen
-                      \nbei der SPD)\nDas war nicht nur ein Anliegen von Willy Brandt; das ist \nauch
-                      ein Anliegen der AfD seit Bestehen der AfD: Mehr \nDemokratie wagen im Großen, beispielsweise
-                      durch \nVolksabstimmungen und Volksbegehren; mehr Demokra-\ntie wagen aber auch
-                      im Kleinen, im Rahmen der \nGeschäftsordnung, die gänzlich weltfremd vorschreibt,
-                      \ndass allein für den Wahlvorschlag zum Bundeskanzler – – \nFrau Haßelmann,\n(Britta
-                      Haßelmann [BÜNDNIS 90/DIE \nGRÜNEN]: Ja!)\nda haben Sie unseren Antrag wohl nicht
-                      begriffen; ent-\nweder haben Sie ihn selbst nicht gelesen oder sich ihn \nfalsch
-                      erklären lassen. Es geht nicht darum, dass wir \ndas Quorum absenken wollen für
-                      die Wahl des Bundes-\nkanzlers, sondern es geht schlicht und ergreifend um den \nWahlvorschlag.\n(Amira
-                      Mohamed Ali [DIE LINKE]: Ja, das hat \nsie doch gesagt!)\nAlso, Sie haben einfach
-                      am Thema vorbeigeredet, wie \nwir das von Ihnen kennen, Frau Haßelmann.\n(Beifall
-                      bei der AfD)\nAber die Bestenauslese schlägt ja offenbar bei den Grü-\nnen auch
-                      bei den Parlamentarischen Geschäftsführern \nnicht durch.\n(Claudia Roth [Augsburg]
-                      [BÜNDNIS 90/DIE \nGRÜNEN]: O mein Gott!)\nBei der AfD ist das anders.\nAlso: Die
-                      Geschäftsordnung schreibt eigentlich völlig \nweltfremd vor, dass man für den Vorschlag
-                      zur Wahl \neines Bundeskanzlers 25 Prozent der Mitglieder des \nDeutschen Bundestags,
-                      also knapp 190, braucht. Allein \num kandidieren zu dürfen, benötigt man diese Anzahl,
-                      die \nsich offenbart. Das ist ein ganz klarer Verstoß gegen die \nGeheimheit der
-                      Wahl. Und wenn wir in diesen bunten \nBundestag hineinschauen, bringt nur eine einzige
-                      Partei \nes alleine zustande, 25 Prozent für den Wahlvorschlag \nzusammenzubekommen.
-                      Das wäre die SPD.\n(Ralph Brinkhaus [CDU/CSU]: Das ist falsch!)\nEine andere Fraktion
-                      schafft es auch noch durch eine, \nsagen wir mal, seltsame Auslegung der Geschäftsord-\nnung,
-                      durch eine komische Konstellation, dass sich \nzwei Parteien zusammenschließen,
-                      zwei Parteien, die \nkrachend verloren haben bei der Bundestagswahl: die \nCDU bundesweit
-                      bei knapp 19 Prozent – das muss man \nmal wissen –, die CSU gerade mal bei 5,2 Prozent
-                      – \ngerade mal die 5-Prozent-Hürde übersprungen; die CSU \nhat gerade mal 0,3 Prozent
-                      mehr als die Linken.\n(Dorothee Bär [CDU/CSU]: Ja, in einem \nBundesland! In einem
-                      einzigen Bundesland! \nDer Vollhonk! Unmöglich! Unfassbar!)\nDas muss man mal wissen,
-                      was in Deutschland los ist.\n(Beifall bei der AfD)\nMeine Damen und Herren, Demokratie
-                      verlangt da-\nnach, dass natürlich ein Wahlvorschlag gemacht werden \nkann von einem
-                      relativ geringen Quorum ausgehend. \nDeshalb schlagen wir vor: Jede Fraktion hat
-                      das Recht, \neinen Kandidaten vorzuschlagen zur Wahl des Bundes-\nkanzlers. Dann
-                      – Frau Haßelmann, ich erkläre Ihnen das \ngerne noch mal – kommt es natürlich darauf
-                      an, dass man \ndie Kanzlermehrheit im Deutschen Bundestag erreicht.\nDas, was Herr
-                      Müller und Herr Buschmann hier gesagt \nhaben, ist vom Bereich der Verschwörungstheorien
-                      wirk-\nlich nicht weit entfernt und von Unkenntnis auch nicht, \nHerr Müller. Nicht
-                      die Väter und Mütter des Grundgeset-\nzes haben das so eingeführt, sondern die Väter
-                      und Müt-\nter der Geschäftsordnung. Die Väter und Mütter des \nGrundgesetzes haben
-                      dazu gar nichts geregelt.\n(Beifall bei der AfD)\nDeshalb unsere dringende Bitte,
-                      meine Damen und \nHerren, ganz im Sinne der Bürger unseres Landes: Ver-\nzichten
-                      wir auf die Gendersprache, und werden wir ganz \nim Sinne von Willy Brandt etwas
-                      demokratischer\n(Zurufe von der SPD: Hoi!)\ndadurch, dass wir die Formalien für
-                      den Vorschlag zum \nKandidaten eines Bundeskanzlers etwas absenken! Wer-\nden Sie
-                      demokratischer! Folgen Sie der AfD! Stimmen \nSie unseren Anträgen zu!\nVielen Dank.\n(Beifall
-                      bei der AfD)\nAlterspräsident Dr. Wolfgang Schäuble:\nVoraussichtlich letzter Redner
-                      in dieser Debatte ist der \nKollege Jan Korte, Die Linke.\n(Beifall bei der LINKEN)\nJan
-                      Korte (DIE LINKE):\nSehr geehrter Herr Alterspräsident Dr. Schäuble! Also, \nHerr
-                      Brandner, gleich in der ersten Sitzung die braune \nWiderlichkeitsskala in solche
-                      Höhen zu treiben,\n(Dr. Bernd Baumann [AfD]: Jetzt kommt die \nrote Widerlichkeit!
-                      Das ist noch schlimmer!)\ndas ist immerhin respektvoll.\n(Beifall bei der LINKEN,
-                      der SPD, dem \nBÜNDNIS 90/DIE GRÜNEN und der FDP)\nDass ausgerechnet Sie Willy Brandt
-                      zitieren, der gegen \ndie Nazis gekämpft hat, der niedergekniet ist vor den \nOpfern
-                      des Aufstandes im Warschauer Ghetto, dass aus-\ngerechnet Sie, die in der Tradition
-                      der Nazis stehen,\n(Dr. Bernd Baumann [AfD]: Und Sie in der \nTradition von Ulbricht!)\ndas
-                      hier anbringen, ist abartig, um das in aller Klarheit zu \nsagen. Abartig und ekelerregend!\n(Beifall
-                      bei der LINKEN, der SPD und dem \nBÜNDNIS 90/DIE GRÜNEN – Norbert \nKleinwächter
-                      [AfD]: Sie hätten aus dem \nParlament raus gehört! – Weitere Zurufe von \nder AfD)\nLiebe
-                      Kolleginnen und Kollegen, sehr geehrte Damen \nund Herren von der AfD,\n(Zurufe
-                      von der AfD)\nDeutscher Bundestag – 20. Wahlperiode – 1. Sitzung. Berlin, Dienstag,
-                      den 26. Oktober 2021                                12 \nStephan Brandner \n(A)
-                      \n(B) \n(C) \n(D) \nwenn ich mir die politische Lage angucke, dann finde ich \nzurzeit
-                      besonders wichtig: Wie entwickelt sich Corona? \nIch finde es wichtig, darüber zu
-                      diskutieren, wie wir \nKinderarmut bekämpfen können. Und ich mache mir gro-\nße
-                      Sorgen, dass sich hier eine Koalition anbahnt, in der \ndas Soziale hinten runterfallen
-                      wird, weil die stabil \nmarktradikale FDP dafür schon sorgen wird.\n(Lachen bei
-                      Abgeordneten der FDP – Christian \nLindner [FDP]: Das werden wir jetzt die \nnächsten
-                      vier Jahre hören!)\nDas ist etwas, was mich und viele Menschen bewegt.\nWas ist
-                      der AfD wichtig? Der AfD ist wichtig: die \nVerunglimpfung von geschlechtergerechter
-                      Sprache. \nDas einzig Sinnvolle an Ihrem Änderungsantrag ist, \ndass man sehen kann,
-                      wie parlamentarisch verblödet Sie \neigentlich sind. Ich will Ihnen mal was sagen:
-                      Wir können \nan Ihrem Änderungsantrag – das ist das einzig Gute – \nsehr gut erkennen,
-                      dass Sie offenbar in vier Jahren Bun-\ndestag nicht einmal einen Gesetzestext gelesen
-                      haben. Da \ngibt es kein Binnen-I, keine Doppelpunkte und keine \nGendersternchen.\n(Beifall
-                      bei der LINKEN)\nDas ist so absurd, was Sie hier beantragen, weil es das gar \nnicht
-                      gibt in den Gesetzestexten. Also: Völlig für den \nPapierkorb, was Sie hier vorgelegt
-                      haben!\n(Beifall bei der LINKEN)\nMeine Fraktion wird die Vorlage der sozialdemokrati-\nschen
-                      Fraktion unterstützen; denn ich halte diese \nGeschäftsordnung für eine gute Grundlage,
-                      auf der wir \nhier miteinander streiten und diskutieren können. Es fin-\ndet unsere
-                      Zustimmung. Das bedeutet aber natürlich \nnicht, dass die Geschäftsordnung so bleibt,
-                      wie sie jetzt \nist, sondern sie muss generalüberholt werden. Dazu will \nich auch
-                      einige Vorschläge machen; sie sind gar nicht \nalle explizit von mir. Ich habe mir
-                      noch mal die Reden \nzum Beginn der letzten Wahlperiode vom Kollegen \nBuschmann,
-                      der Kollegin Haßelmann und vom Kollegen \nSchneider durchgelesen. Das sind ja sehr,
-                      sehr gute Vor-\nschläge gewesen. Carsten, die guten Vorschläge scheiter-\nten ja
-                      immer an der CDU/CSU. Das können wir jetzt \nändern, und deswegen werden wir natürlich
-                      auch alle \neure Vorschläge hier einbringen.\n(Dr. Marco Buschmann [FDP]: Das machen
-                      wir \nschon selber!)\nUnd dann ist ja auch eine Mehrheit kein Problem, worü-\nber
-                      ich mich sehr freue.\n(Beifall bei der LINKEN)\nIch halte es für zentral, dass wir
-                      endlich dazu kommen, \nAusschusssitzungen öffentlich zu machen. Ich finde, wir \nmüssen
-                      das parlamentarische Fragerecht dringend stär-\nken und ausbauen. Ich finde, wir
-                      müssen darüber dis-\nkutieren, wie wir die Möglichkeit von Großverdienern, \ndurch
-                      Parteispenden Einfluss hier auf den Laden zu neh-\nmen, endlich begrenzen können.
-                      Das ist eine zentrale \nFrage für die Glaubwürdigkeit der Politik.\n(Beifall bei
-                      der LINKEN)\nIch glaube darüber hinaus – das ist jetzt bitter für die \nFDP –, dass
-                      wir endlich Großspenden von Unternehmen \nverbieten müssen. Denn Politik darf nicht
-                      käuflich sein. \nDa müssen Sie anders an Geld rankommen.\n(Beifall bei der LINKEN)\nSo
-                      geht es auf jeden Fall nicht.\nIch will noch einen letzten Punkt ansprechen, über
-                      den \nwir hier wirklich nachdenken müssen. Wenn Sie sich mal \ndie Wahlbeteiligung
-                      angucken, kann man erkennen: Es \nist eine soziale Frage. Wenn ich mir den Wahlkreis
-                      Starn-\nberg angucke, sehe ich, dass wir dort eine Wahlbetei-\nligung von 80 Prozent
-                      haben. Bei mir in Sachsen-Anhalt, \nim Wahlkreis Anhalt, sind es gerade mal 65 Prozent.\n(Dr.
-                      Marco Buschmann [FDP]: Dann musst du \nmal bessere Werbung machen!)\nDas heißt also,
-                      diejenigen, die das höchste Pro-Kopf-Ein-\nkommen haben, nehmen überproportional
-                      ihre demo-\nkratischen Rechte wahr, und damit haben wir ein Un-\ngleichgewicht in
-                      der parlamentarischen Demokratie. \nWir müssen darüber nachdenken, wie wir auch
-                      für Leute, \ndiese zum Teil 35 Prozent, die nicht mehr an Wahlen \nteilnehmen, die
-                      sich abgemeldet haben, die Parlamente \nund das Parlamentsgeschehen so attraktiv
-                      machen kön-\nnen, dass sie sich angesprochen fühlen.\n(Beifall bei der LINKEN sowie
-                      bei Abge-\nordneten der SPD – Enrico Komning [AfD]: \nDurch Sie passiert das bestimmt
-                      nicht!)\nLast, but not least: Ich glaube, dass wir bei der Kon-\ntrolle und der
-                      Begrenzung des Lobbyismus jetzt wirklich \nweiterkommen können, liebe Freunde von
-                      der SPD; denn \ndie Halbtagslobbyisten der CDU/CSU sitzen ja – das ist \ndas einzig
-                      Erfreuliche für meine Partei, kann man so \nsagen – jetzt in der Opposition.\n(Alexander
-                      Dobrindt [CDU/CSU]: Es scheint \nIhnen sehr schlecht zu gehen!)\nSie sind jetzt
-                      kein Hinderungsgrund mehr. Deswegen \nglaube ich, dass wir für die Vorschläge der
-                      FDP, der \nGrünen und der SPD – die Linke ist immer für große \nReformen zu haben
-                      –, die ich in der nächsten Woche \neinbringen werde und die zum Teil wortgleich
-                      von den \nGrünen und der FDP kommen, hier eine übergroße Mehr-\nheit haben werden,
-                      und darüber freuen wir uns.\nAlles Gute für die weitere Debatte!\n(Beifall bei der
-                      LINKEN)\nAlterspräsident Dr. Wolfgang Schäuble:\nLiebe Kolleginnen und Kollegen!
-                      Herr Kollege Korte, \nwir waren uns eigentlich in der letzten Legislaturperiode
-                      \neinig, dass wir Vorwürfe, dass Fraktionen oder Kollegin-\nnen und Kollegen in
-                      der Tradition der Nationalsozialisten \nstehen, als unparlamentarisch in diesem
-                      Hause nicht \nhören wollen.\n(Beifall bei der AfD – Jan Korte [DIE LINKE]: \nStimmt
-                      aber!)\nMein Rat an meine Nachfolgerin\n(Jan Korte [DIE LINKE]: Das habe ich auch
-                      \nnicht behauptet!)\nDeutscher Bundestag – 20. Wahlperiode – 1. Sitzung. Berlin,
-                      Dienstag, den 26. Oktober 2021                                                                                                                                                                                                     13\nJan
-                      Korte \n(A) \n(B) \n(C) \n(D) \nund an alle, die es angeht – Sie alle, mich eingeschlos-\nsen
-                      –, ist, dass wir daran auch in dieser Legislaturperiode \nfesthalten.\nDamit schließe
-                      ich die Aussprache.\nWir kommen jetzt zur Abstimmung. Wir kommen \nzunächst zum
-                      Änderungsantrag der Fraktion der AfD \nauf der Drucksache 20/3 mit dem Titel „Weitergeltung
-                      \nvon Geschäftsordnungsrecht, hier: Bessere Lesbarkeit \nvon Drucksachen durch Verzicht
-                      auf Gendersprache“. \nDie Fraktion der AfD wünscht, über ihren Antrag in der \nSache
-                      abzustimmen. Die Fraktionen der SPD, von Bünd-\nnis 90/Die Grünen und der FDP wünschen
-                      Überweisung \nan den Ausschuss für Wahlprüfung, Immunität und \nGeschäftsordnung.\nWir
-                      stimmen nach ständiger Übung zuerst über den \nAntrag auf Überweisung ab. Ich frage
-                      deshalb: Wer \nstimmt für die beantragte Überweisung? – Wer stimmt \ndagegen? –
-                      Enthaltungen? – Keine. Dann ist die Über-\nweisung gegen die Stimmen der AfD mit
-                      den Stimmen \ndes übrigen Hauses so beschlossen. Dann stimmen wir \nüber den Antrag
-                      auf Drucksache 20/3 nicht in der Sache \nab.\nDann kommt der Änderungsantrag der
-                      Fraktion der \nAfD auf der Drucksache 20/4 mit dem Titel „Weitergel-\ntung von Geschäftsordnungsrecht,
-                      hier: Quoren zur Wahl \ndes Bundeskanzlers in § 4 Satz 2 GOBT und zum Miss-\ntrauensantrag
-                      gegen den Bundeskanzler in § 97 Absatz 1 \nSatz 2 GOBT senken“. Wer stimmt für diesen
-                      Änderungs-\nantrag? – Wer stimmt dagegen? – Wer enthält sich? – \nDann ist dieser
-                      Änderungsantrag gegen die Stimmen \nder AfD mit den Stimmen des übrigen Hauses abgelehnt.\nDamit
-                      kommen wir zum Antrag der Fraktion der SPD \nauf der Drucksache 20/1 zur Weitergeltung
-                      von \nGeschäftsordnungsrecht. Wer stimmt für diesen Antrag? – \nWer stimmt dagegen?
-                      – Wer enthält sich? – Dann ist \ndieser Antrag bei Enthaltung der AfD mit den Stimmen
-                      \ndes übrigen Hauses angenommen.\nJetzt rufe ich den Tagesordnungspunkt 3 auf:\nWahl
-                      der Präsidentin/des Präsidenten  \nverbunden mit Namensaufruf  \nund Feststellung
-                      der Beschlussfähigkeit\nMit dieser Wahl werden der Namensaufruf der Mit-\nglieder
-                      des Deutschen Bundestags und die Feststellung \nder Beschlussfähigkeit verbunden.\nEs
-                      entspricht der parlamentarischen Tradition, dass die \nstärkste Fraktion eine Kandidatin
-                      oder einen Kandidaten \nvorschlägt. – Herr Fraktionsvorsitzender Dr.  Mützenich.\nDr.
-                      Rolf Mützenich (SPD):\nSehr geehrter Herr Alterspräsident, die SPD-Bundes-\ntagsfraktion
-                      schlägt die Kollegin Bärbel Bas vor.\n(Beifall bei der SPD sowie bei Abgeordneten
-                      \ndes BÜNDNISSES 90/DIE GRÜNEN, der \nFDP und der LINKEN)\nAlterspräsident Dr. Wolfgang
-                      Schäuble:\nLiebe Kolleginnen und Kollegen, Sie haben den Vor-\nschlag gehört. Die
-                      Abgeordnete Bärbel Bas ist vor-\ngeschlagen worden.\nJetzt bitte ich um Ihre Aufmerksamkeit
-                      für einige Hin-\nweise zum Wahlverfahren: Die Wahl findet mit verdeck-\nten Stimmkarten,
-                      also geheim, statt. Gewählt ist, wer die \nMehrheit der Mitglieder des Hauses, also
-                      mindestens \n369 Stimmen, erhält. Für diese Wahl benötigen Sie Ihren \nblauen Wahlausweis
-                      aus Ihrem Stimmkartenfach in der \nWestlobby. Die Abgeordneten auf den Tribünen
-                      haben \nihre Wahlausweise vom Plenarassistenzdienst erhalten.\n(Zurufe von der Tribüne:
-                      Nein!)\n– Haben Sie nicht? Dann werden Sie ihn noch bekom-\nmen. Ich bitte, es zu
-                      veranlassen, dass Sie Ihren Wahl-\nausweis bekommen.\nBitte kontrollieren Sie, dass
-                      Ihr Wahlausweis Ihren \nNamen trägt.\nDie Abgeordneten hier unten, im Plenarsaal,
-                      werden in \nder Abgeordnetenlobby wählen. Gehen Sie bitte dort erst \nnach Aufruf
-                      Ihres Namens hin. Dort erhalten Sie eine \nblaue Stimmkarte und den amtlichen Wahlumschlag
-                      \nvon den Schriftführerinnen und Schriftführern an den \nAusgabetischen. Die Abgeordneten
-                      auf der Tribüne wer-\nden auf der Tribünenebene wählen. Dort befindet sich \nauch
-                      ein Ausgabetisch für die genannten Wahlunterlagen \nsowie eine Wahlkabine.\nGültig
-                      sind nur Stimmen mit einem Kreuz bei „Ja“, \n„Nein“ oder „Enthalte mich“. Ungültig
-                      sind Stimmen \nauf nichtamtlichen Stimmkarten sowie Stimmkarten, die \nmehr als
-                      ein Kreuz, kein Kreuz oder andere Namen ent-\nhalten.\nSie dürfen Ihre Stimmkarte
-                      nur in der Wahlkabine \nankreuzen, und Sie müssen ebenfalls noch in der Wahl-\nkabine
-                      die Stimmkarte in den Umschlag legen. Die \nSchriftführerinnen und Schriftführer
-                      sind verpflichtet, \njeden, der seine Stimmkarte außerhalb der Wahlkabine \nkennzeichnet
-                      oder in den Umschlag legt, zurückzuwei-\nsen. Die Stimmabgabe kann in einem solchen
-                      Fall jedoch \nvorschriftsmäßig wiederholt werden.\nNachdem Sie die Stimmkarte in
-                      einer Wahlkabine \ngekennzeichnet und dort in den Wahlumschlag gelegt \nhaben, gehen
-                      Sie bitte zu den Wahlurnen. Bevor Sie \nden Wahlumschlag in eine der Wahlurnen werfen,
-                      müs-\nsen Sie Ihren Wahlausweis einer der Schriftführerinnen \noder einem der Schriftführer
-                      an der Wahlurne übergeben. \nDer Nachweis der Teilnahme an der Wahl kann nur durch
-                      \ndie Abgabe des Wahlausweises erbracht werden.\nDie Wahlumschläge der Abgeordneten
-                      auf den Tribü-\nnen sowie die der übrigen Abgeordneten werden selbst-\nverständlich
-                      vor der Auszählung zusammengeschüttet, \nsodass das Wahlgeheimnis gewahrt bleibt.\nNoch
-                      ein Hinweis, der ebenso für die später folgenden \nWahlen gilt: Das Fotografieren
-                      oder Filmen der aus-\ngefüllten Stimmkarten stellt einen Verstoß gegen das \nWahlgeheimnis
-                      dar und verletzt die Ordnung und Würde \ndes Hauses. Für den Fall, dass ich von
-                      solchen Verstößen \nDeutscher Bundestag – 20. Wahlperiode – 1. Sitzung. Berlin,
-                      Dienstag, den 26. Oktober 2021                                14 \nAlterspräsident
-                      Dr. Wolfgang Schäuble \n(A) \n(B) \n(C) \n(D) \ngegen das Wahlgeheimnis in dieser
-                      Sitzung oder später \nKenntnis erlange, behalte ich mir schon jetzt vor, Ord-\nnungsmaßnahmen
-                      zu ergreifen.\nIch erinnere außerdem an die Pflicht zum Tragen einer \nmedizinischen
-                      Mund-Nasen-Bedeckung sowie die Kolle-\nginnen und Kollegen auf den Tribünen zusätzlich
-                      an das \nAbstandsgebot.\nJetzt bitte ich die eingeteilten Schriftführerinnen und
-                      \nSchriftführer, die vorgesehenen Plätze einzunehmen. – \nAlle Plätze sind besetzt.\nDamit
-                      bitte ich Sie, den Namensaufruf zu verfolgen \nund sich nach dem Aufruf Ihres Namens
-                      zur Entgegen-\nnahme der Stimmkarte und des Wahlumschlages zu den \nAusgabetischen
-                      zu begeben.\nDie Schriftführerinnen und Schriftführer haben die \nPlätze eingenommen.
-                      Ich eröffne die Wahl und bitte, \nmit dem Aufruf der Namen zu beginnen.\n(Namensaufruf
-                      und Wahl)\nLiebe Kolleginnen und Kollegen, darf ich fragen, ob es \nein Mitglied
-                      des Hauses gibt, das seine Stimme noch \nnicht abgeben konnte, obwohl er oder sie
-                      es wollte? – \nDas ist offensichtlich nicht der Fall. Dann schließe ich \ndie Wahl
-                      und bitte die Schriftführerinnen und Schrift-\nführer, mit der Auszählung zu beginnen.\nBis
-                      zur Auszählung unterbreche ich die Sitzung für \netwa 30 Minuten. Der Wiederbeginn
-                      der Sitzung wird \nrechtzeitig durch Klingelzeichen angekündigt.\n(Unterbrechung
-                      von 13.01 bis 13.25 Uhr)\nAlterspräsident Dr. Wolfgang Schäuble:\nLiebe Kolleginnen
-                      und Kollegen, ich bitte Sie, wieder \nPlatz zu nehmen. Ich eröffne die unterbrochene
-                      Sitzung \nwieder.\nSobald Sie Platz genommen haben, verrate ich Ihnen \nein Geheimnis.
-                      – Sie sollten schon alle Platz genommen \nhaben, wenn ich das Ergebnis der Wahl
-                      bekannt gebe – es \nist immerhin die Wahl der Präsidentin des 20. Deutschen \nBundestages:
-                      abgegebene Stimmen 724. Die Beschluss-\nfähigkeit des 20. Deutschen Bundestages
-                      ist damit fest-\ngestellt. Mit Ja haben gestimmt 576 Abgeordnete.\n(Anhaltender
-                      Beifall im ganzen Hause – Die \nFraktionen der SPD, der CDU/CSU, des \nBÜNDNISSES
-                      90/DIE GRÜNEN, der FDP, \nder LINKEN sowie Abgeordnete der AfD \nerheben sich)\nMit
-                      Nein haben gestimmt 90 Abgeordnete. Es gab 58 Ent-\nhaltungen. Die Kollegin Bärbel
-                      Bas hat die erforderliche \nMehrheit von mindestens 369 Stimmen erreicht, und sie
-                      \nist damit zur Präsidentin des 20. Deutschen Bundestages \ngewählt.1)\nIch frage
-                      Sie jetzt, Frau Kollegin Bas: Nehmen Sie die \nWahl an?\nBärbel Bas (SPD):\nHerr
-                      Alterspräsident, vielen Dank. Ich nehme die Wahl \nvon Herzen gerne an. Vielen Dank.\n(Beifall
-                      im ganzen Hause – Abgeordnete aller \nFraktionen gratulieren der Präsidentin und
-                      \nüberreichen Blumensträuße)\nAlterspräsident Dr. Wolfgang Schäuble:\nDann, Frau
-                      Präsidentin, gratuliere ich Ihnen persönlich \nund auch im Namen des ganzen Hauses
-                      sehr herzlich.\nSobald die Blumensträuße überreicht sind und die \nsonstigen Glückwünsche
-                      ausgesprochen, bitte ich Sie, \ndieses Amt hier zu übernehmen.\nLiebe Kolleginnen
-                      und Kollegen, jetzt noch einmal: \nFrau Präsidentin, bitte übernehmen Sie das Amt.\n(Beifall
-                      bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN, der FDP und der \nLINKEN
-                      sowie bei Abgeordneten der AfD)\nTagesordnungspunkt 4:\nAmtsübernahme durch die
-                      Präsidentin/den Prä-\nsidenten \nmit Ansprache\nPräsidentin Bärbel Bas:\nSehr geehrter
-                      Herr Bundespräsident! Sehr geehrte Frau \nBundeskanzlerin! Meine Damen und Herren!
-                      Liebe Kol-\nleginnen und Kollegen! Als Annemarie Renger 1972 \nBundestagspräsidentin
-                      wurde, war das eine Zeitenwende. \nEine Frau an der Spitze des Deutschen Bundestages,
-                      eine \nFrau im zweithöchsten Amt! Das war neu und wahr-\nscheinlich auch einigen
-                      nicht geheuer. Annemarie Renger \nhatte ihren Namen selbst ins Spiel gebracht, hat
-                      sie \ndamals gesagt. Inzwischen sind fast 50 Jahre vergangen. \nIch kann Ihnen versichern:
-                      Unsere Gesellschaft ist etwas \nweiter als damals. Ich habe nicht selbst den Finger
-                      \ngehoben – das stimmt –, aber ich habe im richtigen \nMoment Ja gesagt.\n(Beifall
-                      bei der SPD, dem BÜNDNIS 90/DIE \nGRÜNEN, der FDP und der LINKEN sowie bei \nAbgeordneten
-                      der CDU/CSU)\nAls Zeitenwende empfinde ich meine Wahl dennoch.\nAuf der Tribüne
-                      begrüße ich ganz besonders herzlich \nmeine Vorgängerin Rita Süssmuth,\n(Beifall)\neine
-                      weitere Politikerin, die diesem Hause und auch der \nGesellschaft gezeigt hat, wie
-                      viel eine Frau in einem \nStaatsamt bewirken kann.\nIch begrüße ebenso herzlich
-                      Sabine Bergmann-Pohl, \ndie in der deutschen Parlamentsgeschichte eine besonde-\nre
-                      Rolle gespielt hat: als Präsidentin der letzten und ersten \nfrei gewählten Volkskammer
-                      der DDR.\n(Beifall)\nHier im Bundestag werden die Debatten ausgetragen, \ndie Debatten,
-                      die das Land bewegen. Regierung und \nOpposition treffen aufeinander. Politik wird
-                      verständlich \nund sichtbar, jeden Abend in den Nachrichten. Es tut \n1) Namensverzeichnis
-                      der Teilnehmerinnen und Teilnehmer an der Wahl \nsiehe Anlage 2 \nDeutscher Bundestag
-                      – 20. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 26. Oktober 2021                                                                                                                                                                                                     15\nAlterspräsident
-                      Dr. Wolfgang Schäuble \n(A) \n(B) \n(C) \n(D) \nunserem Land gut, wenn die Bürgerinnen
-                      und Bürger \nsehen: Im Herzen der Demokratie trägt eine Frau die Ver-\nantwortung.\nHeute
-                      konstituiert sich der 20. Deutsche Bundestag. \nIch bin erst die dritte Frau an
-                      seiner Spitze. Die dritte \nseit 1949! Ruhmreich ist das nicht. Denn die Verantwor-\ntung
-                      ist lange noch nicht gerecht auf alle Schultern ver-\nteilt. Daran zu arbeiten,
-                      sehe ich als eine meiner beson-\nderen Aufgaben als Bundestagspräsidentin.\n(Beifall
-                      bei der SPD, dem BÜNDNIS 90/DIE \nGRÜNEN, der FDP und der LINKEN sowie bei \nAbgeordneten
-                      der CDU/CSU)\nLiebe Kolleginnen und Kollegen, Sie haben mich eben \nin dieses Amt
-                      gewählt. Was für eine Ehre! Ich danke \nIhnen herzlich für das Vertrauen. Das ist
-                      ein großes Ver-\ntrauen, das Sie mir gegeben haben, und mir ist auch völlig \nbewusst,
-                      dass mit diesem Amt hohe Erwartungen ver-\nbunden sind.\nIch verspreche Ihnen: Ich
-                      werde die Präsidentin aller \nAbgeordneten sein. Ich werde all meine Kraft daranset-\nzen,
-                      den Bundestag nach innen überparteilich zu leiten \nund nach außen selbstbewusst
-                      zu repräsentieren.\n(Beifall bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN,
-                      der FDP und der \nLINKEN sowie bei Abgeordneten der AfD)\nDarin werde ich übrigens
-                      allen meinen Vorgängerinnen \nund Vorgängern folgen.\nSehr geehrter Herr Schäuble,
-                      ich danke Ihnen für die \nnachdenklichen Worte zu Beginn der Sitzung. Vor allem
-                      \ndanke ich Ihnen für Ihre außergewöhnlichen Leistungen \nin den vergangenen vier
-                      Jahren. Sie haben das Amt des \nBundestagspräsidenten in einer herausfordernden
-                      Zeit \nübernommen. Das Parteiengefüge hatte sich verschoben. \nUnser Land durchlebte
-                      heftige, zornige Debatten, was \nsich übrigens auch hier im Hause widerspiegelt.
-                      Als Bun-\ndestagspräsident haben Sie die Kontroverse ermöglicht \nund zum Streit
-                      ermutigt. Aber Sie haben auch Grenzen \ngezogen, wo es nötig war. Sie haben stets
-                      darüber \ngewacht, dass die Würde des Parlaments gewahrt blieb. \nIch denke, ich
-                      darf das im Namen aller Mitglieder dieses \nHauses sagen: Sie haben sich um unsere
-                      parlamentari-\nsche Demokratie verdient gemacht. Herzlichen Dank!\n(Anhaltender
-                      Beifall bei der SPD, der CDU/ \nCSU, dem BÜNDNIS 90/DIE GRÜNEN, der \nFDP und der
-                      LINKEN – Beifall bei \nAbgeordneten der AfD)\nDanken möchte ich auch dem scheidenden
-                      Vizeprä-\nsidenten Hans-Peter Friedrich und der ehemaligen Vize-\npräsidentin Dagmar
-                      Ziegler, die nicht mehr kandidiert \nhat, ebenso allen Kolleginnen und Kollegen,
-                      die das Par-\nlament heute verlassen. Viele sind aus eigenem Ent-\nschluss gegangen,
-                      andere haben kein neues Mandat erhal-\nten. Sie alle haben in den zurückliegenden
-                      Jahren hart für \nunser Land gearbeitet. Dafür gebührt Ihnen unser großer \nRespekt.\n(Beifall
-                      bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN, der FDP und der \nLINKEN
-                      sowie bei Abgeordneten der AfD)\nBei meinem Dank will ich die vielen Menschen im
-                      \nHintergrund nicht vergessen: die Mitarbeiterinnen und \nMitarbeiter in den Abgeordnetenbüros,
-                      in den Fraktionen \nund auch in der Bundestagsverwaltung. Ihrem Einsatz \nverdanken
-                      wir die perfekte Organisation am heutigen \nTag und – weit darüber hinaus – die
-                      Stabilität der deut-\nschen Politik, die den politischen Neuanfang erst möglich
-                      \nmacht.\nIch möchte an diesem Tag auch an einen besonderen \nMenschen erinnern,
-                      von dem ich wünschte, er könnte hier \nbei uns sitzen. Thomas Oppermann hat dem
-                      Deutschen \nBundestag über viele Wahlperioden hinweg angehört: als \nüberzeugter
-                      Sozialdemokrat, als leidenschaftlicher Par-\nlamentarier und zuletzt als ein über
-                      Parteigrenzen hinweg \ngeachteter Vizepräsident.\nGestern vor einem Jahr ist Thomas
-                      Oppermann von \nuns gegangen. Ich habe viel von ihm gelernt. Er \nbeherrschte das
-                      parlamentarische Handwerk wie kaum \nein anderer. Und ich spüre an einem Tag wie
-                      heute: Er \nfehlt.\nMeine Damen und Herren, dieses Parlament ist beson-\nders jung,
-                      und es tut unserem Land gut, dass sich gerade \njüngere Menschen für Veränderung
-                      und Innovation stark-\nmachen. Außerdem ist dieses Parlament besonders viel-\nfältig.
-                      Das war bei der Verlesung der Namen unserer \nSchriftführer vorhin deutlich zu hören.
-                      Auch das tut unse-\nrem Land gut.\nDie Zusammensetzung des 20. Deutschen Bundestages
-                      \nzeigt, dass seine Mitglieder in ganz verschiedenen Teilen \nder Gesellschaft verwurzelt
-                      sind. Sie bringen unter-\nschiedliche Berufserfahrungen und Herkunftsgeschich-\nten
-                      mit. Ihre Lebensläufe und Lebenswege werden unsere \nDebatten bereichern. Die Vielfalt
-                      ist eine Chance für uns \nalle – in diesem Haus, aber auch außerhalb.\n(Beifall
-                      bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN, der FDP und der \nLINKEN)\nDuisburg,
-                      wo ich geboren bin, hat übrigens auch noch \nnicht erlebt, dass ein Kind der Stadt
-                      in ein so hohes \nStaatsamt gewählt wird.\n(Beifall bei der SPD sowie bei Abgeordneten
-                      \nder CDU/CSU und der FDP)\nDas musste ich jetzt einmal zwischendurch loswerden.
-                      \nIch verspreche, meine Stadt nicht aus dem Blick zu ver-\nlieren. Dafür stehe ich:
-                      dass wir in dieser Legislaturpe-\nriode eine neue Bürgernähe entwickeln – nicht
-                      nur, weil \ndieser Bundestag beachtlich bunt zusammengesetzt ist.\nLassen Sie uns
-                      viele Menschen ansprechen, auf die \nBürgerinnen und Bürger in unserem Land zugehen,
-                      vor \nallem auf jene, die sich von der Politik seit Langem nicht \nmehr angesprochen
-                      fühlen, Menschen, denen „die Poli-\ntik“ fremd geworden ist. Ein vielfältiges, junges,
-                      frisch \ngewähltes Parlament kann leichter Brücken bauen. Es \nkann Vorurteile,
-                      Abwehrreaktionen und Misstrauen über-\nwinden helfen.\nDoch Politik ist nur dann
-                      gut, wenn sie auch verständ-\nlich ist. Das ist auch ein großes Versprechen der
-                      Demo-\nkratie. Und das hat viel mit unserer Sprache zu tun. Ver-\nstecken wir uns
-                      nicht hinter einem komplizierten \nDeutscher Bundestag – 20. Wahlperiode – 1. Sitzung.
-                      Berlin, Dienstag, den 26. Oktober 2021                                16 \nPräsidentin
-                      Bärbel Bas \n(A) \n(B) \n(C) \n(D) \nFachjargon, hinter Meinungen von Expertinnen
-                      und \nExperten! Ich wünsche mir, dass wir schwierige juristi-\nsche Fragen, mit
-                      denen wir es zu tun haben, in die Spra-\nche übersetzen, die in unserem Land gesprochen
-                      und ver-\nstanden wird.\n(Beifall bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE
-                      GRÜNEN, der FDP und der \nLINKEN sowie bei Abgeordneten der AfD)\nEs liegt an uns:
-                      Wir können zeigen, dass wir Abge-\nordnete sind, die zuhören, und ein Parlament,
-                      dem \nzugehört wird. Wir brauchen dazu Worte, bei denen \nZuhören Freude macht,
-                      weil sich aus unseren Debatten \nerschließt, dass wir uns hier im Bundestag mit
-                      den Fragen \nbeschäftigen, die für die Zukunft aller Menschen in die-\nsem Lande
-                      wichtig sind. Wir können über unsere Sprache \nzeigen, dass wir das Wohl aller im
-                      Blick haben.\nWer mit Gewinn zuhört, wer versteht, worum es hier in \ndiesem Hause
-                      geht, wird auch das Gespräch suchen, den \nAustausch mit uns, den gewählten Abgeordneten.
-                      Wer \nmerkt, dass wir diesen Austausch ernsthaft wollen, wird \nsich auf uns einlassen,
-                      wird mitdenken, über politische \nEntscheidungen mit uns streiten wollen und nicht
-                      gleich \nlosschreien, dagegenhalten oder andere niedermachen.\nWas wir brauchen,
-                      ist eine Einladung an möglichst \nviele Menschen, mitzumachen. Wir haben dafür neue
-                      \nBeteiligungsformen. Die Bürgerräte sind ein Format, \ndas Teilhabe ermöglicht.
-                      So wünsche ich mir die kom-\nmende Legislatur im Deutschen Bundestag: offen und
-                      \nlebendig.\nDann sind wir natürlich noch lange nicht alle einer \nMeinung – natürlich
-                      nicht. Aber dann haben wir die \nChance, Politik wieder als gemeinsames Ringen um
-                      \nWege in die Zukunft zu begreifen. Dafür stehe ich, für \nein respektvolles Miteinander,
-                      für eine verständliche \nPolitik, für ein Parlament, das die Politik hinausträgt
-                      in \ndie Gesellschaft.\nBringen wir die Debatten, die wir hier unter dieser \nKuppel
-                      führen, in unsere Wahlkreise, zu mir nach Duis-\nburg genauso wie nach Greifswald
-                      oder nach Passau oder \nan viele andere schöne Orte in unserem Land\n(Zuruf: Köln!)\n–
-                      „Köln“ höre ich gerade –,\n(Heiterkeit – Gitta Connemann [CDU/CSU]: \nOstfriesland!)\nauch
-                      zu denen, die sich von der Politik abgewandt haben, \ndie das Gefühl haben, nicht
-                      wahrgenommen zu werden! \nSie müssen wie alle anderen auch eine Chance haben, \nsich
-                      in dieser Politik wiederzufinden. Das ist ihr gutes \nRecht. Denn sie alle sind
-                      gleichberechtigter Teil unserer \nGesellschaft, genauso wie jene, die wir in Talkshows
-                      \nerleben, wie die, deren Tweets oder Facebook-Einträge \nAufregung auslösen, wie
-                      die Vertreterinnen und Vertreter \nder kleinen und großen Interessenverbände und
-                      Organi-\nsationen. Sie alle sind wichtig.\nAber kümmern wir uns auch ganz bewusst
-                      um die \nMitte der Gesellschaft! Es sind Menschen, die an \nDemonstrationen vorbeigehen,
-                      aber selbst nie demons-\ntrieren würden, die zu erschöpft sind, um sich in Initiati-\nven
-                      zu engagieren, die mit ihrem Alltag zu kämpfen \nhaben, die vollauf damit beschäftigt
-                      sind, ihre Kinder \nund ihre alternden Eltern zu versorgen, die gestrandet \nsind
-                      oder die unsere Sprache nicht sprechen, denen die \nMittel fehlen, auf eigenen Beinen
-                      zu stehen. Sie alle \nhaben auch Interessen – berechtigte Interessen –,\n(Beifall
-                      bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN, der FDP und der \nLINKEN
-                      sowie bei Abgeordneten der AfD)\nund sie haben wenig Gelegenheit, sich Gehör zu
-                      ver-\nschaffen. Ich wünsche mir, dass wir auch diesen Men-\nschen zuhören und ihnen
-                      eine barrierefreie Teilhabe \nermöglichen. Daran müssen wir arbeiten. Denn für alle
-                      \ndiese Menschen sind wir da. Sie sollen sich in ihrem \nParlament vertreten sehen;
-                      sie sollen sich in unserem \nBundestag wiederfinden – alle, nicht nur eigene Anhän-\nger.
-                      Das ist eine Verantwortung, die wir hier im Hause \ngemeinsam tragen.\nIch wünsche
-                      mir für diese Legislaturperiode gegensei-\ntigen Respekt. Das ist keine Einbahnstraße:
-                      Ich erwarte \nRespekt für die Bürgerinnen und Bürger, aber auch Res-\npekt von ihnen
-                      und einen respektvollen Umgang mit-\neinander hier im Haus. Wir haben eine Vorbildfunktion.
-                      \nJede und jeder Einzelne von uns steht für „die Politik“ \nund damit in der Pflicht,
-                      den Deutschen Bundestag wür-\ndig zu vertreten.\n(Beifall bei der SPD, der CDU/CSU,
-                      dem \nBÜNDNIS 90/DIE GRÜNEN, der FDP und der \nLINKEN sowie bei Abgeordneten der
-                      AfD)\nDas ist nicht nur eine Frage des Stils; es ist auch eine \nFrage der demokratischen
-                      Kultur. Schlagen wir einen \nangemessenen Ton an! Schrille Laute hört niemand gern,
-                      \nleise Töne übrigens auch nicht. Wir können schon hörbar \nund vernehmlich Position
-                      beziehen, deutlich erklären, \nwohin wir wollen und welche Wege uns als die besten
-                      \nerscheinen. Widerspruch ist erlaubt. Darum tagen wir \nhier im Parlament: um Argumente
-                      auszutauschen, um \nden Streit in der Sache auszutragen.\nWir werden viele unterschiedliche
-                      Stimmen und Mei-\nnungen hören, gegensätzliche Argumente. Die Schärfe \nder Argumentation
-                      darf dabei den politischen Gegner \nnicht herabwürdigen, ihn nicht beschädigen.
-                      Wir sind \nnicht hier, einander persönlich zu bekriegen.\n(Beifall bei der SPD,
-                      der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN, der FDP und der \nLINKEN sowie bei Abgeordneten
-                      der AfD)\nLassen Sie mich aber eins auch deutlich sagen: Hass \nund Hetze sind keine
-                      Meinung.\n(Beifall bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN, der FDP
-                      und der \nLINKEN sowie bei Abgeordneten der AfD)\nAls Präsidentin werde ich dieses
-                      Parlament vor Angriffen \nschützen und die Demokratie gegen ihre Feinde verteidi-\ngen.\nLiebe
-                      Kolleginnen und Kollegen, viele große, strittige \nThemen liegen vor uns: der Klimawandel,
-                      besonders der \nUmbau der Wirtschaft mit dem Ziel, Klimaneutralität zu \nerreichen.
-                      Nachhaltige Entscheidungen erwarten gerade \nDeutscher Bundestag – 20. Wahlperiode
-                      – 1. Sitzung. Berlin, Dienstag, den 26. Oktober 2021                                                                                                                                                                                                     17\nPräsidentin
-                      Bärbel Bas \n(A) \n(B) \n(C) \n(D) \ndie jungen Menschen in unserem Land von uns,
-                      und das \nBundesverfassungsgericht hat ihnen recht gegeben. Wir \nentscheiden eben
-                      gerade nicht nur für unsere Generation, \nsondern auch für die kommenden Generationen.\n(Beifall
-                      bei der SPD, dem BÜNDNIS 90/DIE \nGRÜNEN, der FDP und der LINKEN sowie bei \nAbgeordneten
-                      der CDU/CSU)\nDas gilt auch für alle anderen drängenden Fragen, die \nwir zu beantworten
-                      haben: für Asyl und Migration, die \nDigitalisierung von Staat und Verwaltung, den
-                      Aufbruch \nin eine inklusive Gesellschaft. Diese konstituierende Sit-\nzung zeigt
-                      im Übrigen: Auch die Pandemie und ihre \nFolgen werden uns noch weiter beschäftigen.\nUnd
-                      noch ein großes Thema ist uns allen erhalten \ngeblieben: Ich fordere schon jetzt
-                      die Fraktionen auf – \nSie sehen mich leicht schmunzeln, weil ich das schon \nein
-                      bisschen von Herrn Schäuble vorhin gehört habe –, \ndas Wahlrecht auf die Tagesordnung
-                      zu setzen.\n(Beifall bei der SPD, dem BÜNDNIS 90/DIE \nGRÜNEN, der FDP und der LINKEN
-                      sowie bei \nAbgeordneten der CDU/CSU und der AfD)\nIch wünsche mir eine Reform,
-                      die den Namen verdient. \nDas erwarten die Bürgerinnen und Bürger von uns. In \nRichtung
-                      der Fraktionen sage ich mal so locker: Jetzt \naber wirklich!\n(Beifall bei der
-                      SPD, dem BÜNDNIS 90/DIE \nGRÜNEN und der FDP)\nDas Parlament wird diese und andere
-                      wichtige Geset-\nzesvorhaben diskutieren und verabschieden. Ich lade Sie \nein:
-                      Lassen Sie uns gemeinsam Politik machen zum Woh-\nle der Menschen in unserem Land,
-                      in der Europäischen \nUnion und weltweit. Ich erwarte dabei einen respektvol-\nlen
-                      Umgang miteinander in diesem Bundestag, integre \nAbgeordnete, die bei aller Unterschiedlichkeit
-                      in der \nSache „wir“ sagen, die wieder Begeisterung am Mit-\nmachen wecken und die
-                      verantwortlich handeln.\nIn dieser Wahlperiode werden wir den 75. Geburtstag \ndes
-                      Grundgesetzes feiern – ein besonderes Datum, auf \ndas wir uns, glaube ich, alle
-                      gemeinsam freuen können. \nBei allem Streit, bei allen Konflikten und Krisen können
-                      \nwir froh und stolz darauf sein, dass wir in einer stabilen \nund lebendigen Demokratie
-                      leben.\n(Beifall bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN, der FDP
-                      und der \nLINKEN sowie bei Abgeordneten der AfD)\nIch freue mich auf die parlamentarische
-                      Arbeit mit \nIhnen hier im Haus, und ich lade die Bürgerinnen und \nBürger dazu
-                      ein, gemeinsam mit uns weiter an unserer \nDemokratie zu arbeiten.\nHerzlichen Dank.\n(Beifall
-                      bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN, der FDP und der \nLINKEN
-                      sowie bei Abgeordneten der AfD)\nDann wollen wir mal in die Tagesordnung weiter
-                      ein-\nsteigen. Ich rufe den Tagesordnungspunkt 5 auf:\nFestlegung der Zahl der Stellvertreterinnen
-                      und \nStellvertreter der Präsidentin/des Präsidenten\nDrucksache 20/5\nHierzu liegt
-                      ein Antrag der Fraktionen der SPD, Bünd-\nnis 90/Die Grünen, FDP und Die Linke auf
-                      Drucksache \n20/5 vor. Die Fraktion der CDU/CSU hat beantragt, über \nden Antrag
-                      getrennt abzustimmen, und zwar zum einen \nüber Satz 1 – Zahl der Stellvertreterinnen
-                      und Stellver-\ntreter – und zum anderen über Satz 2 – Vorschlagsrecht.\nIch rufe
-                      zunächst Satz 1 des Antrages auf. Wer stimmt \ndafür? – Wer stimmt dagegen? – Enthaltungen?
-                      – Satz 1 \ndes Antrages ist angenommen mit den Stimmen der \nLinken, der Fraktionen
-                      der SPD, der Grünen, der FDP \nund der AfD-Fraktion gegen die Stimmen der CDU/ \nCSU-Fraktion.\nSchließlich
-                      rufe ich jetzt Satz 2 des Antrages auf. Wer \nstimmt für Satz 2?\n(Abg. Fabian Jacobi
-                      [AfD] meldet sich von der \nTribüne zu Wort)\n– Ich bin mitten in der Abstimmung.
-                      Entschuldigung, \naber in der Abstimmung kann man sich nicht zu Wort \nmelden.\n(Beifall
-                      bei der SPD und der FDP)\nIch wiederhole die Abstimmung. Wir stimmen über \nSatz
-                      2 ab.\n(Fabian Jacobi [AfD]: Entschuldigung! – \nGegenruf des Abg. Dr. Rolf Mützenich
-                      [SPD]: \nMachen Sie sich doch nicht zum Hampel-\nmann!)\nIch wiederhole: Wer stimmt
-                      für Satz 2? – Wer stimmt \ndagegen? – Enthaltungen? – Damit ist dieser Satz 2 \nangenommen
-                      gegen die Stimmen der AfD-Fraktion. \nDamit ist der Antrag insgesamt angenommen
-                      und die \nZahl der Stellvertreterinnen und Stellvertreter der Prä-\nsidentin auf
-                      sechs festgelegt.\n(Abg. Fabian Jacobi [AfD] meldet sich erneut \nzu Wort)\n– Jetzt
-                      ist die Abstimmung abgeschlossen, und ich erteile \nIhnen das Wort.\n(Das Mikrofon
-                      des Abg. Fabian Jacobi [AfD] \nschaltet sich nicht ein – Unruhe – Carsten \nSchneider
-                      [Erfurt] [SPD], an den Abg. Fabian \nJacobi [AfD] gewandt: Einfach testen lassen,
-                      \ndann kann man hier runtergehen!)\n– Ich warte noch. Das kriegen wir technisch
-                      bestimmt \ngleich hin.\n(Mike Moncsek [AfD]: Kein Strom!)\n– Das ist keine Absicht.
-                      Die Technik ist auf dem Weg. \nWir warten.\nFabian Jacobi (AfD):\nAh! Faszinierend.
-                      Wunderbar. – Frau Präsidentin, vie-\nlen Dank. Ich hatte zumindest versucht, mich
-                      vor der \nAbstimmung über Satz 2 zu Wort zu melden, der sich, \nDeutscher Bundestag
-                      – 20. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 26. Oktober 2021                                18
-                      \nPräsidentin Bärbel Bas \n(A) \n(B) \n(C) \n(D) \nwie Sie richtig erwähnt haben,
-                      auf das Vorschlagsrecht \nbei der Wahl der Stellvertreter der Präsidentin bezieht.
-                      \nIch wollte nur fürs Protokoll anmerken, dass – auch im \nHinblick auf den beim
-                      Bundesverfassungsgericht anhän-\ngigen Organstreit – ich davon ausgehe, dass dieser
-                      Satz 2 \nmein Vorschlagsrecht als Abgeordneter nicht tangiert. – \nFürs Protokoll.
-                      Vielen Dank.\nDas hätte ich gerne vor der Abstimmung gesagt. Das \nhabe ich hiermit
-                      nachgeholt. Ich glaube nicht, dass es am \nAbstimmungsergebnis irgendwas geändert
-                      hätte. Aber es \nwäre korrekt gewesen, mich das vor der Abstimmung \nsagen zu lassen.\nVielen
-                      Dank.\n(Beifall bei Abgeordneten der AfD – Zuruf von \nder SPD: Lächerlich!)\nPräsidentin
-                      Bärbel Bas:\nVielen Dank.\nIch rufe den Tagesordnungspunkt 6 auf:\nWahl der Stellvertreterinnen
-                      und Stellvertreter \nder Präsidentin/des Präsidenten\nNach unserer Geschäftsordnung
-                      erfolgt die Wahl der \nVizepräsidentinnen und Vizepräsidenten geheim. Inter-\nfraktionell
-                      ist vereinbart worden, die Wahlen der sechs \nStellvertreterinnen und Stellvertreter
-                      der Präsidentin mit \nWahlausweis und einer Stimmkarte, auf der alle vor-\ngeschlagenen
-                      Kandidatinnen und Kandidaten aufgeführt \nsind, durchzuführen. – Ich sehe, Sie sind
-                      damit einver-\nstanden. Dann verfahren wir so.\nMir liegen folgende Vorschläge von
-                      den Fraktionen \nvor: von der Fraktion der SPD Aydan Özoğuz, von der \nFraktion
-                      der CDU/CSU Yvonne Magwas, von der Frak-\ntion Bündnis 90/Die Grünen Claudia Roth,
-                      von der Frak-\ntion der AfD Dr. Michael Kaufmann und von der Fraktion \nDie Linke
-                      Petra Pau.\n(Alexander Graf Lambsdorff [FDP]: Wolfgang \nKubicki!)\n– Man könnte
-                      fast meinen, das wäre Absicht; aber das ist \nnicht so. Herr Kubicki, Entschuldigung.\n(Beifall
-                      bei Abgeordneten der FDP – Heiterkeit \nbei der SPD – Wolfgang Kubicki [FDP]: Das
-                      \ngeht ja gut los, Frau Präsidentin!)\nSie haben gerade festgestellt: Sie sind wahrscheinlich
-                      der \neinzige Mann, wenn das Ergebnis so kommt. – Ich bitte \nvielmals um Entschuldigung.
-                      Selbstverständlich hat auch \ndie Fraktion der FDP einen Vorschlag mit Wolfgang
-                      \nKubicki.\n(Beifall bei Abgeordneten der FDP – Dr. Marco \nBuschmann [FDP]: Sehr
-                      gut! Guter Mann!)\nGuter Mann, sagt zumindest die Fraktion.\nIch bitte aber dennoch
-                      noch mal um Ihre Aufmerksam-\nkeit für weitere Hinweise zum Ablauf der Wahl.\nDie
-                      Wahl findet mit verdeckten Stimmkarten, also \ngeheim, statt. Gewählt ist, wer die
-                      Stimmen der Mehrheit \nder Mitglieder des Bundestages erhält; das sind 369 Stim-\nmen.
-                      Für diesen Wahlgang sind Stimmkarte und Wahl-\nausweis gelb. Ihren Wahlausweis können
-                      Sie, soweit \nnoch nicht geschehen, den Stimmkartenfächern in der \nWestlobby entnehmen.
-                      Die Abgeordneten auf der Tribü-\nne haben ihren Wahlausweis vom Plenarsitzungsdienst
-                      \nerhalten. Diese Wahl erfolgt wieder in der Abgeordneten-\nlobby. Die auf der Tribüne
-                      sitzenden Kolleginnen und \nKollegen wählen wieder oben auf der Tribüne. An den
-                      \nAusgabetischen erhalten Sie Ihre gelbe Stimmkarte und \nden amtlichen Wahlumschlag.
-                      Auf der Stimmkarte sind \nalle vorgeschlagenen Kandidatinnen und Kandidaten auf-\ngeführt.\nSie
-                      können zu jedem Kandidatenvorschlag „Ja“, \n„Nein“ oder „Enthaltung“ ankreuzen.
-                      Sie haben also ins-\ngesamt sechs Stimmen. Wenn Sie bei einem Namen mehr \nals ein
-                      Kreuz oder gar kein Kreuz machen oder andere \nNamen oder Zusätze eintragen, ist
-                      diese Stimme ungül-\ntig. Sie dürfen Ihre Stimmkarte nur in der Wahlkabine \nankreuzen
-                      und müssen die Stimmkarte ebenfalls noch \nin der Wahlkabine in den Umschlag legen.\nBevor
-                      Sie den Wahlumschlag in die Wahlurne werfen, \nmüssen Sie Ihren Wahlausweis einer
-                      der Schriftführerin-\nnen oder einem der Schriftführer an der Wahlurne über-\ngeben.\nIch
-                      bitte die Schriftführerinnen und Schriftführer, die \nvorgesehenen Plätze einzunehmen.
-                      Dieser Wahlgang \nerfolgt ohne Namensaufruf. Gehen Sie gleichwohl bitte \nnicht
-                      alle sofort; Sie haben ausreichend Zeit. Ich schließe \ndie Wahl erst, wenn alle
-                      anwesenden Abgeordneten ihre \nStimme abgegeben haben. Ich eröffne die Wahl.\nLiebe
-                      Kolleginnen und Kollegen, haben alle Mitglie-\nder des Hauses, auch die Schriftführerinnen
-                      und Schrift-\nführer, ihren Wahlumschlag abgegeben? – Noch nicht, \nein Kopfschütteln.
-                      Dann warte ich noch.\nLiebe Kolleginnen und Kollegen, haben jetzt alle ihre \nStimme
-                      abgegeben? – Das sieht gut aus; i ch sehe einen \nerhobenen Daumen und ein Kopfnicken.
-                      Das ist dann \noffensichtlich der Fall. Ich schließe die Wahl und bitte \ndie Schriftführerinnen
-                      und Schriftführer, mit der Auszäh-\nlung zu beginnen.\nBis zur Bekanntgabe des Ergebnisses
-                      der Wahl unter-\nbreche ich die Sitzung für voraussichtlich 80 Minuten. \nAber vielleicht
-                      geht es auch schneller. Achten Sie auf \ndas Klingelzeichen; das wird Sie auf jeden
-                      Fall wieder \nhierhinlocken. Der Wiederbeginn wird rechtzeitig durch \nKlingelsignal
-                      bekannt gegeben.\n(Unterbrechung von 14.39 bis 15.44 Uhr)\nPräsidentin Bärbel Bas:\nLiebe
-                      Kolleginnen und Kollegen, die unterbrochene \nSitzung ist wieder eröffnet. Ich würde
-                      Sie bitten, nach \nMöglichkeit wieder Platz zu nehmen. – Dann kann ich \ndas Ergebnis
-                      der Wahl der Stellvertreterinnen und Stell-\nvertreter der Präsidentin bekannt geben.
-                      Ich würde Sie \nbitten, mit den Glückwünschen zu warten, bis ich alle \nErgebnisse
-                      verkündet habe und alle Gewählten die \nAnnahme der Wahl erklärt haben.\nAbgegebene
-                      Stimmen 727. Von den abgegebenen \nStimmen entfielen auf Aydan Özoğuz 544 Jastimmen,\nDeutscher
-                      Bundestag – 20. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 26. Oktober 2021
-                      \                                                                                                                                                                                                    19\nFabian
-                      Jacobi \n(A) \n(B) \n(C) \n(D) \n(Beifall bei der SPD, der CDU/CSU, dem \nBÜNDNIS
-                      90/DIE GRÜNEN, der FDP und der \nLINKEN sowie bei Abgeordneten der AfD)\n127 Neinstimmen,
-                      55 Enthaltungen, 1 ungültige Stimme.\nAuf Yvonne Magwas entfielen 600 Jastimmen,\n(Beifall
-                      bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN, der FDP und der \nLINKEN
-                      sowie bei Abgeordneten der AfD)\n62 Neinstimmen, 60 Enthaltungen, 5 ungültige Stimmen.\nAuf
-                      Claudia Roth entfielen 565 Jastimmen,\n(Beifall bei der SPD, der CDU/CSU, dem \nBÜNDNIS
-                      90/DIE GRÜNEN, der FDP und der \nLINKEN sowie bei Abgeordneten der AfD)\n111 Neinstimmen,
-                      50 Enthaltungen, 1 ungültige Stimme.\nAuf Wolfgang Kubicki entfielen 564 Jastimmen,\n(Beifall
-                      bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN, der FDP und der \nLINKEN
-                      sowie bei Abgeordneten der AfD)\n91 Neinstimmen, 69 Enthaltungen, 3 ungültige Stimmen.\nAuf
-                      Dr. Michael Kaufmann entfielen 118 Jastimmen, \n553 Neinstimmen, 29 Enthaltungen
-                      und 27 ungültige \nStimmen.\n(Beifall bei Abgeordneten der SPD und der \nAfD)\nAuf
-                      Petra Pau entfielen 484 Jastimmen,\n(Beifall bei der SPD, der CDU/CSU, dem \nBÜNDNIS
-                      90/DIE GRÜNEN, der FDP und der \nLINKEN)\n163 Neinstimmen, 76 Enthaltungen und 4
-                      ungültige \nStimmen.\nDie Abgeordneten Aydan Özoğuz, Yvonne Magwas, \nClaudia Roth,
-                      Wolfgang Kubicki und Petra Pau haben \ndie erforderliche Mehrheit erreicht und sind
-                      zu Stellver-\ntreterinnen und Stellvertretern der Präsidentin gewählt.\n(Beifall
-                      bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN, der FDP und der \nLINKEN)\nDer
-                      Abgeordnete Dr. Michael Kaufmann hat die erfor-\nderliche Mehrheit nicht erreicht.1)\nIch
-                      frage Sie, Frau Kollegin Aydan Özoğuz: Nehmen \nSie die Wahl an?\nAydan Özoğuz (SPD):\nFrau
-                      Präsidentin, ich nehme die Wahl sehr gerne an \nund freue mich auf die Zusammenarbeit.
-                      – Vielen Dank.\n(Beifall bei der SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN,
-                      der FDP und der \nLINKEN)\nPräsidentin Bärbel Bas:\nIch frage Sie, Frau Kollegin
-                      Magwas: Nehmen Sie die \nWahl an?\nYvonne Magwas (CDU/CSU):\nIch nehme die Wahl
-                      an, bedanke mich auf das Herz-\nlichste für das Vertrauen und freue mich auf die
-                      Zusam-\nmenarbeit. – Vielen Dank.\n(Beifall bei der CDU/CSU, der SPD, dem \nBÜNDNIS
-                      90/DIE GRÜNEN, der FDP und der \nLINKEN)\nPräsidentin Bärbel Bas:\nVielen Dank.
-                      – Frau Kollegin Roth, nehmen Sie die \nWahl an?\nClaudia Roth (Augsburg) (BÜNDNIS
-                      90/DIE GRÜ-\nNEN):\nJa, ich nehme sie mit großer Freude an, bedanke mich \nvon ganzem
-                      Herzen für das Vertrauen und werde mich \nbemühen, es nicht zu enttäuschen.\n(Beifall
-                      beim BÜNDNIS 90/DIE GRÜNEN, \nbei der SPD, der CDU/CSU, der FDP und der \nLINKEN
-                      sowie bei Abgeordneten der AfD)\nPräsidentin Bärbel Bas:\nHerr Kollege Kubicki,
-                      nehmen Sie die Wahl an?\nWolfgang Kubicki (FDP):\nFrau Präsidentin, ich nehme die
-                      Wahl sehr gerne an. \nBeim nächsten Mal werde ich mich auch selbst wählen. – \nVielen
-                      Dank.\n(Beifall bei der FDP, der SPD, der CDU/CSU, \ndem BÜNDNIS 90/DIE GRÜNEN und
-                      der \nLINKEN sowie bei Abgeordneten der AfD)\nPräsidentin Bärbel Bas:\nFrau Kollegin
-                      Pau, nehmen Sie die Wahl an?\nPetra Pau (DIE LINKE):\nFrau Präsidentin, ich nehme
-                      die Wahl an und freue \nmich auf die Zusammenarbeit für die Demokratie.\n(Beifall
-                      bei der LINKEN, der SPD, der CDU/ \nCSU, dem BÜNDNIS 90/DIE GRÜNEN und \nder FDP)\nPräsidentin
-                      Bärbel Bas:\nIm Namen des Hauses und auch ganz persönlich wün-\nsche ich Ihnen Glück
-                      und Erfolg für das verantwortungs-\nvolle Amt, und ich hoffe auf eine gute Zusammenarbeit
-                      \nim Präsidium.\nJetzt hatte sich Herr Baumann gemeldet.\n(Gabriele Katzmarek [SPD]:
-                      Jetzt gratulieren \nwir erst!)\n1) Namensverzeichnis der Teilnehmerinnen und Teilnehmer
-                      an der Wahl \nsiehe Anlage 3 \nDeutscher Bundestag – 20. Wahlperiode – 1. Sitzung.
-                      Berlin, Dienstag, den 26. Oktober 2021                                20 \nPräsidentin
-                      Bärbel Bas \n(A) \n(B) \n(C) \n(D) \nEntschuldigung – wenn Sie noch zwei Sekunden
-                      warten, \nHerr Baumann. Die Kolleginnen und Kollegen möchten \neben gratulieren,
-                      und dann komme ich noch einmal auf \nSie zurück.\n(Abgeordnete aller Fraktionen
-                      gratulieren den \nVizepräsidentinnen und dem Vizepräsidenten – \nBeifall bei der
-                      SPD, der CDU/CSU, dem \nBÜNDNIS 90/DIE GRÜNEN, der FDP und der \nLINKEN)\nLiebe
-                      Kolleginnen und Kollegen, wenn ich den ersten \nPGF richtig verstanden habe,\n(Michael
-                      Grosse-Brömer [CDU/CSU]: Wel-\nchen?)\ndann beantragt die AfD-Fraktion eine Sitzungsunterbre-\nchung.
-                      Ich würde die Sitzung jetzt bis circa 16.30 Uhr – \neine halbe Stunde? – unterbrechen.
-                      Wir werden durch \nKlingelzeichen Bescheid geben, wenn es weitergeht.\nVielen Dank.\n(Unterbrechung
-                      von 15.55 bis 16.30 Uhr)\nPräsidentin Bärbel Bas:\nLiebe Kolleginnen und Kollegen,
-                      die unterbrochene \nSitzung ist wieder eröffnet. Ich bitte alle, Platz zu neh-\nmen.\nHerr
-                      Dr. Baumann von der AfD-Fraktion hat mir gera-\nde mitgeteilt, dass die AfD heute
-                      keinen weiteren Wahl-\ngang wünscht.\n(Beifall bei Abgeordneten der CDU/CSU)\nFür
-                      heute herzlichen Dank dafür.\nLiebe Kolleginnen und Kollegen, bevor ich Sie bitte,
-                      \nsich zur Nationalhymne zu erheben, gestatten Sie mir \nnoch einen Hinweis, auch
-                      an die Zuschauerinnen und \nZuschauer: Pandemiebedingt und zum Schutz unserer \nGesundheit
-                      verzichten wir ausnahmsweise auf das Mit-\nsingen der Hymne. Das haben wir den Fraktionen
-                      auch so \nmitgeteilt. Ich würde mir wünschen, dass Sie das einhal-\nten, für uns
-                      alle. Deshalb wird die Nationalhymne instru-\nmental vorgetragen. – Da kommen sie.
-                      \n(Beifall)\nIch bitte Sie, sich jetzt zu erheben.\n(Nationalhymne – Beifall)\nWir
-                      sind damit am Schluss unserer heutigen Tagesord-\nnung. Über den Zeitpunkt der nächsten
-                      Sitzung des Deut-\nschen Bundestages werde ich Sie rechtzeitig informieren. \nBevor
-                      ich die Sitzung schließe, darf ich Sie herzlich zu \neinem kleinen Empfang in die
-                      Halle des Paul-Löbe-Hau-\nses einladen. Bitte beachten Sie, dass auch dort die 3-G-
-                      \nRegel gilt.\n(Beifall)\nDie Sitzung ist geschlossen.\n(Schluss: 16.33 Uhr)\nDeutscher
-                      Bundestag – 20. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 26. Oktober 2021
-                      \                                                                                                                                                                                                    21\nPräsidentin
-                      Bärbel Bas \n(A) \n(B) \n(C) \n(D) \n\nAnlagen zum Stenografischen Bericht  \nAnlage
-                      1 \nEntschuldigte Abgeordnete\nAbgeordnete(r)\nChrupalla, Tino AfD\nDieren, Jan
-                      SPD\nJensen, Gyde* FDP\nKluckert, Daniela FDP\nLehmann, Sylvia SPD\nNestle, Dr.
-                      Ingrid BÜNDNIS 90/ \nDIE GRÜNEN\nAbgeordnete(r)\nOrtleb, Josephine * SPD\nPohl,
-                      Jürgen AfD\nWitt, Uwe AfD\n* aufgrund gesetzlichen Mutterschutzes\nAnlage 2 \nErgebnis
-                      und Namensverzeichnis\nder Mitglieder des Deutschen Bundestages, die an der Wahl
-                      der Präsidentin des Deutschen Bundestages \nteilgenommen haben\n(Tagesordnungspunkt
-                      3)\nAbgegebene Stimmkarten: 724\nAbgeordnete/r Ja-Stimmen* Nein-Stimmen Enthaltungen
-                      Ungültige Stimmen\nBärbel Bas 576 90 58 –\n* Zur Wahl sind mindestens 369 Ja-Stimmen
-                      erforderlich.\nSPD\nSanae Abdi\nAdis Ahmetovic\nReem Alabali-Radovan\nDagmar Andres\nNiels
-                      Annen\nJohannes Arlt\nHeike Baehrens\nUlrike Bahr\nDaniel Baldy\nNezahat Baradari\nSören
-                      Bartol\nBärbel Bas\nDr. Holger Becker\nJürgen Berghahn\nBengt Bergt\nJakob Blankenburg\nLeni
-                      Breymaier\nKatrin Budde\nIsabel Cademartori Dujisin\nDr. Lars Castellucci\nJürgen
-                      Coße\nBernhard Daldrup\nHakan Demir\nDr. Karamba Diaby\nMartin Diedenhofen\nEsther
-                      Dilcher\nSabine Dittmar\nFelix Döring\nFalko Droßmann\nAxel Echeverria\nSonja Eichwede\nHeike
-                      Engelhardt\nDr. Wiebke Esdar\nSaskia Esken\nYasmin Fahimi\nAriane Fäscher\nDr. Johannes
-                      Fechner\nSebastian Fiedler\nDr. Edgar Franke\nFabian Funke\nManuel Gava\nMichael
-                      Gerdes\nMartin Gerster\nAngelika Glöckner\nTimon Gremmels\nKerstin Griese\nUli Grötsch\nBettina
-                      Hagedorn\nRita Hagl-Kehl\nMetin Hakverdi\nSebastian Hartmann\nDirk Heidenblut\nHubertus
-                      Heil (Peine)\nFrauke Heiligenstadt\nGabriela Heinrich\nWolfgang Hellmich\nAnke Hennig\nNadine
-                      Heselhaus\nThomas Hitschler\nJasmina Hostert\nVerena Hubertz\nMarkus Hümpfer\nFrank
-                      Junge\nJosip Juratovic\nOliver Kaczmarek\nElisabeth Kaiser\nMacit Karaahmetoglu\nCarlos
-                      Kasper\nAnna Kassautzki\nGabriele Katzmarek\nRainer Johannes Keller\nDr. Franziska
-                      Kersten\nCansel Kiziltepe\nHelmut Kleebank\nDr. Kristian Klinck\nLars Klingbeil\nAnnika
-                      Klose\nTim Klüssendorf\nDr. Bärbel Kofler\nSimona Koß\nAnette Kramme\nDunja Kreiser\nMartin
-                      Kröber\nKevin Kühnert\nSarah Lahrkamp\nAndreas Larem\nDr. Karl Lauterbach\nKevin
-                      Leiser\nLuiza Licina-Bode\nEsra-Leon Limbacher\nHelge Lindh\nDeutscher Bundestag
-                      – 20. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 26. Oktober 2021                                                                                                                                                                                                     23\n(A)
-                      \n(B) \n(C) \n(D) \nBettina Lugk\nHeiko Maas\nDr. Tanja Machalet\nIsabel Mackensen-Geis\nErik
-                      von Malottki\nHolger Mann\nKaweh Mansoori\nZanda Martens\nDorothee Martin\nParsa
-                      Marvi\nFranziska Mascheck\nKatja Mast\nAndreas Mehltretter\nTakis Mehmet Ali\nRobin
-                      Mesarosch\nKathrin Michel\nDr. Matthias Miersch\nMatthias David Mieves\nSusanne
-                      Mittag\nFalko Mohrs\nClaudia Moll\nSiemtje Möller\nBettina Müller\nMichael Müller\nDetlef
-                      Müller (Chemnitz)\nMichelle Müntefering\nDr. Rolf Mützenich\nRasha Nasr\nBrian Nickholz\nDietmar
-                      Nietan\nJörg Nürnberger\nLennard Oehl\nMahmut Özdemir (Duisburg)\nAydan Özoğuz\nDr.
-                      Christos Pantazis\nWiebke Papenbrock\nMathias Papendieck\nNatalie Pawlik\nJens Peick\nChristian
-                      Petry\nDr. Andreas Philippi\nJan Plobner\nSabine Poschmann\nAchim Post (Minden)\nYe-One
-                      Rhie\nAndreas Rimkus\nSönke Rix\nDennis Rohde\nSebastian Roloff\nDr. Martin Rosemann\nJessica
-                      Rosenthal\nMichael Roth (Heringen)\nDr. Thorsten Rudolph\nTina Rudolph\nBernd Rützel\nSarah
-                      Ryglewski\nJohann Saathoff\nIngo Schäfer\nAxel Schäfer (Bochum)\nRebecca Schamber\nJohannes
-                      Schätzl\nDr. Nina Scheer\nMarianne Schieder\nUdo Schiefner\nPeggy Schierenbeck\nTimo
-                      Schisanowski\nChristoph Schmid\nDr. Nils Schmid\nUwe Schmidt\nDagmar Schmidt (Wetzlar)\nDaniel
-                      Schneider\nCarsten Schneider (Erfurt)\nOlaf Scholz\nJohannes Schraps\nChristian
-                      Schreider\nMichael Schrodi\nSvenja Schulze\nFrank Schwabe\nStefan Schwartze\nAndreas
-                      Schwarz\nRita Schwarzelühr-Sutter\nDr. Lina Seitzl\nSvenja Stadler\nMartina Stamm-Fibich\nDr.
-                      Ralf Stegner\nMathias Stein\nNadja Sthamer\nRuppert Stüwe\nClaudia Tausend\nMichael
-                      Thews\nMarkus Töns\nCarsten Träger\nAnja Troff-Schaffarzyk\nDerya Türk-Nachbaur\nFrank
-                      Ullrich\nMarja-Liisa Völlers\nDirk Vöpel\nDr. Carolin Wagner\nMaja Wallstein\nHannes
-                      Walter\nCarmen Wegge\nMelanie Wegling\nDr. Joe Weingarten\nLena Werner\nBernd Westphal\nDirk
-                      Wiese\nDr. Herbert Wollmann\nGülistan Yüksel\nStefan Zierke\nDr. Jens Zimmermann\nArmand
-                      Zorn\nKatrin Zschau\nCDU/CSU\nKnut Abraham\nStephan Albani\nNorbert Maria Altenkamp\nPhilipp
-                      Amthor\nArtur Auernhammer\nPeter Aumer\nDorothee Bär\nThomas Bareiß\nDr. André Berghegger\nPeter
-                      Beyer\nMarc Biadacz\nSteffen Bilger\nSimone Borchardt\nMichael Brand (Fulda)\nDr.
-                      Reinhard Brandl\nDr. Helge Braun\nSilvia Breher\nSebastian Brehm\nHeike Brehmer\nMichael
-                      Breilmann\nRalph Brinkhaus\nDr. Carsten Brodesser\nDr. Marlon Bröhr\nYannick Bury\nGitta
-                      Connemann\nMario Czaja\nAstrid Damerow\nAlexander Dobrindt\nMichael Donth\nHansjörg
-                      Durz\nRalph Edelhäußer\nAlexander Engelhard\nMartina Englhardt-Kopf\nThomas Erndl\nHermann
-                      Färber\nUwe Feiler\nEnak Ferlemann\nThorsten Frei\nDr. Hans-Peter Friedrich  \n(Hof)\nMichael
-                      Frieser\nIngo Gädechens\nDr. Thomas Gebhart\nDr. Jonas Geissler\nFabian Gramling\nDr.
-                      Ingeborg Gräßle\nHermann Gröhe\nMichael Grosse-Brömer\nMarkus Grübel\nManfred Grund\nOliver
-                      Grundmann\nMonika Grütters\nSerap Güler\nFritz Güntzler\nOlav Gutting\nChristian
-                      Haase\nFlorian Hahn\nJürgen Hardt\nMatthias Hauer\nDr. Stefan Heck\nMechthild Heil\nThomas
-                      Heilmann\nMark Helfrich\nMichael Hennrich\nMarc Henrichmann\nAnsgar Heveling\nSusanne
-                      Hierl\nChristian Hirte\nAlexander Hoffmann\nDr. Hendrik Hoppenstedt\nFranziska Hoppermann\nHubert
-                      Hüppe\nErich Irlstorfer\nAnne Janssen\nThomas Jarzombek\nAndreas Jung\nIngmar Jung\nAnja
-                      Karliczek\nRonja Kemmer\nRoderich Kiesewetter\nMichael Kießling\nDr. Georg Kippels\nDr.
-                      Ottilie Klein\nVolkmar Klein\nJulia Klöckner\nAxel Knoerig\nJens Koeppen\nAnne König\nMarkus
-                      Koob\nCarsten Körber\nGunther Krichbaum\nDr. Günter Krings\nTilman Moritz Kuban\nUlrich
-                      Lange\nDr. Silke Launert\nJens Lehmann\nPaul Lehrieder\nDr. Katja Leikert\nDr. Andreas
-                      Lenz\nAndrea Lindholz\nDr. Carsten Linnemann\nPatricia Lips\nBernhard Loos\nDr.
-                      Jan-Marco Luczak\nDaniela Ludwig\nKlaus Mack\nYvonne Magwas\nAndreas Mattfeldt\nStephan
-                      Mayer (Altötting)\nVolker Mayer-Lay\nDr. Michael Meister\nFriedrich Merz\nJan Metzler\nDr.
-                      Mathias Middelberg\nDietrich Monstadt\nMaximilian Mörseburg\nAxel Müller\nFlorian
-                      Müller\nSepp Müller\nCarsten Müller  \n(Braunschweig)\nStefan Müller (Erlangen)\nDr.
-                      Stefan Nacke\nPetra Nicolaisen\nWilfried Oellers\nMoritz Oppelt\nFlorian Oßner\nJosef
-                      Oster\nHenning Otte\nStephan Pilsinger\nDr. Christoph Ploß\nDr. Martin Plum\nThomas
-                      Rachel\nKerstin Radomski\nAlexander Radwan\nAlois Rainer\nDr. Peter Ramsauer\nHenning
-                      Rehbaum\nDr. Markus Reichel\nJosef Rief\nLars Rohwer\nDeutscher Bundestag – 20.
-                      Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 26. Oktober 2021                                24
-                      \n(A) \n(B) \n(C) \n(D) \nDr. Norbert Röttgen\nStefan Rouenhoff\nThomas Röwekamp\nErwin
-                      Rüddel\nAlbert Rupprecht\nCatarina dos Santos Firnhaber\nDr. Wolfgang Schäuble\nDr.
-                      Christiane Schenderlein\nAndreas Scheuer\nJana Schimke\nPatrick Schnieder\nNadine
-                      Schön\nFelix Schreiner\nArmin Schwarz\nDetlef Seif\nThomas Silberhorn\nBjörn Simon\nTino
-                      Sorge\nJens Spahn\nKatrin Staffler\nDr. Wolfgang Stefinger\nAlbert Stegemann\nJohannes
-                      Steiniger\nChristian Frhr. von Stetten\nDieter Stier\nDiana Stöcker\nGero Storjohann\nStephan
-                      Stracke\nMax Straubinger\nChristina Stumpp\nDr. Hermann-Josef Tebroke\nHans-Jürgen
-                      Thies\nAlexander Throm\nAntje Tillmann\nAstrid Timmermann-Fechter\nMarkus Uhl\nDr.
-                      Volker Ullrich\nKerstin Vieregge\nDr. Oliver Vogt\nChristoph de Vries\nDr. Johann
-                      David Wadephul\nMarco Wanderwitz\nNina Warken\nDr. Anja Weisgerber\nMaria-Lena Weiss\nSabine
-                      Weiss (Wesel I)\nKai Whittaker\nAnnette Widmann-Mauz\nDr. Klaus Wiener\nKlaus-Peter
-                      Willsch\nElisabeth Winkelmeier-Becker\nTobias Winkler\nMechthilde Wittmann\nMareike
-                      Lotte Wulf\nEmmi Zeulner\nPaul Ziemiak\nNicolas Zippelius\nBÜNDNIS 90/ \nDIE GRÜNEN\nStephanie
-                      Aeffner\nLuise Amtsberg\nAndreas Audretsch\nMaik Außendorf\nTobias Bacherle\nLisa
-                      Badum\nAnnalena Baerbock\nFelix Banaszak\nKarl Bär\nCanan Bayram\nKatharina Beck\nLukas
-                      Benner\nDr. Franziska Brantner\nAgnieszka Brugger\nFrank Bsirske\nDr. Anna Christmann\nDr.
-                      Janosch Dahmen\nEkin Deligöz\nDr. Sandra Detzer\nKatharina Dröge\nDeborah Düring\nHarald
-                      Ebner\nLeon Eckert\nMarcel Emmerich\nEmilia Fester\nSchahina Gambir\nTessa Ganserer\nMatthias
-                      Gastel\nKai Gehring\nStefan Gelbhaar\nDr. Jan-Niclas Gesenhues\nKatrin Göring-Eckardt\nDr.
-                      Armin Grau\nErhard Grundl\nSabine Grützmacher\nRobert Habeck\nBritta Haßelmann\nLinda
-                      Heitmann\nKathrin Henneberger\nBernhard Herrmann\nDr. Bettina Hoffmann\nDr. Anton
-                      Hofreiter\nBruno Hönel\nDieter Janecek\nLamya Kaddor\nDr. Kirsten Kappert-Gonther\nMichael
-                      Kellner\nKatja Keul\nMisbah Khan\nSven-Christian Kindler\nMaria Klein-Schmeink\nChantal
-                      Kopf\nLaura Kraft\nPhilip Krämer\nOliver Krischer\nChristian Kühn (Tübingen)\nRenate
-                      Künast\nMarkus Kurth\nRicarda Lang\nSven Lehmann\nSteffi Lemke\nAnja Liebert\nHelge
-                      Limburg\nDr. Tobias Lindner\nDenise Loop\nMax Lucks\nDr. Anna Lührmann\nZoe Mayer\nSusanne
-                      Menge\nSwantje Henrike Michaelsen\nDr. Irene Mihalic\nBoris Mijatovic\nClaudia Müller\nSascha
-                      Müller\nBeate Müller-Gemmeke\nSara Nanni\nDr. Ophelia Nick\nDr. Konstantin von Notz\nOmid
-                      Nouripour\nKaroline Otte\nCem Özdemir\nJulian Pahlke\nLisa Paus\nDr. Paula Piechotta\nFiliz
-                      Polat\nDr. Anja Reinalter\nTabea Rößner\nClaudia Roth (Augsburg)\nDr. Manuela Rottmann\nCorinna
-                      Rüffer\nKassem Taher Saleh\nJamila Schäfer\nDr. Sebastian Schäfer\nStefan Schmidt\nMarlene
-                      Schönberger\nChristina-Johanne Schröder\nKordula Schulz-Asche\nMelis Sekmen\nNyke
-                      Slawik\nDr. Anne Monika Spallek\nMerle Spellerberg\nNina Stahr\nDr. Till Steffen\nHanna
-                      Steinmüller\nDr. Wolfgang  \nStrengmann-Kuhn\nAwet Tesfaiesus\nJürgen Trittin\nKatrin
-                      Uhlig\nDr. Julia Verlinden\nNiklas Wagener\nRobin Wagener\nJohannes Wagner\nBeate
-                      Walter-Rosenheimer\nSaskia Weishaupt\nStefan Wenzel\nTina Winklmann\nFDP\nValentin
-                      Abel\nKatja Adler\nRenata Alt\nChristine Aschenberg-Dugnus\nNicole Bauer\nJens Beeck\nIngo
-                      Bodtke\nFriedhelm Boginski\nDr. Jens Brandenburg  \n(Rhein-Neckar)\nMario Brandenburg
-                      \ \n(Südpfalz)\nSandra Bubendorfer-Licht\nDr. Marco Buschmann\nKarlheinz Busen\nCarl-Julius
-                      Cronenberg\nBijan Djir-Sarai\nChristian Dürr\nDr. Marcus Faber\nDaniel Föst\nOtto
-                      Fricke\nMaximilian Funke-Kaiser\nMartin Gaßner-Herz\nKnut Gerschau\nThomas Hacker\nReginald
-                      Hanke\nPhilipp Hartewig\nUlrike Harzer\nPeter Heidt\nKatrin Helling-Plahr\nMarkus
-                      Herbrand\nTorsten Herbst\nKatja Hessel\nDr. Gero Clemens Hocker\nManuel Höferlin\nDr.
-                      Christoph Hoffmann\nReinhard Houben\nOlaf In der Beek\nDr. Ann-Veruschka Jurisch\nKarsten
-                      Klein\nDaniela Kluckert\nPascal Kober\nDr. Lukas Köhler\nCarina Konrad\nMichael
-                      Kruse\nWolfgang Kubicki\nKonstantin Kuhle\nAlexander Graf Lambsdorff\nUlrich Lechte\nJürgen
-                      Lenders\nDr. Thorsten Lieb\nLars Lindemann\nChristian Lindner\nMichael Georg Link
-                      \ \n(Heilbronn)\nOliver Luksic\nKristine Lütke\nTill Mansmann\nAnikó Merten\nChristoph
-                      Meyer\nMaximilian Mordhorst\nAlexander Müller\nFrank Müller-Rosentritt\nClaudia
-                      Raffelhüschen\nDr. Volker Redder\nHagen Reinhold\nBernd Reuther\nDr. h. c. Thomas
-                      \ \nSattelberger\nChristian Sauter\nFrank Schäffler\nRia Schröder\nAnja Schulz\nMatthias
-                      Seestern-Pauly\nDr. Stephan Seiter\nRainer Semet\nDeutscher Bundestag – 20. Wahlperiode
-                      – 1. Sitzung. Berlin, Dienstag, den 26. Oktober 2021                                                                                                                                                                                                     25\n(A)
-                      \n(B) \n(C) \n(D) \nJudith Skudelny\nBettina Stark-Watzinger\nKonrad Stockmeier\nDr.
-                      Marie-Agnes Strack- \nZimmermann\nBenjamin Strasser\nLinda Teuteberg\nJens Teutrine\nMichael
-                      Theurer\nStephan Thomae\nNico Tippelt\nManfred Todtenhausen\nDr. Florian Toncar\nDr.
-                      Andrew Ullmann\nGerald Ullrich\nJohannes Vogel (Olpe)\nSandra Weeser\nNicole Westig\nDr.
-                      Volker Wissing\nAfD\nCarolin Bachmann\nDr. Christina Baum\nDr. Bernd Baumann\nRoger
-                      Beckamp\nMarc Bernhard\nAndreas Bleck\nRené Bochmann\nPeter Boehringer\nGereon Bollmann\nDirk
-                      Brandes\nStephan Brandner\nJürgen Braun\nMarcus Bühl\nJoana Cotar\nDr. Gottfried
-                      Curio\nThomas Dietz\nThomas Ehrhorn\nDr. Michael Espendiller\nRobert Farle\nPeter
-                      Felser\nDietmar Friedhoff\nMarkus Frohnmaier\nDr. Götz Frömming\nDr. Alexander Gauland\nAlbrecht
-                      Glaser\nHannes Gnauck\nKay Gottschalk\nMariana Iris Harder-Kühnel\nJochen Haug\nMartin
-                      Hess\nKarsten Hilse\nNicole Höchst\nLeif-Erik Holm\nJohannes Huber\nGerrit Huy\nFabian
-                      Jacobi\nSteffen Janich\nDr. Marc Jongen\nDr. Malte Kaufmann\nDr. Michael Kaufmann\nStefan
-                      Keuter\nNorbert Kleinwächter\nEnrico Komning\nJörn König\nSteffen Kotré\nDr. Rainer
-                      Kraft\nBarbara Lenk\nRüdiger Lucassen\nCorinna Miazga\nMike Moncsek\nMatthias Moosdorf\nSebastian
-                      Münzenmaier\nEdgar Naujok\nJan Ralf Nolte\nGerold Otten\nTobias Matthias Peterka\nStephan
-                      Protschka\nMartin Reichardt\nMartin Erwin Renner\nFrank Rinck\nBernd Schattner\nUlrike
-                      Schielke-Ziesing\nEugen Schmidt\nJan Wenzel Schmidt\nJörg Schneider\nUwe Schulz\nThomas
-                      Seitz\nMartin Sichert\nDr. Dirk Spaniel\nRené Springer\nKlaus Stöber\nBeatrix von
-                      Storch\nDr. Alice Weidel\nDr. Harald Weyel\nWolfgang Wiehle\nDr. Christian Wirth\nJoachim
-                      Wundrak\nKay-Uwe Ziegler\nDIE LINKE\nGökay Akbulut\nAli Al-Dailami\nDr. Dietmar
-                      Bartsch\nMatthias W. Birkwald\nSevim Dağdelen\nAnke Domscheit-Berg\nKlaus Ernst\nSusanne
-                      Ferschl\nNicole Gohlke\nChristian Görke\nAtes Gürpinar\nDr. Gregor Gysi\nDr. André
-                      Hahn\nSusanne Hennig-Wellsow\nAndrej Hunko\nKatja Kipping\nJan Korte\nIna Latendorf\nCaren
-                      Lay\nRalph Lenkert\nChristian Leye\nDr. Gesine Lötzsch\nThomas Lutze\nPascal Meiser\nAmira
-                      Mohamed Ali\nCornelia Möhring\nZaklin Nastic\nPetra Pau\nSören Pellmann\nVictor
-                      Perli\nHeidi Reichinnek\nMartina Renner\nBernd Riexinger\nDr. Petra Sitte\nJessica
-                      Tatti\nAlexander Ulrich\nKathrin Vogler\nDr. Sahra Wagenknecht\nJanine Wissler\nFraktionslos\nMatthias
-                      Helferich\nStefan Seidler\nAbgeordnete, die sich wegen gesetzlichen Mutterschutzes
-                      für ihre Abwesenheit entschuldigt haben, sind in der  \nListe der entschuldigten
-                      Abgeordneten (Anlage 1) aufgeführt.\nDeutscher Bundestag – 20. Wahlperiode – 1.
-                      Sitzung. Berlin, Dienstag, den 26. Oktober 202126 \n(A) \n(B) \n(C) \n(D)\nAnlage
-                      3 \nErgebnisse und Namensverzeichnis\nder Mitglieder des Deutschen Bundestages,
-                      die an der Wahl der Stellvertreterinnen und Stellvertreter der \nPräsidentin des
-                      Deutschen Bundestages teilgenommen haben\n(Tagesordnungspunkt 6)\nAbgegebene Stimmkarten:
-                      727\nAbgeordnete/r Ja-Stimmen* Nein-Stimmen Enthaltungen Ungültige Stimmen\nAydan
-                      Özoğuz 544 127 55 1\nYvonne Magwas 600 62 60 5\nClaudia Roth 565 111 50 1\nWolfgang
-                      Kubicki 564 91 69 3\nDr. Michael Kaufmann 118 553 29 27\nPetra Pau 484 163 76 4\n*
-                      Zur Wahl sind mindestens 369 Ja-Stimmen erforderlich.\nSPD\nSanae Abdi\nAdis Ahmetovic\nReem
-                      Alabali-Radovan\nDagmar Andres\nNiels Annen\nJohannes Arlt\nHeike Baehrens\nUlrike
-                      Bahr\nDaniel Baldy\nNezahat Baradari\nSören Bartol\nBärbel Bas\nDr. Holger Becker\nJürgen
-                      Berghahn\nBengt Bergt\nJakob Blankenburg\nLeni Breymaier\nKatrin Budde\nIsabel Cademartori
-                      Dujisin\nDr. Lars Castellucci\nJürgen Coße\nBernhard Daldrup\nHakan Demir\nDr. Karamba
-                      Diaby\nMartin Diedenhofen\nEsther Dilcher\nSabine Dittmar\nFelix Döring\nFalko Droßmann\nAxel
-                      Echeverria\nSonja Eichwede\nHeike Engelhardt\nDr. Wiebke Esdar\nSaskia Esken\nYasmin
-                      Fahimi\nAriane Fäscher\nDr. Johannes Fechner\nSebastian Fiedler\nDr. Edgar Franke\nFabian
-                      Funke\nManuel Gava\nMichael Gerdes\nMartin Gerster\nAngelika Glöckner\nTimon Gremmels\nKerstin
-                      Griese\nUli Grötsch\nBettina Hagedorn\nRita Hagl-Kehl\nMetin Hakverdi\nSebastian
-                      Hartmann\nDirk Heidenblut\nHubertus Heil (Peine)\nFrauke Heiligenstadt\nGabriela
-                      Heinrich\nWolfgang Hellmich\nAnke Hennig\nNadine Heselhaus\nThomas Hitschler\nJasmina
-                      Hostert\nVerena Hubertz\nMarkus Hümpfer\nFrank Junge\nJosip Juratovic\nOliver Kaczmarek\nElisabeth
-                      Kaiser\nMacit Karaahmetoglu\nCarlos Kasper\nAnna Kassautzki\nGabriele Katzmarek\nRainer
-                      Johannes Keller\nDr. Franziska Kersten\nCansel Kiziltepe\nHelmut Kleebank\nDr. Kristian
-                      Klinck\nLars Klingbeil\nAnnika Klose\nTim Klüssendorf\nDr. Bärbel Kofler\nSimona
-                      Koß\nAnette Kramme\nDunja Kreiser\nMartin Kröber\nKevin Kühnert\nSarah Lahrkamp\nAndreas
-                      Larem\nDr. Karl Lauterbach\nKevin Leiser\nLuiza Licina-Bode\nEsra-Leon Limbacher\nHelge
-                      Lindh\nBettina Lugk\nHeiko Maas\nDr. Tanja Machalet\nIsabel Mackensen-Geis\nErik
-                      von Malottki\nHolger Mann\nKaweh Mansoori\nZanda Martens\nDorothee Martin\nParsa
-                      Marvi\nFranziska Mascheck\nKatja Mast\nAndreas Mehltretter\nTakis Mehmet Ali\nRobin
-                      Mesarosch\nKathrin Michel\nDr. Matthias Miersch\nMatthias David Mieves\nSusanne
-                      Mittag\nFalko Mohrs\nClaudia Moll\nSiemtje Möller\nBettina Müller\nMichael Müller\nDetlef
-                      Müller (Chemnitz)\nMichelle Müntefering\nDr. Rolf Mützenich\nRasha Nasr\nBrian Nickholz\nDietmar
-                      Nietan\nJörg Nürnberger\nLennard Oehl\nMahmut Özdemir (Duisburg)\nAydan Özoğuz\nDr.
-                      Christos Pantazis\nWiebke Papenbrock\nMathias Papendieck\nNatalie Pawlik\nJens Peick\nChristian
-                      Petry\nDr. Andreas Philippi\nJan Plobner\nSabine Poschmann\nAchim Post (Minden)\nYe-One
-                      Rhie\nAndreas Rimkus\nSönke Rix\nDennis Rohde\nSebastian Roloff\nDr. Martin Rosemann\nJessica
-                      Rosenthal\nMichael Roth (Heringen)\nDr. Thorsten Rudolph\nTina Rudolph\nBernd Rützel\nDeutscher
-                      Bundestag – 20. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 26. Oktober 2021
-                      \     27 \n(A) \n(B) \n(C) \n(D)\nSarah Ryglewski\nJohann Saathoff\nIngo Schäfer\nAxel
-                      Schäfer (Bochum)\nRebecca Schamber\nJohannes Schätzl\nDr. Nina Scheer\nMarianne
-                      Schieder\nUdo Schiefner\nPeggy Schierenbeck\nTimo Schisanowski\nChristoph Schmid\nDr.
-                      Nils Schmid\nUwe Schmidt\nDagmar Schmidt (Wetzlar)\nDaniel Schneider\nCarsten Schneider
-                      (Erfurt)\nOlaf Scholz\nJohannes Schraps\nChristian Schreider\nMichael Schrodi\nSvenja
-                      Schulze\nFrank Schwabe\nStefan Schwartze\nAndreas Schwarz\nRita Schwarzelühr-Sutter\nDr.
-                      Lina Seitzl\nSvenja Stadler\nMartina Stamm-Fibich\nDr. Ralf Stegner\nMathias Stein\nNadja
-                      Sthamer\nRuppert Stüwe\nClaudia Tausend\nMichael Thews\nMarkus Töns\nCarsten Träger\nAnja
-                      Troff-Schaffarzyk\nDerya Türk-Nachbaur\nFrank Ullrich\nMarja-Liisa Völlers\nDirk
-                      Vöpel\nDr. Carolin Wagner\nMaja Wallstein\nHannes Walter\nCarmen Wegge\nMelanie
-                      Wegling\nDr. Joe Weingarten\nLena Werner\nBernd Westphal\nDirk Wiese\nDr. Herbert
-                      Wollmann\nGülistan Yüksel\nStefan Zierke\nDr. Jens Zimmermann\nArmand Zorn\nKatrin
-                      Zschau\nCDU/CSU\nKnut Abraham\nStephan Albani\nNorbert Maria Altenkamp\nPhilipp
-                      Amthor\nArtur Auernhammer\nPeter Aumer\nDorothee Bär\nThomas Bareiß\nDr. André Berghegger\nPeter
-                      Beyer\nMarc Biadacz\nSteffen Bilger\nSimone Borchardt\nMichael Brand (Fulda)\nDr.
-                      Reinhard Brandl\nDr. Helge Braun\nSilvia Breher\nSebastian Brehm\nHeike Brehmer\nMichael
-                      Breilmann\nRalph Brinkhaus\nDr. Carsten Brodesser\nDr. Marlon Bröhr\nYannick Bury\nGitta
-                      Connemann\nMario Czaja\nAstrid Damerow\nAlexander Dobrindt\nMichael Donth\nHansjörg
-                      Durz\nRalph Edelhäußer\nAlexander Engelhard\nMartina Englhardt-Kopf\nThomas Erndl\nHermann
-                      Färber\nUwe Feiler\nEnak Ferlemann\nThorsten Frei\nDr. Hans-Peter Friedrich  \n(Hof)\nMichael
-                      Frieser\nIngo Gädechens\nDr. Thomas Gebhart\nDr. Jonas Geissler\nFabian Gramling\nDr.
-                      Ingeborg Gräßle\nHermann Gröhe\nMichael Grosse-Brömer\nMarkus Grübel\nManfred Grund\nOliver
-                      Grundmann\nMonika Grütters\nSerap Güler\nFritz Güntzler\nOlav Gutting\nChristian
-                      Haase\nFlorian Hahn\nJürgen Hardt\nMatthias Hauer\nDr. Stefan Heck\nMechthild Heil\nThomas
-                      Heilmann\nMark Helfrich\nMichael Hennrich\nMarc Henrichmann\nAnsgar Heveling\nSusanne
-                      Hierl\nChristian Hirte\nAlexander Hoffmann\nDr. Hendrik Hoppenstedt\nFranziska Hoppermann\nHubert
-                      Hüppe\nErich Irlstorfer\nAnne Janssen\nThomas Jarzombek\nAndreas Jung\nIngmar Jung\nAnja
-                      Karliczek\nRonja Kemmer\nRoderich Kiesewetter\nMichael Kießling\nDr. Georg Kippels\nDr.
-                      Ottilie Klein\nVolkmar Klein\nJulia Klöckner\nAxel Knoerig\nJens Koeppen\nAnne König\nMarkus
-                      Koob\nCarsten Körber\nGunther Krichbaum\nDr. Günter Krings\nTilman Moritz Kuban\nUlrich
-                      Lange\nArmin Laschet\nDr. Silke Launert\nJens Lehmann\nPaul Lehrieder\nDr. Katja
-                      Leikert\nDr. Andreas Lenz\nAndrea Lindholz\nDr. Carsten Linnemann\nPatricia Lips\nBernhard
-                      Loos\nDr. Jan-Marco Luczak\nDaniela Ludwig\nKlaus Mack\nYvonne Magwas\nAndreas Mattfeldt\nStephan
-                      Mayer (Altötting)\nVolker Mayer-Lay\nDr. Michael Meister\nFriedrich Merz\nJan Metzler\nDr.
-                      Mathias Middelberg\nDietrich Monstadt\nMaximilian Mörseburg\nAxel Müller\nFlorian
-                      Müller\nSepp Müller\nCarsten Müller  \n(Braunschweig)\nStefan Müller (Erlangen)\nDr.
-                      Stefan Nacke\nPetra Nicolaisen\nWilfried Oellers\nMoritz Oppelt\nFlorian Oßner\nJosef
-                      Oster\nHenning Otte\nStephan Pilsinger\nDr. Christoph Ploß\nDr. Martin Plum\nThomas
-                      Rachel\nKerstin Radomski\nAlexander Radwan\nAlois Rainer\nDr. Peter Ramsauer\nHenning
-                      Rehbaum\nDr. Markus Reichel\nJosef Rief\nLars Rohwer\nDr. Norbert Röttgen\nStefan
-                      Rouenhoff\nThomas Röwekamp\nErwin Rüddel\nAlbert Rupprecht\nCatarina dos Santos
-                      \ \nFirnhaber\nDr. Wolfgang Schäuble\nDr. Christiane Schenderlein\nAndreas Scheuer\nJana
-                      Schimke\nPatrick Schnieder\nNadine Schön\nFelix Schreiner\nArmin Schwarz\nDetlef
-                      Seif\nThomas Silberhorn\nBjörn Simon\nTino Sorge\nJens Spahn\nKatrin Staffler\nDr.
-                      Wolfgang Stefinger\nAlbert Stegemann\nJohannes Steiniger\nChristian Frhr. von Stetten\nDieter
-                      Stier\nDiana Stöcker\nGero Storjohann\nStephan Stracke\nMax Straubinger\nChristina
-                      Stumpp\nDr. Hermann-Josef Tebroke\nHans-Jürgen Thies\nAlexander Throm\nAntje Tillmann\nAstrid
-                      Timmermann-Fechter\nMarkus Uhl\nDr. Volker Ullrich\nKerstin Vieregge\nDr. Oliver
-                      Vogt\nChristoph de Vries\nDr. Johann David Wadephul\nMarco Wanderwitz\nNina Warken\nDr.
-                      Anja Weisgerber\nMaria-Lena Weiss\nSabine Weiss (Wesel I)\nKai Whittaker\nAnnette
-                      Widmann-Mauz\nDr. Klaus Wiener\nKlaus-Peter Willsch\nElisabeth Winkelmeier- \nBecker\nTobias
-                      Winkler\nDeutscher Bundestag – 20. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den
-                      26. Oktober 202128 \n(A) \n(B) \n(C) \n(D)\nMechthilde Wittmann\nMareike Lotte Wulf\nEmmi
-                      Zeulner\nPaul Ziemiak\nNicolas Zippelius\nBÜNDNIS 90/ \nDIE GRÜNEN\nStephanie Aeffner\nLuise
-                      Amtsberg\nAndreas Audretsch\nMaik Außendorf\nTobias Bacherle\nLisa Badum\nAnnalena
-                      Baerbock\nFelix Banaszak\nKarl Bär\nCanan Bayram\nKatharina Beck\nLukas Benner\nDr.
-                      Franziska Brantner\nAgnieszka Brugger\nFrank Bsirske\nDr. Anna Christmann\nDr. Janosch
-                      Dahmen\nEkin Deligöz\nDr. Sandra Detzer\nKatharina Dröge\nDeborah Düring\nHarald
-                      Ebner\nLeon Eckert\nMarcel Emmerich\nEmilia Fester\nSchahina Gambir\nTessa Ganserer\nMatthias
-                      Gastel\nKai Gehring\nStefan Gelbhaar\nDr. Jan-Niclas Gesenhues\nKatrin Göring-Eckardt\nDr.
-                      Armin Grau\nErhard Grundl\nSabine Grützmacher\nRobert Habeck\nBritta Haßelmann\nLinda
-                      Heitmann\nKathrin Henneberger\nBernhard Herrmann\nDr. Bettina Hoffmann\nDr. Anton
-                      Hofreiter\nBruno Hönel\nDieter Janecek\nLamya Kaddor\nDr. Kirsten Kappert-Gonther\nMichael
-                      Kellner\nKatja Keul\nMisbah Khan\nSven-Christian Kindler\nMaria Klein-Schmeink\nChantal
-                      Kopf\nLaura Kraft\nPhilip Krämer\nOliver Krischer\nChristian Kühn (Tübingen)\nRenate
-                      Künast\nMarkus Kurth\nSven Lehmann\nSteffi Lemke\nAnja Liebert\nHelge Limburg\nDr.
-                      Tobias Lindner\nDenise Loop\nMax Lucks\nDr. Anna Lührmann\nZoe Mayer\nSusanne Menge\nSwantje
-                      Henrike Michaelsen\nDr. Irene Mihalic\nBoris Mijatovic\nClaudia Müller\nSascha Müller\nBeate
-                      Müller-Gemmeke\nSara Nanni\nDr. Ophelia Nick\nDr. Konstantin von Notz\nOmid Nouripour\nKaroline
-                      Otte\nCem Özdemir\nJulian Pahlke\nLisa Paus\nDr. Paula Piechotta\nFiliz Polat\nDr.
-                      Anja Reinalter\nTabea Rößner\nClaudia Roth (Augsburg)\nDr. Manuela Rottmann\nCorinna
-                      Rüffer\nKassem Taher Saleh\nJamila Schäfer\nDr. Sebastian Schäfer\nUlle Schauws\nStefan
-                      Schmidt\nMarlene Schönberger\nChristina-Johanne Schröder\nKordula Schulz-Asche\nMelis
-                      Sekmen\nNyke Slawik\nDr. Anne Monika Spallek\nMerle Spellerberg\nNina Stahr\nDr.
-                      Till Steffen\nHanna Steinmüller\nDr. Wolfgang Strengmann- \nKuhn\nAwet Tesfaiesus\nJürgen
-                      Trittin\nKatrin Uhlig\nDr. Julia Verlinden\nNiklas Wagener\nRobin Wagener\nJohannes
-                      Wagner\nBeate Walter-Rosenheimer\nSaskia Weishaupt\nStefan Wenzel\nTina Winklmann\nFDP\nValentin
-                      Abel\nKatja Adler\nMuhanad Al-Halak\nRenata Alt\nChristine Aschenberg-Dugnus\nNicole
-                      Bauer\nJens Beeck\nIngo Bodtke\nFriedhelm Boginski\nDr. Jens Brandenburg  \n(Rhein-Neckar)\nMario
-                      Brandenburg  \n(Südpfalz)\nSandra Bubendorfer-Licht\nDr. Marco Buschmann\nKarlheinz
-                      Busen\nCarl-Julius Cronenberg\nBijan Djir-Sarai\nChristian Dürr\nDr. Marcus Faber\nDaniel
-                      Föst\nOtto Fricke\nMaximilian Funke-Kaiser\nMartin Gaßner-Herz\nKnut Gerschau\nThomas
-                      Hacker\nReginald Hanke\nPhilipp Hartewig\nUlrike Harzer\nPeter Heidt\nKatrin Helling-Plahr\nMarkus
-                      Herbrand\nTorsten Herbst\nKatja Hessel\nDr. Gero Clemens Hocker\nManuel Höferlin\nDr.
-                      Christoph Hoffmann\nReinhard Houben\nOlaf In der Beek\nGyde Jensen\nDr. Ann-Veruschka
-                      Jurisch\nKarsten Klein\nDaniela Kluckert\nPascal Kober\nDr. Lukas Köhler\nCarina
-                      Konrad\nMichael Kruse\nWolfgang Kubicki\nKonstantin Kuhle\nAlexander Graf Lambsdorff\nUlrich
-                      Lechte\nJürgen Lenders\nDr. Thorsten Lieb\nLars Lindemann\nChristian Lindner\nMichael
-                      Georg Link  \n(Heilbronn)\nOliver Luksic\nKristine Lütke\nTill Mansmann\nAnikó Merten\nChristoph
-                      Meyer\nMaximilian Mordhorst\nAlexander Müller\nFrank Müller-Rosentritt\nClaudia
-                      Raffelhüschen\nDr. Volker Redder\nHagen Reinhold\nBernd Reuther\nDr. h. c. Thomas
-                      \ \nSattelberger\nChristian Sauter\nFrank Schäffler\nRia Schröder\nAnja Schulz\nMatthias
-                      Seestern-Pauly\nDr. Stephan Seiter\nRainer Semet\nJudith Skudelny\nBettina Stark-Watzinger\nKonrad
-                      Stockmeier\nDr. Marie-Agnes Strack- \nZimmermann\nBenjamin Strasser\nLinda Teuteberg\nJens
-                      Teutrine\nMichael Theurer\nStephan Thomae\nNico Tippelt\nManfred Todtenhausen\nDr.
-                      Florian Toncar\nDr. Andrew Ullmann\nGerald Ullrich\nJohannes Vogel (Olpe)\nSandra
-                      Weeser\nNicole Westig\nDr. Volker Wissing\nAfD\nCarolin Bachmann\nDr. Christina
-                      Baum\nDr. Bernd Baumann\nRoger Beckamp\nMarc Bernhard\nAndreas Bleck\nRené Bochmann\nPeter
-                      Boehringer\nGereon Bollmann\nDirk Brandes\nStephan Brandner\nJürgen Braun\nMarcus
-                      Bühl\nJoana Cotar\nDr. Gottfried Curio\nThomas Dietz\nThomas Ehrhorn\nDr. Michael
-                      Espendiller\nRobert Farle\nPeter Felser\nDietmar Friedhoff\nMarkus Frohnmaier\nDr.
-                      Götz Frömming\nDr. Alexander Gauland\nAlbrecht Glaser\nHannes Gnauck\nKay Gottschalk\nDeutscher
-                      Bundestag – 20. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 26. Oktober 2021
-                      \     29 \n(A) \n(B) \n(C) \n(D)\nMariana Iris Harder-Kühnel\nJochen Haug\nMartin
-                      Hess\nKarsten Hilse\nNicole Höchst\nLeif-Erik Holm\nJohannes Huber\nGerrit Huy\nFabian
-                      Jacobi\nSteffen Janich\nDr. Marc Jongen\nDr. Malte Kaufmann\nDr. Michael Kaufmann\nStefan
-                      Keuter\nNorbert Kleinwächter\nEnrico Komning\nJörn König\nSteffen Kotré\nDr. Rainer
-                      Kraft\nBarbara Lenk\nRüdiger Lucassen\nCorinna Miazga\nMike Moncsek\nMatthias Moosdorf\nSebastian
-                      Münzenmaier\nEdgar Naujok\nJan Ralf Nolte\nGerold Otten\nTobias Matthias Peterka\nStephan
-                      Protschka\nMartin Reichardt\nMartin Erwin Renner\nFrank Rinck\nBernd Schattner\nUlrike
-                      Schielke-Ziesing\nEugen Schmidt\nJan Wenzel Schmidt\nJörg Schneider\nUwe Schulz\nThomas
-                      Seitz\nMartin Sichert\nDr. Dirk Spaniel\nRené Springer\nKlaus Stöber\nBeatrix von
-                      Storch\nDr. Alice Weidel\nDr. Harald Weyel\nWolfgang Wiehle\nDr. Christian Wirth\nJoachim
-                      Wundrak\nKay-Uwe Ziegler\nDIE LINKE\nGökay Akbulut\nAli Al-Dailami\nDr. Dietmar
-                      Bartsch\nMatthias W. Birkwald\nSevim Dağdelen\nAnke Domscheit-Berg\nKlaus Ernst\nSusanne
-                      Ferschl\nNicole Gohlke\nChristian Görke\nAtes Gürpinar\nDr. Gregor Gysi\nDr. André
-                      Hahn\nSusanne Hennig-Wellsow\nKatja Kipping\nJan Korte\nIna Latendorf\nCaren Lay\nRalph
-                      Lenkert\nChristian Leye\nDr. Gesine Lötzsch\nThomas Lutze\nPascal Meiser\nAmira
-                      Mohamed Ali\nCornelia Möhring\nZaklin Nastic\nPetra Pau\nSören Pellmann\nVictor
-                      Perli\nHeidi Reichinnek\nMartina Renner\nBernd Riexinger\nDr. Petra Sitte\nJessica
-                      Tatti\nAlexander Ulrich\nKathrin Vogler\nDr. Sahra Wagenknecht\nJanine Wissler\nFraktionslos\nMatthias
-                      Helferich\nStefan Seidler\nAbgeordnete, die sich wegen gesetzlichen Mutterschutzes
-                      für ihre Abwesenheit entschuldigt haben, sind in der  \nListe der entschuldigten
-                      Abgeordneten (Anlage 1) aufgeführt.\nDeutscher Bundestag – 20. Wahlperiode – 1.
-                      Sitzung. Berlin, Dienstag, den 26. Oktober 202130 \n(A) \n(B) \n(C) \n(D) \nGesamtherstellung:
-                      H. Heenemann GmbH & Co. KG, Buch- und Offsetdruckerei, Bessemerstraße 83–91, 12103
-                      Berlin, www.heenemann-druck.de \nVertrieb: Bundesanzeiger Verlag GmbH, Postfach
-                      10 05 34, 50445 Köln, Telefon (02 21) 97 66 83 40, Fax (02 21) 97 66 83 44, www.betrifft-gesetze.de
-                      \nISSN 0722-8333"
-                    fundstelle:
-                      pdf_url: https://dserver.bundestag.de/btp/20/20001.pdf
-                      id: '5432'
-                      dokumentnummer: 20/1
-                      datum: '2021-10-26'
-                      verteildatum: '2021-10-27'
-                      dokumentart: Plenarprotokoll
-                      herausgeber: BT
-                      urheber: [ ]
-                  - id: '5431'
-                    dokumentart: Plenarprotokoll
-                    typ: Dokument
-                    dokumentnummer: '1009'
-                    wahlperiode: 19
-                    herausgeber: BR
-                    datum: '2021-10-08'
-                    titel: Protokoll der 1009. Sitzung des Bundesrates
-                    text: "Vertrieb: Bundesanzeiger Verlag GmbH, Postfach 10 05 34, 50445 Köln\nTelefon
-                      (02 21) 97 66 83 40, Fax (02 21) 97 66 83 44, www.betrifft-gesetze.de\nISSN 0720-7999\nPlenarprotokoll
-                      1009\nBUNDESRAT\nStenografischer Bericht\n1009. Sitzung\nBerlin, Freitag, den 8.
-                      Oktober 2021\nI n h a l t :\nZur Tagesordnung . . . . . . . . . . . . . . . . .
-                      . . . . 409\nRückblick des Präsidenten . . . . . . . . . . . . . . . 409\n1. Wahl
-                      des Präsidiums – gemäß Artikel 52 \nAbsatz 1 GG i.V.m. § 5 Absatz 1 GO BR – . 410\nBeschluss:
-                      Der Ministerpräsident des Landes \nThüringen, Bodo R a m e l o w , wird \nzum Präsidenten
-                      des Bundesrates gewählt.\nDer Ministerpräsident des Landes Sachsen-\nAnhalt, Dr.
-                      Reiner H a s e l o f f , und \nder Präsident des Senats der Freien und \nHansestadt
-                      Hamburg, Erster Bürgermeister \nDr. Peter T s c h e n t s c h e r , werden \nzu
-                      Vizepräsidenten gewählt . . . . . . . . . . . 411\n2. Wahl des Vorsitzenden und
-                      der stellver-\ntretenden Vorsitzenden der Europakam-\nmer – gemäß § 45c GO BR –
-                      . . . . . . . . . . . 411\nBeschluss: Es werden gewählt: Minister\nProf. Dr. Benjamin-Immanuel
-                      H o f f  \n(Thüringen) zum Vorsitzenden, Staatsmi-\nnister Rainer R o b r a  (Sachsen-Anhalt)
-                      \nund der Präsident des Senats der Freien und \nHansestadt Hamburg, Erster Bürgermeister
-                      \nDr. Peter T s c h e n t s c h e r , zu stell-\nvertretenden Vorsitzenden . . .
-                      . . . . . . . . . 411\n3. Wahl der Vorsitzenden der Ausschüsse –\ngemäß § 12 Absatz
-                      1 GO BR – (Drucksa-\nche 717/21) . . . . . . . . . . . . . . . . . . . . . . . .
-                      411\nBeschluss: Die Vorsitzenden der Ausschüsse \nwerden gemäß dem Antrag des Präsidenten
-                      \nin Drucksache 717/21 gewählt . . . . . . . . . 411\n4. Wahl der Schriftführer
-                      – gemäß § 10 Ab-\nsatz 1 GO BR – (Drucksache 718/21) . . . . . 411\nBeschluss: Staatsminister
-                      Georg E i s e n -\nr e i c h  (Bayern) und Staatsrat Dr. Olaf\nJ o a c h i m  (Bremen)
-                      werden gewählt . 412\n5. Entwurf eines Gesetzes zur Änderung des \nKaffeesteuergesetzes
-                      (KaffeeStÄndG) – ge-\nmäß Artikel 76 Absatz 1 GG – Antrag des \nLandes Schleswig-Holstein
-                      gemäß § 36 Ab-\nsatz 2 GO BR – (Drucksache 727/21) . . . . . 413\nMonika Heinold
-                      (Schleswig-Holstein) . 413\nMitteilung: Überweisung an den Finanzaus-\nschuss .
-                      . . . . . . . . . . . . . . . . . . . . . . . . . 414\n6. Entwurf eines ... Gesetzes
-                      zur Änderung des \nBundesmeldegesetzes – gemäß Artikel 76 \nAbsatz 1 GG – Antrag
-                      des Landes Nordrhein-\nWestfalen gemäß § 36 Absatz 2 GO BR –\n(Drucksache 728/21)
-                      . . . . . . . . . . . . . . . . . 414\nMitteilung: Überweisung an die zuständigen
-                      \nAusschüsse . . . . . . . . . . . . . . . . . . . . . . 414\n7. Entschließung des
-                      Bundesrates zur Ände-\nrung des Geldwäschegesetzes – Effektive \nBekämpfung der
-                      Geldwäsche gewährleisten –\nAntrag des Landes Berlin – (Drucksa-\nche 693/21) .
-                      . . . . . . . . . . . . . . . . . . . . . . . 414\nDr. Dirk Behrendt (Berlin) .
-                      . . . . . . . 414\nBeschluss: Die Entschließung wird nicht ge-\nfasst . . . . .
-                      . . . . . . . . . . . . . . . . . . . . . . 415\n8. Entschließung des Bundesrates
-                      „Inflations-\ngefahren rasch und entschlossen entgegen-\ntreten – für eine Politik
-                      des stabilen Geldes“\n– Antrag des Freistaates Bayern gemäß § 36 \nAbsatz 2 GO BR
-                      – (Drucksache 730/21) . . . 415\nDr. Florian Herrmann (Bayern) . . . . . 415\nII
-                      Bundesrat – 1009. Sitzung – 8. Oktober 2021\nMitteilung: Überweisung an die zuständigen
-                      \nAusschüsse . . . . . . . . . . . . . . . . . . . . . . 415\n9. Mitteilung der
-                      Kommission an das Europäi-\nsche Parlament und den Rat: Gestaltung der \nKonferenz
-                      zur Zukunft Europas\nCOM(2020) 27 final\n– gemäß §§ 3 und 5 EUZBLG –\n(Drucksache
-                      37/20) . . . . . . . . . . . . . . . . . . 412\nArmin Laschet (Nordrhein-Westfalen)
-                      . 412\nLucia Puttrich (Hessen) . . . . . . . . . . 429*\nBirgit Honé (Niedersachsen)
-                      . . . . . . . 429*\nBeschluss: Stellungnahme . . . . . . . . . . . . . 413\n10.
-                      Mitteilung der Kommission an das Europäi-\nsche Parlament, den Rat, den Europäischen
-                      \nWirtschafts- und Sozialausschuss und den \nAusschuss der Regionen\nBericht über
-                      die Rechtsstaatlichkeit 2021\nDie Lage der Rechtsstaatlichkeit in der \nEuropäischen
-                      Union\nCOM(2021) 700 final\n– gemäß §§ 3 und 5 EUZBLG –\n(Drucksache 618/21) . .
-                      . . . . . . . . . . . . . . . 416\nDr. Klaus Lederer (Berlin) . . . . . . . . .
-                      416\nDr. Stephan Holthoff-Pförtner (Nord-\nrhein-Westfalen) . . . . . . . . . .
-                      . . . 418\nBirgit Honé (Niedersachsen) . . . . . . . 419\nKatja Meier (Sachsen)
-                      . . . . . . . . . . . 420\nBeschluss: Stellungnahme . . . . . . . . . . . . . 422\n11.
-                      Mitteilung der Kommission an das Europäi-\nsche Parlament, den Rat, den Europäischen
-                      \nWirtschafts- und Sozialausschuss und den \nAusschuss der Regionen \nFörderung
-                      eines europäischen Konzepts \nfür künstliche Intelligenz\nCOM(2021) 205 final\n–
-                      gemäß §§ 3 und 5 EUZBLG –\n(Drucksache 561/21) . . . . . . . . . . . . . . . . .
-                      422\nBeschluss: Stellungnahme . . . . . . . . . . . . . 431*\n12. Vorschlag für
-                      eine Verordnung des Europäi-\nschen Parlaments und des Rates über die all-\ngemeine
-                      Produktsicherheit, zur Änderung \nder Verordnung (EU) Nr. 1025/2012 des Eu-\nropäischen
-                      Parlaments und des Rates sowie \nzur Aufhebung der Richtlinie 87/357/EWG \ndes Rates
-                      und der Richtlinie 2001/95/EG des \nEuropäischen Parlaments und des Rates\nCOM(2021)
-                      346 final\n– gemäß Artikel 12 Buchstabe b EUV und \n§§ 3 und 5 EUZBLG –\n(Drucksache
-                      646/21, zu Drucksache 646/21) 422\nBeschluss: Stellungnahme gemäß §§ 3 und 5 \nEUZBLG
-                      . . . . . . . . . . . . . . . . . . . . . . . 423\n13. Vorschlag für eine Verordnung
-                      des Europäi-\nschen Parlaments und des Rates über europä-\nische grüne Anleihen\nCOM(2021)
-                      391 final\n– gemäß Artikel 12 Buchstabe b EUV und \n§§ 3 und 5 EUZBLG –\n(Drucksache
-                      637/21, zu Drucksache 637/21) 423\nBeschluss: Stellungnahme gemäß §§ 3 und 5 \nEUZBLG
-                      . . . . . . . . . . . . . . . . . . . . . . . 423\n14. Vorschlag für eine Richtlinie
-                      des Europäi-\nschen Parlaments und des Rates zur Ände-\nrung der Richtlinien 2013/34/EU,
-                      \n2004/109/EG und 2006/43/EG und der Ver-\nordnung (EU) Nr. 537/2014 hinsichtlich
-                      der \nNachhaltigkeitsberichterstattung von Un-\nternehmen\nCOM(2021) 189 final\n–
-                      gemäß §§ 3 und 5 EUZBLG –\n(Drucksache 548/21, zu Drucksache 548/21) 423\nBeschluss:
-                      Stellungnahme . . . . . . . . . . . . . 424\n15. Verordnung zur Änderung der Wahlord-\nnung,
-                      der Wahlordnung Seeschifffahrt und \nder Verordnung zur Durchführung der Be-\ntriebsratswahlen
-                      bei den Postunternehmen\n(Drucksache 666/21) . . . . . . . . . . . . . . . . . 422\nBeschluss:
-                      Zustimmung gemäß Artikel 80 \nAbsatz 2 GG . . . . . . . . . . . . . . . . . . .
-                      . . 431*\n16. Verordnung zur Bestimmung des für die \nFortschreibung der Regelbedarfsstufen
-                      nach \n§ 28a und des Teilbetrags nach § 34 Ab-\nsatz 3a Satz 1 des Zwölften Buches
-                      Sozialge-\nsetzbuch maßgeblichen Prozentsatzes sowie \nzur Ergänzung der Anlagen
-                      zu §§ 28 und 34 \ndes Zwölften Buches Sozialgesetzbuch für \ndas Jahr 2022 (Regelbedarfsstufen-Fort-\nschreibungsverordnung
-                      2022 – RBSFV \n2022) (Drucksache 719/21) . . . . . . . . . . . . 422\nProf. Dr.
-                      Benjamin-Immanuel Hoff (Thü-\nringen) . . . . . . . . . . . . . . . . . . 432*\nBeschluss:
-                      Zustimmung gemäß Artikel 80 \nAbsatz 2 GG . . . . . . . . . . . . . . . . . . .
-                      . . 431*\n17. Verordnung zur Änderung der Landwirt-\nschaftserzeugnisse-Schulprogramm-Teil-\nnahmeverordnung
-                      (Drucksache 653/21) . . 424\nBeschluss: Zustimmung gemäß Artikel 80 \nAbsatz 2 GG
-                      – Annahme einer Entschlie-\nßung . . . . . . . . . . . . . . . . . . . . . . . .
-                      . . . 424\nBundesrat – 1009. Sitzung – 8. Oktober 2021 III\n18. Verordnung zur Änderung
-                      der Zweiten Ver-\nordnung zur Änderung der InVeKoS-\nVerordnung (Drucksache 654/21)
-                      . . . . . . . 422\nBeschluss: Zustimmung gemäß Artikel 80 \nAbsatz 2 GG . . . .
-                      . . . . . . . . . . . . . . . . . 431*\n19. Verordnung zur Anpassung nationaler
-                      \nRechtsvorschriften an unionsrechtliche Vor-\nschriften über Aromen und Aromen
-                      ent-\nhaltende Lebensmittel (Drucksache 656/21) 422\nBeschluss: Zustimmung gemäß
-                      Artikel 80 \nAbsatz 2 GG nach Maßgabe der beschlos-\nsenen Änderung . . . . . .
-                      . . . . . . . . . . . . . 431*\n20. Verordnung zur Stärkung der Organisationen \nund
-                      Lieferketten im Agrarbereich (Agrar-\norganisationen-und-Lieferketten-Verord-\nnung
-                      – AgrarOLkV) (Drucksache 667/21) . . 422\nBeschluss: Zustimmung gemäß Artikel 80
-                      \nAbsatz 2 GG . . . . . . . . . . . . . . . . . . . . . 431*\n21. Zweite Verordnung
-                      zur Änderung der Di-\nrektzahlungen-Durchführungsverordnung\n(Drucksache 668/21)
-                      . . . . . . . . . . . . . . . . . 422\nBeschluss: Zustimmung gemäß Artikel 80 \nAbsatz
-                      2 GG . . . . . . . . . . . . . . . . . . . . . 431*\n22. Erste Verordnung zur Änderung
-                      der Buß-\ngeldkatalog-Verordnung (Drucksache \n687/21) . . . . . . . . . . . . .
-                      . . . . . . . . . . . . . . 424\nWinfried Hermann (Baden-Württemberg) 424\nDr. Bernd
-                      Buchholz (Schleswig-Holstein) 425\nDr. Maike Schaefer (Bremen) . . . . . . . 426\nBeschluss:
-                      Zustimmung gemäß Artikel 80 \nAbsatz 2 GG – Annahme einer Entschlie-\nßung . . .
-                      . . . . . . . . . . . . . . . . . . . . . . . . 427\n23. Verordnung zur Änderung
-                      der Kehr- und \nÜberprüfungsordnung und weiterer Vor-\nschriften (Drucksache 658/21)
-                      . . . . . . . . . . 422\nBeschluss: Zustimmung gemäß Artikel 80 \nAbsatz 2 GG .
-                      . . . . . . . . . . . . . . . . . . . . 431*\n24. Verordnung zur Novellierung der
-                      Preisanga-\nbenverordnung (Drucksache 669/21) . . . . . 427\nBeschluss: Zustimmung
-                      gemäß Artikel 80 \nAbsatz 2 GG nach Maßgabe der beschlos-\nsenen Änderungen – Annahme
-                      einer Ent-\nschließung . . . . . . . . . . . . . . . . . . . . . . . 427\n25. Verordnung
-                      zur Änderung der Niederdruck-\nanschlussverordnung (Drucksache 670/21) 422\nBeschluss:
-                      Zustimmung gemäß Artikel 80 \nAbsatz 2 GG – Annahme einer Entschlie-\nßung . . .
-                      . . . . . . . . . . . . . . . . . . . . . . . . 431*\n26. Bestellung eines Mitglieds
-                      des Verwaltungs-\nrates der Kreditanstalt für Wiederaufbau\n– gemäß § 7 Absatz 1
-                      Nummer 3 und Ab-\nsatz 2 KredAnstWiAG – (Drucksache 692/21) 422\nBeschluss: Zustimmung
-                      zu der Empfehlung \nin Drucksache 692/1/21 . . . . . . . . . . . . . 431*\n27. Benennung
-                      eines Mitglieds für den Beirat \nDeutschlandstipendium beim Bundesminis-\nterium
-                      für Bildung und Forschung – gemäß \n§ 12 StipG i.V.m. § 5 Absatz 1 Satz 2 Num-\nmer
-                      3 StipV – (Drucksache 673/21) . . . . . . 422\nBeschluss: Zustimmung zu der Empfehlung\nin
-                      Drucksache 673/1/21 . . . . . . . . . . . . . 431*\n28. Benennung eines stellvertretenden
-                      Mitglieds \nfür den Beirat der Bundesnetzagentur für \nElektrizität, Gas, Telekommunikation,
-                      \nPost und Eisenbahnen – gemäß § 5 \nBEGTPG – Antrag des Landes Rheinland-\nPfalz
-                      gemäß § 36 Absatz 2 GO BR – (Druck-\nsache 742/21) . . . . . . . . . . . . . . .
-                      . . . . . . . 422\nBeschluss: Zustimmung zu dem Vorschlag in \nDrucksache 742/21
-                      . . . . . . . . . . . . . . . . 431*\n29. Entschließung des Bunderates „Beschleuni-\ngung
-                      der Energieinfrastrukturzulassungs-\nverfahren für einen klimaresilienten Wie-\nderaufbau
-                      nach größeren Schadensla-\ngen“ – Antrag der Länder Nordrhein-\nWestfalen, Rheinland-Pfalz
-                      gemäß § 36 Ab-\nsatz 2 GO BR – (Drucksache 756/21) . . . . . 427\nDr. Stephan Holthoff-Pförtner
-                      (Nord-\nrhein-Westfalen) . . . . . . . . . . . . 432*\nMitteilung: Überweisung an
-                      die zuständigen \nAusschüsse . . . . . . . . . . . . . . . . . . . . . . 427\nNächste
-                      Sitzung . . . . . . . . . . . . . . . . . . . . . . . 427\nBeschlüsse im vereinfachten
-                      Verfahren gemäß \n§ 35 GO BR . . . . . . . . . . . . . . . . . . . . . . . . . .
-                      428\nFeststellung gemäß § 34 GO BR . . . . . . . . . . . 428\nIV Bundesrat – 1009.
-                      Sitzung – 8. Oktober 2021\nVerzeichnis der Anwesenden\nV o r s i t z :\nPräsident
-                      D r .  R e i n e r  H a s e l o f f , Minis-\nterpräsident des Landes Sachsen-Anhalt\nS
-                      c h r i f t f ü h r e r :\nGeorg Eisenreich (Bayern)\nB a d e n - W ü r t t e m
-                      b e r g :\nWinfried Kretschmann, Ministerpräsident\nWinfried Hermann, Minister für
-                      Verkehr\nRudolf Hoogvliet, Staatssekretär für Medienpolitik \nund Bevollmächtigter
-                      des Landes Baden-\nWürttemberg beim Bund\nB a y e r n :\nDr. Florian Herrmann, Leiter
-                      der Staatskanzlei und \nStaatsminister für Bundesangelegenheiten und \nMedien\nGeorg
-                      Eisenreich, Staatsminister der Justiz\nB e r l i n :\nDr. Klaus Lederer, Bürgermeister
-                      und Senator für \nKultur und Europa\nDilek Kalayci, Senatorin für Gesundheit, Pflege
-                      und \nGleichstellung\nDr. Dirk Behrendt, Senator für Justiz, Verbraucher-\nschutz
-                      und Antidiskriminierung\nB r a n d e n b u r g :\nDr. Dietmar Woidke, Ministerpräsident\nKatrin
-                      Lange, Ministerin der Finanzen und für\nEuropa\nB r e m e n :\nDr. Maike Schaefer,
-                      Bürgermeisterin, Senatorin für \nKlimaschutz, Umwelt, Mobilität, Stadtentwick-\nlung
-                      und Wohnungsbau\nDr. Olaf Joachim, Staatsrat, Bevollmächtigter der \nFreien Hansestadt
-                      Bremen beim Bund\nH a m b u r g :\nDr. Andreas Dressel, Senator, Präses der Finanz-\nbehörde\nDr.
-                      Dorothee Stapelfeldt, Senatorin, Präses der \nBehörde für Stadtentwicklung und Wohnen\nH
-                      e s s e n :\nVolker Bouffier, Ministerpräsident\nLucia Puttrich, Ministerin für
-                      Bundes- und Europa-\nangelegenheiten und Bevollmächtigte des Landes \nHessen beim
-                      Bund\nTarek Al-Wazir, Minister für Wirtschaft, Energie, \nVerkehr und Wohnen\nM
-                      e c k l e n b u r g - V o r p o m m e r n :\nBettina Martin, Ministerin für Bildung,
-                      Wissenschaft \nund Kultur\nHarry Glawe, Minister für Wirtschaft, Arbeit und \nGesundheit\nN
-                      i e d e r s a c h s e n :\nStephan Weil, Ministerpräsident\nDr. Bernd Althusmann,
-                      Minister für Wirtschaft,\nArbeit, Verkehr und Digitalisierung\nReinhold Hilbers,
-                      Finanzminister\nBirgit Honé, Ministerin für Bundes- und Europaan-\ngelegenheiten
-                      und Regionale Entwicklung, \nBevollmächtigte des Landes Niedersachsen beim \nBund\nBoris
-                      Pistorius, Minister für Inneres und Sport\nBundesrat – 1009. Sitzung – 8. Oktober
-                      2021 V\nN o r d r h e i n - W e s t f a l e n :\nArmin Laschet, Ministerpräsident\nDr.
-                      Joachim Stamp, Minister für Kinder, Familie, \nFlüchtlinge und Integration\nDr.
-                      Stephan Holthoff-Pförtner, Minister für Bundes-\nund Europaangelegenheiten sowie
-                      Internationales \nim Geschäftsbereich des Ministerpräsidenten\nR h e i n l a n d
-                      - P f a l z :\nDr. Stefanie Hubig, Ministerin für Bildung\nS a a r l a n d :\nTobias
-                      Hans, Ministerpräsident\nAnke Rehlinger, Ministerin für Wirtschaft, Arbeit, \nEnergie
-                      und Verkehr\nHenrik Eitel, Staatssekretär, Chef der Staatskanzlei \nund Bevollmächtigter
-                      des Saarlandes beim Bund\nS a c h s e n :\nMartin Dulig, Staatsminister für Wirtschaft,
-                      Arbeit \nund Verkehr\nKatja Meier, Staatsministerin der Justiz und für\nDemokratie,
-                      Europa und Gleichstellung\nS a c h s e n - A n h a l t :\nDr. Reiner Haseloff, Ministerpräsident\nDr.
-                      Lydia Hüskens, Ministerin für Infrastruktur und \nDigitales\nProf. Dr. Armin Willingmann,
-                      Minister für Wissen-\nschaft, Energie, Klimaschutz und Umwelt\nS c h l e s w i g
-                      - H o l s t e i n :\nDaniel Günther, Ministerpräsident\nMonika Heinold, Finanzministerin\nDr.
-                      Bernd Buchholz, Minister für Wirtschaft, Ver-\nkehr, Arbeit, Technologie und Tourismus\nT
-                      h ü r i n g e n :\nBodo Ramelow, Ministerpräsident\nAnja Siegesmund, Ministerin
-                      für Umwelt, Energie \nund Naturschutz\nProf. Dr. Benjamin-Immanuel Hoff, Minister
-                      für \nKultur, Bundes- und Europaangelegenheiten und \nChef der Staatskanzlei\nV
-                      o n  d e r  B u n d e s r e g i e r u n g :\nDr. Hendrik Hoppenstedt, Staatsminister
-                      bei der \nBundeskanzlerin\nSarah Ryglewski, Parl. Staatssekretärin beim Bun-\ndesminister
-                      der Finanzen\nSteffen Bilger, Parl. Staatssekretär beim Bundesmi-\nnister für Verkehr
-                      und digitale Infrastruktur\nMiguel Berger, Staatssekretär des Auswärtigen \nAmtes\n\nBundesrat
-                      – 1009. Sitzung – 8. Oktober 2021 409\n1009. Sitzung\nBerlin, den 8. Oktober 2021\nBeginn:
-                      09.31 Uhr\nPräsident Dr. Reiner Haseloff: Meine sehr geehr-\nten Damen und Herren,
-                      liebe Kolleginnen und Kollegen, \nich eröffne die 1009. Sitzung des Bundesrates.
-                      \nZur Tagesordnung: Sie liegt Ihnen in vorläufiger \nForm mit 29 Punkten vor.\nZur
-                      Reihenfolge: Nach TOP 4 wird TOP 9 aufgerufen. \nIm Übrigen bleibt die Reihenfolge
-                      unverändert. \nGibt es Wortmeldungen zur Tagesordnung? – Das se-\nhe ich nicht.\nDann
-                      ist diese so festgestellt. \nSehr geehrte Damen und Herren, liebe Kolleginnen \nund
-                      Kollegen, die Zeit flieht. In wenigen Wochen endet \ndie Bundesratspräsidentschaft
-                      Sachsen-Anhalts. Die \nPräsidentschaft war mir Ehre und Verpflichtung zugleich.
-                      \nDie Präsidentschaft war mir nicht nur Ehre, sie war auch \neine große Freude.\nIch
-                      möchte allen Mitarbeiterinnen und Mitarbeitern \nder Bundesratsverwaltung herzlich
-                      danken. Sie waren ein \ntolles Team und haben mir die Arbeit sehr leicht ge-\nmacht.
-                      Dabei war es in mehrfacher Hinsicht ein unge-\nwöhnliches und sehr intensives Jahr.
-                      Vor allem die \nCorona-Pandemie hat die zurückliegenden Monate sehr \ngeprägt und
-                      unsere Arbeit stark beeinflusst. Mehrfach \ntrafen wir uns deshalb zu Sondersitzungen.\nMittlerweile
-                      haben wir gelernt, mit der Pandemie zu \nleben und sie gleichzeitig zurückzudrängen.
-                      Dennoch \nmüssen wir weiter vorsichtig und umsichtig sein. Die \nallermeisten Menschen
-                      in unserem Land haben sich sehr \nverantwortungsbewusst und rücksichtsvoll verhalten,
-                      \nweder sich noch ihre Mitmenschen gefährdet und großes \nVerständnis für die getroffenen
-                      und mitunter schmerzhaf-\nten Maßnahmen gezeigt. Die überwältigende Mehrheit \nunserer
-                      Bevölkerung hat durch konkrete Handlungen eine \nbeeindruckende Solidarität bewiesen.
-                      Dafür danke ich \nallen Mitbürgerinnen und Mitbürgern ganz herzlich. \nEinen ganz
-                      besonderen Dank möchte ich an alle im Ge-\nsundheitswesen Beschäftigten richten.
-                      Ohne ihre Ein-\nsatzbereitschaft, ohne ihre Umsicht und ohne ihr Pflicht-\ngefühl
-                      hätte die Pandemie nicht so erfolgreich einge-\ndämmt werden können.\nAuch die Hochwasserkatastrophe
-                      im Sommer hat un-\nser Land vor große Herausforderungen gestellt. In einer \nSondersitzung
-                      im September haben wir wenige Tage \nnach dem Bundestag den Hilfsfonds für die Geschädigten
-                      \nder Flutkatastrophe gebilligt und dem Aufbauhilfegesetz \n2021 zugestimmt. Viele
-                      Betroffene haben das als ein \nhoffnungsvolles und ermutigendes Signal verstanden.
-                      \nUnd genau das sollte es auch sein. Bund und Länder \nhaben gemeinsam schnell und
-                      effizient gehandelt. Unsere \npolitischen Strukturen sind krisentauglich.\nDer Föderalismus
-                      ist aber mehr als nur ein Ordnungs-\nprinzip. Er ist einer der zentralen Bausteine
-                      unserer De-\nmokratie. Denn er stellt auch einen wirksamen Schutz vor \neiner Gefährdung
-                      der Demokratie durch einseitige \nMachtausübung dar. Freiheit ist ein Wesenskern
-                      des \nFöderalismus. Zentralisierung hingegen, so hat es einmal \nThomas N i p p
-                      e r d e y formuliert, bedeutet „die Er-\nfahrung von Anonymität, Entfremdung, Heimatlosigkeit,
-                      \nIdentitätsverlust, Instabilität, Nicht-Funktionieren“.\nAber unsere Freiheit und
-                      unser föderales System sind \nkeine Selbstläufer. Wir beobachten in letzter Zeit
-                      einen \nschwindenden Respekt gegenüber demokratischen Nor-\nmen und Institutionen.
-                      Zudem erleben wir eine Verro-\nhung der politischen und gesellschaftlichen Sitten.
-                      Ras-\nsismus und Diskriminierung sind zu einem ernsthaften \nProblem geworden. Die
-                      Schwelle zur Gewaltbereitschaft \nnimmt immer mehr ab. Ein 20-Jähriger weist auf
-                      die \nMaskenpflicht hin und wird erschossen. Und in den sozi-\nalen Netzwerken wird
-                      dieser entsetzliche Mord auch \nnoch von manchen hämisch kommentiert.\nWas läuft
-                      in Teilen unserer Gesellschaft schief? Wie \ndünn ist der Firnis unserer Zivilisation
-                      eigentlich? Zur \nTagesordnung können wir jetzt keinesfalls übergehen. \nDenn für
-                      unser Gemeinwesen sind wir alle verantwort-\n410 Bundesrat – 1009. Sitzung – 8.
-                      Oktober 2021\nlich. Der US-amerikanische Soziologe Amitai E t z i -\no n i prägte
-                      1996 den Begriff der „Verantwortungsge-\nsellschaft“. Sie verlangt vom Einzelnen
-                      nicht nur mehr \nVerantwortung für sich selbst, sondern auch für die All-\ngemeinheit.
-                      Wir alle müssen für eine offene Gesellschaft \neintreten. Jeden Tag aufs Neue und
-                      mit großer Entschie-\ndenheit. Zivilcourage ist gefragt. Hass und Hetze dürfen \nin
-                      unserer Gesellschaft keinen Platz haben. Es muss \nvielmehr ein Klima der Toleranz
-                      und des gegenseitigen \nRespekts herrschen. Nur dann können Menschen unter-\nschiedlicher
-                      Kulturen und Religionen in Frieden mitei-\nnander leben.\nAuf dieser Grundlage wollen
-                      wir weiter „gemeinsam \nZukunft formen“. Das Motto unserer Bundesratspräsi-\ndentschaft
-                      gilt über den Tag hinaus. Dabei verfügen wir \nüber gute Gestaltungsmöglichkeiten
-                      und Perspektiven. \nUnser Land ist pluralistisch, weltoffen und für die Her-\nausforderungen
-                      der Zukunft gut aufgestellt. Das haben \nauch die Feierlichkeiten zum Tag der Deutschen
-                      Einheit \nam letzten Wochenende in Halle an der Saale gezeigt. \nNeu waren in diesem
-                      Jahr die 32 Einheitsbotschafterin-\nnen und -botschafter. Gemeinsam repräsentierten
-                      sie die \ngroßen Stärken unseres Föderalismus: die Vielfalt in der \nEinheit.\nIn
-                      meine Amtszeit fiel auch die 1000. Sitzung des \nBundesrates. Unsere Demokratie
-                      lebt auch von starken \nund selbstbewussten Institutionen. Zu ihnen gehört seit
-                      \nmehr als sieben Jahrzehnten der Bundesrat. Der Bundes-\npräsident hat in seiner
-                      Ansprache im Bundesrat zu Recht \ndarauf hingewiesen. Die Bedeutung des Bundesrates
-                      und \nseine Rolle in der innerstaatlichen Willensbildung und im \nSystem der Gewaltenteilung
-                      sind anerkannt und unbe-\nstritten. Der Föderalismus in unserem Land ist zu einer
-                      \nlebendigen und selbstverständlichen Realität geworden. \nDas föderale Prinzip
-                      hat sehr viel zur Erfolgsgeschichte \nder Bundesrepublik Deutschland beigetragen,
-                      und diese \nErfolgsgeschichte wollen wir weiter fortschreiben. Denn \ndas Projekt
-                      des demokratischen Verfassungsstaates ist nie \nabgeschlossen. Auch der Föderalismus
-                      kennt als dynami-\nsches System keine Finalität. Er musste sich in der Ver-\ngangenheit
-                      wechselnden Gegebenheiten anpassen, und er \nwird es auch zukünftig tun müssen.\nAuch
-                      die Geschichte der europäischen Integration ist \nseit ihren Anfängen von föderalen
-                      Ideen geprägt. Und \nmehr denn je gilt: Nur eine starke und handlungsfähige \nEU
-                      kann den globalen Herausforderungen des 21. Jahr-\nhunderts gerecht werden und ihre
-                      Werte sowie Interessen \ninternational vertreten. Nur gemeinsam erhalten wir unse-\nre
-                      Handlungsfähigkeit.\nDeshalb sind die internationalen Kontakte während ei-\nner
-                      Bundesratspräsidentschaft enorm wichtig. Gestern \nAbend bin ich aus Rom zurückgekehrt.
-                      Dort war ich zur \nEröffnung der 7. Konferenz der Präsidentinnen und Prä-\nsidenten
-                      der Parlamente der G20-Staaten – endlich wie-\nder in Präsenz. Coronabedingt sind
-                      meine Auslandsreisen \nals Bundesratspräsident allerdings überschaubar gewesen.
-                      \nIch hoffe, dass wieder mehr Normalität einkehrt und wir \ndie Pandemie schrittweise
-                      völlig überwinden.\nIch wünsche dem Freistaat Thüringen – turnusmäßig \ndem Land
-                      Sachsen-Anhalt folgend – viel Erfolg bei der \nWahrnehmung der Aufgaben der Bundesratspräsident-\nschaft.\n(Beifall)\nWir
-                      kommen zu Tagesordnungspunkt 1:\nTOP 1\nWahl des Präsidiums\nNach dem vereinbarten
-                      Turnus schlage ich Ihnen für \ndas am 1. November 2021 beginnende neue Geschäfts-\njahr
-                      vor, den Ministerpräsidenten des Freistaats Thürin-\ngen, Herrn Bodo Ramelow, zum
-                      Präsidenten des Bundes-\nrates zu wählen. \nÜber die Wahl des Präsidenten wird nach
-                      unserer Pra-\nxis durch Aufruf der Länder abgestimmt. Ich bitte, die \nLänder aufzurufen,
-                      und damit also den Schriftführer um \nsein entsprechendes Abarbeiten der Punkte,
-                      die jetzt \nnotwendig sind. – Bitte schön.\nGeorg Eisenreich (Bayern), Schriftführer:\nBaden-Württemberg
-                      Ja\nBayern Ja\nBerlin Ja\nBrandenburg Ja\nBremen Ja\nHamburg Ja\nHessen Ja\nMecklenburg-Vorpommern
-                      Ja\nNiedersachsen Ja\nNordrhein-Westfalen Ja\nRheinland-Pfalz Ja\nSaarland Ja\nSachsen
-                      Ja\nSachsen-Anhalt Ja\nSchleswig-Holstein Ja\nThüringen Ja\nBundesrat – 1009. Sitzung
-                      – 8. Oktober 2021 411\nPräsident Dr. Reiner Haseloff: Demnach kann ich \nfeststellen,
-                      dass Herr Ministerpräsident Bodo R a m e -\nl o w für das Geschäftsjahr 2021/2022
-                      einstimmig zum \nPräsidenten des Bundesrates gewählt ist. \nHerr Ministerpräsident,
-                      ich frage Sie: Nehmen Sie die \nWahl an? \nBodo Ramelow (Thüringen): Ja.\nPräsident
-                      Dr. Reiner Haseloff: Dann darf ich \nIhnen, Herr Kollege Ramelow, die Glückwünsche
-                      des \ngesamten Hauses aussprechen und Sie nach vorne bitten. \n(Beifall – Übergabe
-                      des Staffelstabs und kurzer \nFototermin im Halbrund)\nDer Stab war jetzt zunächst
-                      nur zum Testen und An-\nfühlen da, denn bis zum 31. Oktober muss ich ihn noch in
-                      \nder Hand behalten. \n(Heiterkeit)\nDann werden wir die Übergabe noch einmal persön-\nlich
-                      machen. Wie gesagt, das ist die letzte Sitzung vor \ndem Wechsel. Ich denke, das
-                      haben wir jetzt alles ord-\nnungsgemäß gemacht. – Alles Gute, eine glückliche \nHand!\nWir
-                      werden sehen, wer jetzt mit ins Präsidium gewählt \nwird und dann weiterhin flankierend
-                      hilft. \nSehr geehrte Damen und Herren, dann kommen wir \nzur Wahl der Vizepräsidenten.
-                      \nNach dem verabredeten Turnus schlage ich Ihnen zur \nWahl vor: zum Ersten Vizepräsidenten
-                      den Präsidenten \ndes laufenden Geschäftsjahres und zum Zweiten Vize-\npräsidenten
-                      den Ersten Bürgermeister der Freien und \nHansestadt Hamburg, Herrn Dr. Peter T
-                      s c h e n t -\ns c h e r . \nMit Ihrem Einverständnis lasse ich über diese Vor-\nschläge
-                      gemeinsam abstimmen. Wer zustimmen möchte, \nden bitte ich um das Handzeichen. –
-                      69 Stimmen; ein-\nstimmig. \nDie Vorschläge sind damit einstimmig angenom-\nmen,
-                      die Wahl so protokolliert.\nHerr Dr. Tschentscher hat signalisiert, dass er die
-                      \nWahl annimmt.\nDr. Dorothee Stapelfeldt (Hamburg): Herr Präsi-\ndent, ich kann
-                      Ihnen mitteilen, dass der Erste Bürger-\nmeister mich ermächtigt hat, mitzuteilen,
-                      dass er die \nWahl annimmt. \nPräsident Dr. Reiner Haseloff: Da Sie dabei die \nSchwurhand
-                      gehoben haben, können wir das so zu Proto-\nkoll nehmen. \nIch nehme diese Wahl
-                      ebenfalls an, sodass Kollege \nRamelow im Weiteren auf uns zählen kann. In diesem
-                      \nSinne sind wir arbeitsfähig und treten dann in dieser \nMannschaft ab 1. November
-                      gemeinsam an. \nDann haben wir diesen wichtigen Tagesordnungspunkt \nerledigt. Den
-                      Staffelstab lassen wir hier im Bundesrat, \nund er kann dann bei der weiteren Arbeit
-                      immer gehoben \nwerden. \nWir kommen zu Tagesordnungspunkt 2:\nTOP 2\nWahl des Vorsitzenden
-                      und der stellvertretenden \nVorsitzenden der Europakammer\nDie Länder, deren Regierungschefs
-                      das Präsidium des \nBundesrats bilden, stellen in gleicher Reihenfolge den \nVorsitzenden
-                      der Europakammer und seine zwei Stellver-\ntreter. \nDementsprechend schlage ich
-                      Ihnen vor, Herrn Minis-\nter Prof. Dr. Benjamin-Immanuel H o f f (Thüringen) \nzum
-                      Vorsitzenden, Herrn Staatsminister Rainer R o b -\nr a (Sachsen-Anhalt) zum ersten
-                      stellvertretenden \nVorsitzenden und Herrn Ersten Bürgermeister Dr. Peter \nT s
-                      c h e n t s c h e r (Hamburg) zum zweiten stellver-\ntretenden Vorsitzenden der
-                      Europakammer für das \nGeschäftsjahr 2021/2022 zu wählen. \nWer diesem Vorschlag
-                      zustimmt, den bitte ich um das \nHandzeichen. – 69 Stimmen und damit ein klares
-                      Votum. \nDamit sind der Vorsitzende der Europakammer und \nseine zwei Stellvertreter
-                      einstimmig gewählt. \nWir kommen zu Tagesordnungspunkt 3:\nTOP 3\nWahl der Vorsitzenden
-                      der Ausschüsse (Drucksa-\nche 717/21)\nFür diese Wahl liegt Ihnen der Antrag des
-                      Präsiden-\nten vor.\nWer diesem Antrag zustimmen möchte, den bitte ich \num das
-                      Handzeichen. – 69 Stimmen; ebenfalls einstim-\nmig. \nDann ist das so beschlossen.
-                      \nWir kommen zu Tagesordnungspunkt 4:\nTOP 4\nWahl der Schriftführer (Drucksache
-                      718/21)\nIch schlage vor, für das Geschäftsjahr 2021/2022 \nHerrn Staatsminister
-                      Georg E i s e n r e i c h (Bayern) \nund Herrn Staatsrat Dr. Olaf J o a c h i m
-                      (Bremen) als \nSchriftführer zu wählen. \nWer diesem Vorschlag zustimmt, den bitte
-                      ich um das \nHandzeichen. – Ebenfalls einstimmig. \n412 Bundesrat – 1009. Sitzung
-                      – 8. Oktober 2021\nDamit haben wir auch die Schriftführer gewählt. \nWir treten
-                      in die reguläre Tagesordnung der Arbeits-\npunkte ein. \nWir kommen zu Tagesordnungspunkt
-                      9:\nTOP 9\nMitteilung der Kommission an das Europäische Par-\nlament und den Rat:
-                      Gestaltung der Konferenz zur \nZukunft Europas\nCOM(2020) 27 final\n(Drucksache
-                      37/20)\nEs liegt eine Wortmeldung vor: Herr Ministerpräsident \nLaschet aus Nordrhein-Westfalen.\nArmin
-                      Laschet (Nordrhein-Westfalen): Herr Präsi-\ndent! Liebe Kolleginnen und Kollegen!
-                      Die Mitteilung \nder Kommission „Gestaltung der Konferenz zur Zukunft \nEuropas“,
-                      an der auch der Bundesrat beteiligt sein wird, \ngibt die Gelegenheit, auch einmal
-                      aus Sicht der Länder \neinige Bemerkungen über die Zukunft Europas zu ma-\nchen.
-                      Wer über die Zukunft Europas spricht, braucht \nGeschichtsbewusstsein, und – Herr
-                      Präsident – wir haben \ngerade in Halle an der Saale am Tag der Deutschen Ein-\nheit
-                      erlebt, was nach 31 Jahren deutscher Einheit immer \nnoch offen ist, aber auch,
-                      was in dieser Zeit bewegt wor-\nden ist. Die Bilder von 1989 und 1990, diese unbändige
-                      \nKraft der Hoffnung, des Glücks, der Sehnsucht nach \nFreiheit, der Wunsch, diese
-                      unnatürliche Teilung des \nKontinents zu überwinden – das hat uns alle bewegt. \nJedes
-                      Mal, wenn wir diese Bilder an solchen Gedenkta-\ngen sehen, ist es wieder wach –
-                      in Polen, in Ungarn, auch \nin Leipzig, Dresden und im damaligen Ostberlin.\nEuropa
-                      war geistesgeschichtlich immer der Raum, der \nden einzelnen Menschen in den Mittelpunkt
-                      stellte, die \nPerson und das Subjekt, jemanden, nicht etwas – mit \nunverfügbarer
-                      Würde ausgestattet, eigenverantwortlich \nhandelnd, aufgehoben in der Gemeinschaft
-                      und im Ge-\nmeinwesen. Das Gegenteil waren die Mauern, die Wach-\ntürme und die
-                      Todeszonen. Direkt hier, auf der anderen \nSeite des Bundesratsgebäudes, wird man
-                      jedes Mal, wenn \nman in dieses Gebäude kommt, daran erinnert, was das \nFalsche
-                      war, das Gescheiterte. Das Kollektiv, die Volks-\ndemokratie – alles Namen für die
-                      Verschleierung von \nDiktatur und totalitärem Herrschaftssystem.\nDie große Frage
-                      ist jetzt – und deshalb hat die Präsi-\ndentin der Europäischen Kommission diese
-                      Konferenz \neinberufen –: Warum stehen wir heute eigentlich an ei-\nnem Punkt, an
-                      dem dieses Europa von vielen wieder \ninfrage gestellt wird? Eigentlich hätte man
-                      doch nach den \nErfahrungen von 1990 sagen müssen: Jetzt ist der Ost-\nWest-Konflikt
-                      weg, jetzt können wir zusammen eine \nbessere Welt gestalten, jetzt arbeiten wir
-                      noch enger \nzusammen. – Das Gegenteil ist gerade der Fall. Wir erle-\nben fortdauernde
-                      Spaltungen zwischen Ost und West, \nNord und Süd. Selbst im eigenen Land erleben
-                      wir eine \nhöhere Aggression als vielleicht in den Zeiten vor der \nTeilung, vor
-                      1990. In den letzten 30 Jahren wurde der \nSieg der Freiheit über die Unfreiheit
-                      zu einer Selbstver-\nständlichkeit. Mit dem ideologischen Gegner haben viele \nnach
-                      1990 auch den Sinn für die Gefährdung unserer \nFreiheitsordnungen verloren. Viele
-                      haben vergessen, \nwofür Europa im Kern steht, nämlich für Freiheit, Demo-\nkratie
-                      und Rechtsstaatlichkeit. \nViele haben nach 1990 nur noch materiell argumen-\ntiert:
-                      Jetzt ist Europa nicht mehr im Antagonismus „USA \nund Europa gegen die damalige
-                      Sowjetunion“, jetzt geht \nes um materielle Dinge, Leistungskonkurrenz geografi-\nscher
-                      Räume. Wir müssen leistungsfähiger, wettbewerbs-\nfähiger werden. – Das waren die
-                      Themen und weniger \ndiese ursprüngliche Grundidee. Es war das blinde Ver-\ntrauen
-                      in die überragende ökonomische Leistungsfähig-\nkeit Europas. Und die Folge? Weltfinanzkrise,
-                      europäi-\nsche Staatsschuldenkrise, gleichzeitig der Aufstieg Chi-\nnas, sodass
-                      viele plötzlich nicht mehr den Glauben hat-\nten, dass dieses Europa so leistungsfähig
-                      ist, welches, \nwenn es nur auf das Ökonomische reduziert ist, dann \nplötzlich
-                      auch mal auf Platz zwei oder Platz drei im \nweltweiten Wettbewerb lag. \nWir sehen
-                      Effizienzdefizite, und diese bringen mit \nsich, dass radikale Gegner der Freiheit
-                      genau das ausnut-\nzen: freiheitsfeindliche Fantasien eines starken Staates, \ndemokratische
-                      Anführer, die von „illiberalen Demokra-\ntien“ sprechen, neue Worte erfinden, die
-                      in sich schon ein \nWiderspruch sind. Und dann gibt es einige, die an der \nangeblichen
-                      Leistungsfähigkeit demokratischer Instituti-\nonen zweifeln und sich an autoritären
-                      Ideen berauschen. \nGerade in der Pandemie haben wir das erlebt. Natürlich \nist
-                      eine Ministerpräsidentenkonferenz ein komplizierter \nWeg, um Lösungen zu finden.
-                      Der autoritäre Staat kann \ndas alleine verfügen. \nWir müssen aber zeigen, dass
-                      unser System, wie wir in \nEuropa und in Deutschland arbeiten, am Ende trotzdem
-                      \nbesser ist. Bundesrat beteiligen ist klug, nachdem Bun-\ndestag geteilt hat; Entscheidungen
-                      nicht davon abhängig \nmachen, wer beim Klicken das erste Ergebnis hat, oder in
-                      \nKlickumfragen Ergebnisse erzielen, sondern im Aus-\ntausch. Erste, zweite, dritte
-                      Lesung – das hat seinen Sinn, \nweil man dann noch einmal nachdenken kann. Experten-\nanhörungen
-                      haben ihren Sinn. Den Bundesrat mit \n16 Länderinteressen zu beteiligen, hat seinen
-                      Sinn. Das \nmuss auch in den europäischen Institutionen erkannt \nwerden. In diesem
-                      Wettbewerb der Systeme ist nicht \nderjenige der Bessere, der sagt: „Autoritär –
-                      so geht es!“, \nsondern wir müssen dieses Freiheitsmodell Europas am \nEnde auch
-                      in der Welt bewähren. Darum geht es in dieser \nKonferenz. Mit diesem Geist müssen
-                      wir den Kampf \ngegen den Klimawandel, Schutz vor Pandemien und \nKrisen, Eindämmung
-                      grenzüberschreitender Bedrohun-\ngen und die Entwicklung von Zukunftstechnologien
-                      vo-\nrantreiben.\nAuch beim Thema Klimakrise gibt es manche, die sa-\ngen: Demokratie
-                      schafft das nicht mehr. Lasst uns das \nBundesrat – 1009. Sitzung – 8. Oktober 2021
-                      413\nautoritärer verfügen! – Nein, bei jedem Thema, das an-\nsteht, darf Europa
-                      nicht die Wege des bevormundenden \nKollektivs oder der radikalen Nutzung individueller
-                      \nRechte gehen, sondern muss europäisch die Freiheit des \nEinzelnen und der Gemeinschaft
-                      leben. Deshalb müssen \ndie europäischen Institutionen – und da sollten wir als
-                      \nBundesrat unsere Ideen einbringen – besser werden beim \nKlimaschutz. Der intertemporale
-                      Freiheitssicherungsas-\npekt, den das Bundesverfassungsgericht neu in die Debat-\nte
-                      eingebracht hat, muss auch für Europa gelten. Wir \nbrauchen eine aktive europäische
-                      Klimaaußenpolitik. Wir \nbrauchen bezahlbare und stabile Energieversorgung. Dies
-                      \nkann man gerade in diesen Zeiten, in denen Deutschland \naus vielen Energien aussteigt
-                      und in neue einsteigt, euro-\npäisch besser machen. Wir brauchen ein handlungsfähi-\ngeres
-                      Europa. Wir brauchen Mut zu Mehrheitsentschei-\ndungen, gerade in der Außenpolitik,
-                      und wir brauchen \neffizientere Strukturen. Mir kann niemand erklären, wa-\nrum
-                      nur mit 27 Kommissaren statt mit 15 effizient ent-\nschieden werden kann. Hier sind
-                      genau die Punkte, die \nwir konkret in die Debatte einbringen können. \nIn Europa
-                      werden, wenn es um das Große geht, die eu-\nropäischen Institutionen wirken. Aber
-                      Europa lebt auch \nvom Kleinen, lebt nicht nur von der Weltpolitik, sondern \nauch
-                      vom Austausch im Kleinen. Gerade hier sind die \ndeutschen Länder gefragt. Ich würde
-                      behaupten, dass \nunsere Länder in den Beziehungen zu Polen und Tsche-\nchien tagtäglich
-                      intensiver den europäischen Prozess \nvoranbringen als die große Bundes- oder Europapolitik.
-                      \nDas Gleiche gilt im Westen zu Belgien, zu den Nieder-\nlanden, zu Luxemburg, zu
-                      Frankreich. Gelebt wird das \nvon uns als Ländern tagtäglich, deshalb muss die Erfah-\nrung
-                      aus der Pandemie auch sein, dass wir diese Koope-\nration noch vergrößern müssen.
-                      Und sollte jemand wie-\nder auf die Idee kommen, Grenzen zu schließen, müssen \nwir
-                      als Länder diejenigen sein, die sagen: Nein, wir wol-\nlen die Lösung über Grenzen
-                      hinweg erreichen. – Das ist \ndie Aufgabe, die vor uns liegt. Ich empfehle auch,
-                      dass \nwir in diesem Prozess nicht nur mit den großen Mitglied-\nstaaten, mit Frankreich
-                      und Italien, sprechen, sondern \nauch mit den vielen kleinen. Denn ohne das Baltikum,
-                      die \nBeneluxstaaten und andere wird das europäische Projekt \nnicht zu realisieren
-                      sein. \nIch wünsche mir, dass die Europäische Union nicht \nnur eine Verwaltungsstruktur
-                      ist, die man irgendwie \nadministriert, sondern dass der Geist von 1989/90 mit \nGeschichtsbewusstsein,
-                      mit einem Sinn für Freiheit und \nVerantwortung und mit Leidenschaft die Konferenz
-                      \nprägt. Dazu wünsche ich allen, die aus diesem Hause dort \nmitwirken und uns dort
-                      vertreten, viel Erfolg und den \ngrößeren Blick auf diese Fragen. \nDies war meine
-                      letzte Rede in dieser Kammer. Ich \nwechsle in die andere Kammer, die an der Spree
-                      gelegen \nist. Danke für die Zusammenarbeit in den letzten Jahren! \nWir sehen uns
-                      alle wieder bei der Ministerpräsidenten-\nkonferenz, deren Vorsitz Nordrhein-Westfalen
-                      vor weni-\ngen Tagen übernommen hat. Im Bundesrat war das aber \nmeine letzte Rede,
-                      und ich danke allen für das gute Mit-\neinander.\n(Beifall)\nPräsident Dr. Reiner
-                      Haseloff: Ganz herzlichen \nDank, lieber Kollege Laschet! Nehmen Sie Ihr neues Amt
-                      \nin der anderen Kammer so wahr, dass Sie immer wissen, \nwoher Sie kommen, und
-                      stellen Sie dann die Klammer \ndar, wenn es darum geht, gemeinsam für Deutschland
-                      \nund Europa die richtigen Entscheidungen zu treffen! \nAlles Gute dafür und Gottes
-                      Segen!\nJe eine Erklärung zu Protokoll1 haben abgegeben: \nFrau Staatsministerin
-                      Puttrich (Hessen) und Frau Mi-\nnisterin Honé (Niedersachsen). \nWir stimmen über
-                      die Ausschussempfehlungen ab. \nZur Einzelabstimmung rufe ich auf: \nZiffer 11!
-                      Jetzt bitte ich um das Handzeichen dafür, \ndass wir die Ziffer 11 gesondert registrieren
-                      können. –\nKlare Mehrheit. \nJetzt bitte das Handzeichen für alle noch nicht erledig-\nten
-                      Ziffern der Ausschussempfehlungen! – Mehrheit. \nDamit hat der Bundesrat entsprechend
-                      Stellung ge-\nnommen.\nNun zum Tagesordnungspunkt 5:\nTOP 5\nEntwurf eines Gesetzes
-                      zur Änderung des Kaffee-\nsteuergesetzes (KaffeeStÄndG) – Antrag des Landes \nSchleswig-Holstein
-                      gemäß § 36 Absatz 2 GO BR –\n(Drucksache 727/21)\nEs spricht zu uns Frau Ministerin
-                      Heinold aus Schles-\nwig-Holstein. \nMonika Heinold (Schleswig-Holstein): Herr Präsi-\ndent!
-                      Meine Damen und Herren! Jedes Jahr landen in \nDeutschland große Mengen Lebensmittel
-                      im Müll. Das \nBundesministerium für Ernährung und Landwirtschaft \nschätzt, dass
-                      es sich um rund 12 Millionen Tonnen han-\ndelt. Immer wieder werden auch Lebensmittel
-                      vernichtet, \ndie zwar kurz vor Ablauf des Mindesthaltbarkeitsdatums \nstehen, aber
-                      noch gut zum Verzehr geeignet sind. Das ist \ninsgesamt eine alarmierende Situation,
-                      und wir müssen \nan mehreren Stellschrauben drehen, um etwas zu ändern. \nEine dieser
-                      Stellschrauben ist die Kaffeesteuer. Denn \nnach jetziger Gesetzeslage gibt es beim
-                      Kaffee sogar \neinen Anreiz für Unternehmungen, die Vernichtung von \nKaffee anderen
-                      Alternativen vorzuziehen. Während die \nVernichtung des Kaffees in einem sogenannten
-                      Steuerla-\nger nach dem Gesetz steuerfrei ist, fällt beim Spenden \ndes Kaffees
-                      aus einem Steuerlager an gemeinnützige \nOrganisationen Kaffeesteuer an. Für Röstkaffee
-                      sind es \n1 Anlagen 1 und 2\n414 Bundesrat – 1009. Sitzung – 8. Oktober 2021\n2,19
-                      Euro, für löslichen Kaffee 4,78 Euro pro Kilo. Da-\nmit setzt das Kaffeesteuergesetz
-                      in seiner jetzigen Form \neinen Anreiz zur Lebensmittelvernichtung. Das kann und
-                      \ndarf so nicht weitergehen, deshalb bringen wir heute \ndiesen Gesetzentwurf zur
-                      Änderung des Kaffeesteuerge-\nsetzes ein. Damit soll künftig geregelt werden, dass
-                      eine \nKaffeespende aus einem Steuerlager zur Förderung ge-\nmeinnütziger und mildtätiger
-                      Zwecke von der Kaffee-\nsteuer befreit wird. Produzenten und Händler haben so \ndie
-                      Möglichkeit, den noch genießbaren Kaffee an Tafeln \noder ähnliche Einrichtungen
-                      zu spenden, ohne dadurch \nfinanziell belastet zu werden und schlechter dazustehen,
-                      \nals wenn sie ihn vernichten würden. \nZiel ist es, dass mehr Kaffee gespendet
-                      wird für Men-\nschen, die auf Hilfe angewiesen sind, und weniger Kaffee \nim Müll
-                      landet. Das ist mit einer einfachen Gesetzesände-\nrung möglich. Lassen Sie uns
-                      diesen Schritt gemeinsam \ngehen! Ich werbe um Unterstützung für diesen Gesetz-\nentwurf.\nPräsident
-                      Dr. Reiner Haseloff: Herzlichen Dank, \nFrau Ministerin Heinold!\nZur weiteren Beratung
-                      weise ich die Vorlage dem Fi-\nnanzausschuss zu. \nWir kommen zu Tagesordnungspunkt
-                      6:\nTOP 6\nEntwurf eines ... Gesetzes zur Änderung des Bun-\ndesmeldegesetzes –
-                      Antrag des Landes Nordrhein-\nWestfalen gemäß § 36 Absatz 2 GO BR – (Drucksa-\nche
-                      728/21)\nEs liegen keine Wortmeldungen vor. \nIch weise die Vorlage dem Innenausschuss
-                      – feder-\nführend – sowie dem Rechtsausschuss – mitberatend –\nzu. \nWir kommen
-                      zu Tagesordnungspunkt 7:\nTOP 7\nEntschließung des Bundesrates zur Änderung des
-                      \nGeldwäschegesetzes – Effektive Bekämpfung der \nGeldwäsche gewährleisten – Antrag
-                      des Landes Ber-\nlin – (Drucksache 693/21)\nEs liegt eine Wortmeldung vor: Herr
-                      Senator Dr. Beh-\nrendt aus Berlin.\nDr. Dirk Behrendt (Berlin): Sehr geehrter Herr
-                      Prä-\nsident! Meine Damen und Herren! Deutschland steht auf \ndem Prüfstand. Deutschland
-                      wird gerade auf Herz und \nNieren daraufhin geprüft, ob hierzulande Geldwäsche \nausreichend
-                      bekämpft wird. Dabei werden wir nicht von \nirgendeiner Institution geprüft, sondern
-                      von der Financial \nAction Task Force, kurz FATF. Dem Bundesministerium \nzufolge
-                      ist das die wichtigste internationale Institution \nzur Bekämpfung und Verhinderung
-                      von Geldwäsche und \nTerrorismusfinanzierung. Bei den Untersuchungen wird \ndie
-                      Gesetzgebung unter die Lupe genommen. Die Prü-\nfenden schauen sich außerdem genau
-                      an, ob die Geldwä-\nschebekämpfung auch in der Praxis funktioniert. Ab \nNovember
-                      sind über mehrere Wochen Vor-Ort-Termine \ngeplant. \nZuletzt wurde Deutschland
-                      im Jahre 2010 auf den \nPrüfstand gestellt. Das Ergebnis war damals verheerend.
-                      \nIm damaligen Bericht der FATF heißt es: „aus zahlrei-\nchen Indikatoren ist zu
-                      schließen, dass Deutschland für \nGeldwäsche und Terrorismusfinanzierung anfällig
-                      ist“. \nAnders formuliert: Deutschland ist ein Geldwäschepara-\ndies.\nLiebe Anwesende,
-                      angesichts dieser Situation möchte \nman meinen, dass der Bundesgesetzgeber alles
-                      Erdenkli-\nche unternimmt, um die Geldwäsche in Deutschland zu \nbekämpfen – gerade
-                      jetzt. Doch dem ist leider nicht so. \nDer Bundesgesetzgeber ist nicht nur nachlässig,
-                      er ver-\nhindert mit neuen Gesetzen sogar die effektive Geldwä-\nschebekämpfung,
-                      und zwar bei der Notaraufsicht. \nEs ist bekannt, dass der deutsche Immobilienmarkt
-                      bei \nder Geldwäsche eine zentrale Rolle spielt. Hier werden \njährlich Milliarden
-                      an Euro gewaschen. Bekannt ist auch: \nohne Notarinnen und Notare kein Immobilienkauf.
-                      Wenn \nder Staat also Einblick in potenzielle Geldwäschege-\nschäfte auf dem Immobilienmarkt
-                      erlangen will, dann \ngeht das am effektivsten über die Notarinnen und Notare, \noder
-                      anders formuliert: Wenn ein 20-jähriger arbeitsloser \nMann mit einer großen Tasche
-                      voll Bargeld zum Notar \nkommt und fünf Wohnungen in Berlin kaufen will, dann \ngibt
-                      es nur eine Person, der das auffallen könnte: den \nNotar. Es gibt auch nur eine
-                      Person, die einen Geldwä-\nscheverdacht melden könnte: den Notar. Leider ist das
-                      \nbekanntlich bisher nur äußerst selten geschehen. Im Jahr \n2019 meldeten deutschlandweit
-                      nur 17 Notarinnen und \nNotare einen Geldwäscheverdacht – 17 von insgesamt \nfast
-                      115.000 Verdachtsmeldungen.\nWas könnte der Staat also unternehmen, um diese un-\nbefriedigende
-                      Situation zu verbessern? Der Staat könnte \nzum Beispiel den Notarinnen und Notaren
-                      genauer auf \ndie Finger schauen. In Berlin ist genau das geschehen. \nAnfang 2020
-                      hat Berlin die Notaraufsicht beim Landge-\nricht ausgebaut und eine Taskforce „Geldwäsche“
-                      einge-\nrichtet. Die Idee dahinter: Wenn die Notare keine Ver-\ndachtsfälle melden,
-                      dann kontrollieren wir die Notare und \nmelden gegebenenfalls die Verdachtsfälle
-                      selbst. Die \nKontrollen und Meldungen an die Financial Intelligence \nUnit, kurz
-                      FIU, liefen auch recht gut, doch dann grätschte \nim Sommer dieses Jahres der Bundesgesetzgeber
-                      dazwi-\nschen. Er änderte einen kleinen, aber entscheidenden Satz \nim Geldwäschegesetz
-                      und setzte die Notaraufsicht damit \nschachmatt. Nun reicht der Aufsicht ein Verdacht
-                      für eine \nGeldwäschemeldung eben nicht mehr aus. Stattdessen \nmuss die Aufsichtsbehörde
-                      positive Kenntnis von einem \nGeldwäschefall haben. Diese Hürde ist enorm hoch und
-                      \nmacht Meldungen an die FIU faktisch unmöglich. Damit \nBundesrat – 1009. Sitzung
-                      – 8. Oktober 2021 415\nhat der Gesetzgeber das zarte Pflänzchen der Notarauf-\nsicht
-                      gleich wieder zertrampelt.\nMeine Damen und Herren, ich kann Ihnen nicht sagen,
-                      \nwas den Bundesgesetzgeber zu diesem rabiaten Schritt \nbewogen hat. Gerade vor
-                      dem Hintergrund der laufenden \nFATF-Prüfungen ist mir eine solche Gesetzesänderung
-                      \nschwer erklärlich. Unser heutiger Entschließungsantrag \nzielt nun genau darauf
-                      ab, diese Gesetzesänderung rück-\ngängig zu machen. Die Notaraufsicht muss wieder
-                      hand-\nlungsfähig werden, um die Geldwäsche effektiv zu be-\nkämpfen. Angesichts
-                      dessen freut mich, dass unser An-\ntrag im Finanzausschuss eine Mehrheit gefunden
-                      hat. \nOffenbar ist der Kreis der Finanzminister von der Reform \nder Geldwäsche
-                      auch nicht begeistert. \nVielleicht wissen Sie, dass Deutschland im vergange-\nnen
-                      Jahr für zwei Jahre die Präsidentschaft der FATF \nübernommen hat, also der Institution,
-                      die Deutschland \nbeim Thema Geldwäschebekämpfung derzeit auf Herz \nund Nieren
-                      prüft. Ich fände es mehr als peinlich, wenn \ndiese Institution unter der Präsidentschaft
-                      Deutschlands \ngerade Deutschland erneut ein Armutszeugnis in Sachen \nGeldwäschebekämpfung
-                      ausstellen würde. Deshalb wer-\nbe ich um die Zustimmung zu unserem Antrag. – Herzli-\nchen
-                      Dank.\nPräsident Dr. Reiner Haseloff: Danke, Herr Sena-\ntor Behrendt!\nZur Abstimmung
-                      liegen Ihnen die Ausschussempfeh-\nlungen vor.\nWer dafür ist, die Entschließung
-                      zu fassen, den bitte \nich um das Handzeichen. – Minderheit.\nDamit hat der Bundesrat
-                      die Entschließung n i c h t\ngefasst.\nWir kommen zu Tagesordnungspunkt 8:\nTOP
-                      8\nEntschließung des Bundesrates „Inflationsgefahren \nrasch und entschlossen entgegentreten
-                      – für eine \nPolitik des stabilen Geldes“ – Antrag des Freistaates \nBayern gemäß
-                      § 36 Absatz 2 GO BR – (Drucksache \n730/21)\nEs spricht zu uns Staatsminister Dr.
-                      Herrmann. \nDr. Florian Herrmann (Bayern): Herr Präsident! \nVerehrte Kolleginnen
-                      und Kollegen! Leider müssen wir \nderzeit in Deutschland, und etwas schwächer auch
-                      im \nEuroraum, einen deutlichen Anstieg der Inflationsrate \nverzeichnen: Im August
-                      waren es 3,9 Prozent. Für Sep-\ntember liegt die Prognose des Statistischen Bundesamtes
-                      \nsogar bei 4,1 Prozent, was der höchste Wert seit Dezem-\nber 1993 wäre.\nNun kann
-                      man streiten, inwieweit die coronabedingten \nSondereffekte eine dauerhaft hohe
-                      Inflationsdynamik \nherbeiführen, aber eines ist sicher: Die Bürgerinnen und \nBürger
-                      unseres Landes leiden ganz unmittelbar an den \nAuswirkungen der Preissteigerungen.
-                      Besonders besorgt \nmacht uns: Es sind gerade die Menschen mit den kleinen \nund
-                      mittleren Einkommen, die Sparer, die Rentner, die \ndiese Situation vor eine besonders
-                      harte Herausforderung \nstellt. Fatalerweise machen uns derzeit auch noch die \nextrem
-                      niedrigen Zinsen und überdurchschnittliche Preis-\nsteigerungen in einzelnen Bereichen,
-                      vor allem bei den \nEnergiekosten, zu schaffen. Die Gemengelage ist also \nhöchst
-                      ungünstig. Die Politik sollte hier nicht tatenlos \nzusehen. Wir wollen nicht, dass
-                      Menschen mit kleinen \nund mittleren Einkommen durch die Inflationsdynamik \nimmer
-                      noch weiter belastet werden. Das sind wir den \nMenschen im Land schuldig.\nGrundsätzlich
-                      ist es natürlich Aufgabe der Europäi-\nschen Zentralbank, bei einer sich verfestigenden
-                      Teue-\nrung Gegenmaßnahmen zu ergreifen und wieder für \nPreisstabilität zu sorgen.
-                      Aktuell ist jedoch nicht damit zu \nrechnen, dass die EZB in dieser immer noch von
-                      Corona \ngeprägten Zeit ihre Geldpolitik strafft. Deshalb sollten \nBund und Länder
-                      Maßnahmen zur Abmilderung der \nInflationswirkungen ergreifen.\nBayern sieht sich
-                      seit jeher als Wächter des stabilen \nGeldes. Deshalb formulieren wir in unserem
-                      Entschlie-\nßungsantrag folgende Instrumente der Entlastung und des \nAusgleichs:\nZum
-                      einen fordern wir eine Initiative zur Verbesse-\nrung der steuerlichen Bedingungen
-                      für Sparerinnen und \nSparer mit folgenden Elementen: einer Anhebung des \nSparer-Pauschbetrages,
-                      der Wiedereinführung einer Spe-\nkulationsfrist bei der Veräußerung langfristiger
-                      Kapital-\nanlagen im Privatvermögen und einer Wiedereinführung \neiner vollständigen
-                      Steuerbefreiung für Erträge aus Ein-\nmalzahlungen aus Lebensversicherungen.\nZum
-                      andern fordern wir eine Kompensation für die in-\nflationstreibende Wirkung des
-                      nationalen CO2-Preises, \nder in den kommenden Jahren weiter steigen wird. Diese
-                      \nKompensation sollte erfolgen durch eine Entlastung der \nHaushalte bei den Energiekosten
-                      über eine Absenkung \nvon Stromsteuer und EEG-Umlage und durch eine Kop-\npelung
-                      der Höhe der Pendlerpauschale an die Entwick-\nlung der Kraftstoffpreise. Wir können
-                      so die Verunsiche-\nrung über die steigende Inflation in der Bevölkerung \nabmildern.
-                      Ich werbe deshalb namens der Bayerischen \nStaatsregierung um Ihre Unterstützung
-                      dieses Entschlie-\nßungsantrags. – Vielen Dank. \nPräsident Dr. Reiner Haseloff:
-                      Vielen Dank, Herr \nStaatsminister Herrmann! \nZur weiteren Beratung weise ich die
-                      Vorlage – feder-\nführend – dem Finanzausschuss und – mitberatend –\ndem Ausschuss
-                      für Umwelt, Naturschutz und nuklea-\nre Sicherheit sowie dem Wirtschaftsausschuss
-                      zu. \n416 Bundesrat – 1009. Sitzung – 8. Oktober 2021\nWir kommen zu Tagesordnungspunkt
-                      10:\nTOP 10\nMitteilung der Kommission an das Europäische Par-\nlament, den Rat,
-                      den Europäischen Wirtschafts- und \nSozialausschuss und den Ausschuss der Regionen\nBericht
-                      über die Rechtsstaatlichkeit 2021\nDie Lage der Rechtsstaatlichkeit in der Europäi-\nschen
-                      Union\nCOM(2021) 700 final\n(Drucksache 618/21)\nEs liegen bisher vier Wortmeldungen
-                      vor. Es beginnt \nHerr Bürgermeister Dr. Lederer aus Berlin.\nDr. Klaus Lederer
-                      (Berlin): Sehr geehrter Herr Prä-\nsident! Meine Damen und Herren! Vor gut drei
-                      Wochen \nsprach Kommissionspräsidentin von der Leyen in ihrer \nRede zur Lage der
-                      Union 2021 von Europas Seele und \nEuropas Zukunft. Die aus dem kulturellen, religiösen
-                      und \nhumanistischen Erbe Europas entstammenden europäi-\nschen Werte beschrieb
-                      sie als „Teil unserer Seele, Teil \ndessen, was uns heute ausmacht“.\nUnd in der
-                      Tat: Die EU muss sich an den grundlegen-\nden gemeinsamen Werten messen lassen,
-                      zu denen sie \nsich in Artikel 2 des Vertrags über die Europäische Union \nbekennt.
-                      Dass diese Werte einen Anspruch formulieren, \nvon dessen Einlösung die europäische
-                      Realität leider in \nmancher Hinsicht weit entfernt ist, führen uns in entsetz-\nlicher
-                      Regelmäßigkeit der auf Abschreckung und Zu-\nrückweisung zielende Umgang der EU
-                      mit schutzsuchen-\nden Menschen an den Außengrenzen, die immer weiter \nsteigende
-                      Zahl der Todesopfer und vermissten Menschen \nauf der Mittelmeerroute und die menschenunwürdigen
-                      \nZustände in den überfüllten Lagern an den EU-\nAußengrenzen vor Augen. Europäische
-                      Werte sind etwas, \ndas es nicht nur weihevoll zu beschwören, sondern in \nkonkretem,
-                      menschenrechtlich orientiertem Handeln stets \nneu zu realisieren und zu leben gilt.\nWenn
-                      wir diese Werte als europäische beschreiben, \nwollen wir damit nicht behaupten,
-                      sie seien exklusiv \neuropäisch – denn das sind sie nicht –, sondern unter-\nstreichen,
-                      dass sie transnational geteilt werden und eben \nkeine ausschließlich deutschen,
-                      spanischen, tschechi-\nschen und so weiter Werte darstellen. Das Streben nach \nder
-                      Einlösung jener Werte, die wir die europäischen \nnennen, nach Freiheit, Demokratie,
-                      Gleichheit, Rechts-\nstaatlichkeit und der Wahrung der Menschenrechte war \ndas
-                      – auch darauf hat die Kommissionspräsidentin in \nihrer Rede hingewiesen –, was
-                      die Freiheitskämpfer/-\ninnen einte, die vor mehr als 30 Jahren den Eisernen \nVorhang
-                      niederrissen und die Berliner Mauer zu Fall \nbrachten.\nVor dem Hintergrund unserer
-                      besonderen Geschichte \nist es insbesondere für Berlin wichtig, Teil der europäi-\nschen
-                      Wertegemeinschaft zu sein. Hier, wo vor mehr als \n30 Jahren für diese Werte gekämpft
-                      wurde, ist vielen \nnoch in Erinnerung, was es bedeutet, eben nicht in einer \nwirklichen
-                      Demokratie oder in einem Rechtsstaat zu \nleben, ihre Regierung nicht frei wählen
-                      zu können, nicht \nfrei zu sein in Meinung und Rede, nicht in Freiheit zu \nleben.\nBedauerlicherweise
-                      erleben wir in Europa Tendenzen, \nbei denen Werte und Vorzüge der Europäischen
-                      Union \nzunehmend von innen heraus infrage gestellt und unter-\nminiert werden.
-                      Wir erleben Tendenzen, bei denen \nRechtsstaatlichkeit und Gewaltenteilung zunehmend
-                      \neiner autoritären Umwertung von Demokratie zum Opfer \nfallen und Errungenschaften
-                      der europäischen Wertege-\nmeinschaft – Grundrechte, soziale Menschenrechte und
-                      \nindividuelle Freiheiten – nicht nur zur Disposition gestellt \nwerden, sondern
-                      auch massiv untergraben werden und \neine Politik der Entsolidarisierung vorangetrieben
-                      wird.\nDiesen Tendenzen, meine Damen und Herren, müssen \nwir uns entgegenstellen.
-                      Wir sind Teil der europäischen \nGemeinschaft, die sich dazu verpflichtet hat, die
-                      gemein-\nsamen Werte einzuhalten und diese zu verteidigen. \nRechtsstaatlichkeit
-                      ist ein Bestandteil dieser gemeinsa-\nmen Werte und zugleich Voraussetzung für die
-                      Garantie \ndieser Werte in der Europäischen Union und den Mit-\ngliedstaaten. Sie
-                      ist von grundlegender Bedeutung für das \nFunktionieren der Europäischen Union und
-                      für das Ver-\ntrauen der Menschen in die EU. Die EU hat seit Jahren \nihre Arbeit
-                      in diesem Bereich verstärkt, und das ist mit \nBlick auf die weltweiten, aber auch
-                      in der EU zu be-\nobachtenden Entwicklungen und angesichts des wach-\nsenden Drucks
-                      auf die Rechtsstaatlichkeit – man muss ja \nnur nach Polen gucken und sich das aktuelle
-                      Urteil des \npolnischen Obersten Gerichts anschauen – mehr als er-\nforderlich.\nEs
-                      ist ausdrücklich zu begrüßen, dass die Europäische \nKommission mit ihren alljährlichen
-                      Rechtsstaatsberichten \ndas bisherige EU-Instrumentarium zum Schutz der \nRechtsstaatlichkeit
-                      ergänzt. Der Bericht 2021 ist ebenso \nwie der Rechtsstaatlichkeitsbericht 2020
-                      das Ergebnis \neines inklusiven Prozesses unter Beteiligung aller \n27 Mitgliedstaaten
-                      und der einschlägigen Interessenträ-\nger. Der Dialog muss hier – das ist, glaube
-                      ich, ganz klar \n– an erster Stelle stehen. Als präventives Instrument im \nRahmen
-                      des jährlichen europäischen Rechtsstaatsmecha-\nnismus soll der Bericht eine Diskussionsgrundlage
-                      liefern \nund das Verständnis und die Herausforderungen im Be-\nreich der Rechtsstaatlichkeit
-                      ermitteln. Erfolge konnten \nbereits erzielt werden. Der bisher vorgelegte Rechtsstaat-\nlichkeitsbericht
-                      hat in mehreren Mitgliedstaaten zu in-\nnenpolitischen Debatten und teilweise zu
-                      konkreten Re-\nformschritten beigetragen. Und so sollten auch die zu-\nkünftigen
-                      EU-Ratspräsidentschaften diese Chance nutzen \nund den angestoßenen Diskussionsprozess
-                      unbedingt \nfortführen.\nKommissionspräsidentin von der Leyen hat in ihrer \nRede
-                      zur Lage der Union 2021 angekündigt, dass die \nRechtsstaatlichkeitsberichte ab
-                      dem kommenden Jahr \nzusätzliche konkrete Empfehlungen für alle Mitgliedstaa-\nBundesrat
-                      – 1009. Sitzung – 8. Oktober 2021 417\nten enthalten sollen. Damit hat sie auch
-                      eine konkrete \nForderung aus der Entschließung des Europäischen Par-\nlaments vom
-                      24. Juni dieses Jahres aufgegriffen. Sie \nbetonte zugleich, dass der Dialog zwar
-                      am Anfang stehe, \naber auch kein Selbstzweck sei und bekräftigte den von \nder
-                      Kommission verfolgten „dualen Ansatz aus Dialog \nund entschlossenem Handeln“.\nAus
-                      der Sicht Berlins, das sich insbesondere in den \nBeziehungen zu Polen engagiert,
-                      ist es diesbezüglich \nauch wichtig, dass der bisherige Austausch und Dialog \nder
-                      Akteurinnen und Akteure in Politik und Verwaltung \nnicht abreißt. Es gilt weiterhin,
-                      miteinander ins Gespräch \nzu kommen und im Gespräch zu bleiben, bewährte Ver-\nfahren
-                      und Austauschformate unbedingt beizubehalten, ja \nvielleicht sogar noch auszubauen.
-                      Am Verhältnis zu \nPolen zeigt sich deutlich: Die europäischen Werte, die \ndemokratischen
-                      Grundprinzipien unseres Zusammenle-\nbens in der Europäischen Union dürfen nicht
-                      abstrakt \nbleiben. Sie müssen mit Leben gefüllt werden. Und das \ngeht am besten
-                      über eine lebendige Zivilgesellschaft, eine \naktive Zivilgesellschaft, die über
-                      die Grenzen hinweg ein \neuropäisches Miteinander lebt.\nAufgabe von Staat und Verwaltung
-                      sollte es sein, eine \nsolche Entwicklung von zivilgesellschaftlichem Engage-\nment
-                      zu unterstützen. Wir in Berlin tun das seit Jahren \nintensiv, denn gerade die Regionen
-                      und die Kommunen \nin Europa können hier einen sehr wichtigen Beitrag leis-\nten.
-                      Für uns in Berlin ist Polen das nächste europäische \nNachbarland. Die große polnische
-                      und polnischstämmige \nCommunity in Berlin bildet eine natürliche Brücke dahin.
-                      \nEs ist ein wichtiger und zentraler Schwerpunkt unserer \neuropapolitischen Arbeit,
-                      auf dieser Basis ein lebendiges \nMiteinander zwischen Berlin und den polnischen
-                      Nach-\nbarregionen und Nachbarstädten zu fördern. Das tun wir \nauf absolut unterschiedlichen
-                      Wegen, unter anderem über \ndeutsch-polnische Projektförderungen im Rahmen der \nOder-Partnerschaft,
-                      mit denen wir den zivilgesellschaftli-\nchen Austausch unterstützen. Diese Förderung
-                      hat in den \nvergangenen Jahren auf bemerkenswerte Weise gezeigt, \nwie auch und
-                      gerade kleinere Projekte nachhaltig wirken \nund Interessen für dieses Nachbarland
-                      wecken können. \nDer Kulturzug zwischen Berlin und Wrocław beispiels-\nweise hat
-                      eindrucksvoll bewiesen, dass ein Zug zwischen \nzwei europäischen Nachbarländern
-                      weit mehr sein kann \nals ein einfaches Transportmittel. Er ist Kulturvermittler,
-                      \ner ist Sprachvermittler, er ist Kontaktbörse und Initiator \nfür gemeinsame grenzüberschreitende
-                      Projekte.\nWir hier in Berlin sind der Auffassung, dass die Idee \neines geeinten,
-                      friedlichen und demokratischen Europas \ndurch jede Form des kulturellen Austauschs
-                      nur gestärkt \nwerden kann. Und ich glaube, auf dieser Ebene müssen \nwir anknüpfen
-                      und unsere gemeinsamen Werte täglich \naufs Neue gemeinsam leben. Damit möchte ich
-                      nun auch \nauf einen bereits angesprochenen Punkt zurückkommen: \ndie europäische
-                      Identität und die Glaubwürdigkeit der \nEuropäischen Union nach innen und nach außen.\nRechtsstaatlichkeit
-                      beinhaltet in materieller Hinsicht \nvor allem auch den Schutz der Menschenrechte.
-                      Die \nBindung der Europäischen Union und der Mitgliedstaaten \nan die Grundrechtecharta
-                      ist bekanntermaßen in Artikel 6 \ndes EU-Vertrags festgeschrieben. Daneben sieht
-                      der EU-\nVertrag auch den Beitritt der Europäischen Union zur \nEuropäischen Konvention
-                      zum Schutz der Menschen-\nrechte und Grundfreiheiten, zur EMRK, vor. Mit der \nEMRK
-                      wurde 1953 erstmals in Europa ein verbindlicher \nvölkerrechtlicher Grundrechtsschutz
-                      geschaffen, der von \njedermann vor dem Europäischen Gerichtshof für Men-\nschenrechte
-                      einklagbar ist. Mit einem Beitritt der EU zur \nEMRK würden auch Individualbeschwerden,
-                      die auf \neiner möglichen Rechtsverletzung durch ein EU-Organ \nberuhen, nach Ausschöpfung
-                      aller innerstaatlichen \nRechtsbehelfe vor dem Europäischen Gerichtshof für \nMenschenrechte
-                      eingeklagt werden können. Die Rechts-\nstaatlichkeit der EU würde somit deutlich
-                      gestärkt wer-\nden, und es wäre – und das kann ja heute gar nicht hoch \ngenug geschätzt
-                      werden – auch ein ganz wichtiger Schritt \nhin zu einem einheitlichen Menschenrechtsschutz
-                      in \nGesamteuropa.\nEin weiterer wichtiger Aspekt der Rechtsstaatlichkeit \nin der
-                      EU ist der europäische Verfassungsgerichtsver-\nbund. Dieser spielt eine wesentliche
-                      Rolle für den Zu-\nsammenhalt in der europäischen Rechtsgemeinschaft. \nDass sich
-                      im Mehrebenensystem immer wieder die Frage \ndes letzten Wortes stellt, ist wenig
-                      überraschend. Das \nsehen wir nicht nur in Bezug auf alle rechtlichen Proble-\nme
-                      beim Beitritt der EU zur EMRK, sondern auch inner-\nhalb der Europäischen Union.
-                      Mit Blick auf diverse ver-\nfassungsgerichtliche Entscheidungen der jüngeren Ver-\ngangenheit
-                      und mit Blick auf manch laufendes Verfahren \nist zu erkennen, dass das Verhältnis
-                      zwischen dem im \nUnionsrecht geltenden Anwendungsvorrang und dem \nKonzept der
-                      mitgliedstaatlichen Verfassungsidentitäten \nklärungsbedürftig ist. Und da müssen
-                      wir nun tatsächlich \nnicht mal nach Polen gucken. Dieses Problem haben wir \nhier
-                      auch. Wir kennen die entsprechenden Urteile des \nBundesverfassungsgerichts, in
-                      denen die Frage aufgewor-\nfen wird, ob der Anwendungsvorrang des EU-Rechts \nvom
-                      Europäischen Gerichtshof oder am Ende doch von \nden nationalstaatlichen Verfassungsgerichten
-                      gewahrt \nwerden soll. Und wir alle brauchen nicht viel Fantasie, \num uns auszumalen,
-                      was es bedeuten würde, wenn wir \ndiese Frage im Blick auf die letztere Instanz
-                      beantworten. \nDas ist nicht nur Warschau, das ist auch Karlsruhe.\nDer Konflikt
-                      zwischen einzelnen mitgliedstaatlichen \nVerfassungsgerichten einschließlich, wie
-                      gesagt, des \nBundesverfassungsgerichts und dem Europäischen Ge-\nrichtshof ist
-                      aus meiner Sicht eine ziemlich große Her-\nausforderung für die EU als Rechtsgemeinschaft
-                      und \nauch für die Rechtsstaatlichkeit auf allen Ebenen. Wenn \neiner sagt: „Ich
-                      stelle das infrage“, werden das andere \nauch tun. Und nicht überall mag es wie
-                      hierzulande die \nGarantien geben, dass es nicht an die Grundfesten rechts-\nstaatlicher
-                      Säulen gehen kann.\n418 Bundesrat – 1009. Sitzung – 8. Oktober 2021\nIch gehe davon
-                      aus, dass man auf längere Sicht gar \nnicht umhinkommen wird, hier ein Primat des
-                      Europäi-\nschen Gerichtshof anzuerkennen. Und das wird, meine \nich, dann nur eines
-                      des EuGH sein können. Das setzt aber \nin jedem Fall voraus, dass zunächst bestimmte
-                      grund-\nund menschenrechtliche Aspekte, die im EU-Recht der-\nzeit noch unterbelichtet
-                      sind, dort auch gestärkt werden. \nDas Thema sollte also bei allen Debatten, die
-                      wir um die \nkünftige Ausgestaltung unseres Zusammenlebens und \nunseres Zusammenwachsens
-                      in der Europäischen Union \nführen, eine ziemlich wichtige Rolle spielen.\nDamit
-                      komme ich zu meinem letzten Punkt, der Zu-\nkunft der EU. Die Konferenz zur Zukunft
-                      der EU bietet \nuns die einmalige Chance, mit den Menschen in der EU \nund Europa
-                      ins Gespräch darüber zu kommen, wie wir \ndie Herausforderungen des gesellschaftlichen
-                      Wandels in \nder EU gemeinsam bewältigen wollen. Im Rahmen der \nKonferenz findet
-                      derzeit auch eine umfassende Diskussi-\non zum Thema „Werte und Rechte, Rechtsstaatlichkeit,
-                      \nSicherheit“ statt. Auf der Plattform der Zukunftskonfe-\nrenz wurden bis August
-                      zu diesem Thema insgesamt \n1.635 Beiträge eingereicht, davon 547 Ideen, 949 Kom-\nmentare
-                      und 139 durchgeführte oder angemeldete Veran-\nstaltungen europaweit zum Thema Rechtsstaatlichkeit.
-                      \nAnhand der umfangreichen Diskussion zeigt sich die \ngroße Bedeutung, die die
-                      Unionsbürgerinnen und Uni-\nonsbürger der Rechtsstaatlichkeit in der Union beimes-\nsen.
-                      Viele von ihnen rufen zu entschiedenem Handeln der \nEU-Institutionen auf, um die
-                      Achtung der Rechtsstaat-\nlichkeit im gesamten europäischen Raum sicherzustellen.
-                      \nBerlin wird diese Diskussionen und die Arbeit im Rah-\nmen der Konferenz weiterhin
-                      intensiv verfolgen, unter-\nstützen und sich natürlich auch beteiligen.\nLassen
-                      Sie mich abschließend sagen: Die Sicherung \nund Stärkung der Rechtsstaatlichkeit,
-                      der Demokratie und \nder Menschenrechte in der EU ist eine der dringendsten \nHerausforderungen
-                      der europäischen Gemeinschaft. \nBerlin zumindest wird sich auch in Zukunft auf
-                      allen \nEbenen dafür einsetzen, und ich hoffe, dass dies auch alle \nanderen Länder
-                      im Rahmen der gemeinsamen Verpflich-\ntung zur Wahrung und Sicherung der Rechtsstaatlichkeit
-                      \nauf ähnliche Weise tun. – Vielen Dank.\nPräsident Dr. Reiner Haseloff: Herzlichen
-                      Dank, \nHerr Lederer!\nWir sind noch am Anfang der Sitzung. Deswegen habe \nich
-                      Sie abweichend von der Geschäftsordnung nicht \nunterbrochen. Die Regelredezeit
-                      haben wir im März über \ndie Geschäftsordnung auf fünf Minuten festgelegt. Aber
-                      \naufgrund der Bedeutsamkeit des Themas und weil wir \nauch kein Hauptstadtgesetz
-                      haben, habe ich der Bundes-\nhauptstadt Berlin diesen kleinen Zusatz erlaubt.\nJetzt
-                      kommt als Nächster Herr Minister Dr. Holthoff-\nPförtner aus Nordrhein-Westfalen.\nDr.
-                      Stephan Holthoff-Pförtner (Nordrhein-\nWestfalen): Sehr geehrter Herr Präsident!
-                      Liebe Kolle-\nginnen! Liebe Kollegen! Siebenmal hat sich der Bundes-\nrat in den
-                      letzten drei Jahren mit dem Thema Rechtsstaat-\nlichkeit befasst. Nordrhein-Westfalen
-                      hat die Rechtsstaat-\nlichkeit in den Jahren 2018 und 2019 zu einem Haupt-\nthema
-                      seines Vorsitzes in der Europaministerkonferenz \ngemacht und seit dieser Zeit intensiv
-                      verfolgt, und in \ndiesem Plenum beraten wir eine Beschlussempfehlung \ndes Europaausschusses
-                      zum Rechtsstaatlichkeitsbericht, \ndie auf einen gemeinsamen Antrag von Nordrhein-\nWestfalen,
-                      Baden-Württemberg, Bayern und Niedersach-\nsen zurückgeht.\nEs ist gut, dass wir
-                      uns auch in der Zeit, in der uns der \nBundestag keine Gesetze zur Entscheidung
-                      übersendet, \nmit Fragen der Europapolitik befassen, und es ist beson-\nders gut,
-                      dass wir das auch einmal am frühen Vormittag \nmachen. Ich erinnere sehr gerne an
-                      den Wunsch der Kol-\nlegin Puttrich aus dem Februar 2020, die darauf hinge-\nwiesen
-                      hat, dass das Thema Europapolitik grundsätzlich \nfrüher auf die Tagesordnung gehört
-                      und einer der wesent-\nlichen Punkte des Bundesrates sein sollte. Ich schließe \nmich
-                      dem ausdrücklich an.\nDass wir uns häufig mit dem Thema Rechtsstaatlich-\nkeit befassen
-                      müssen, hat zwei Gründe.\nErstens. Die Rechtsstaatlichkeit ist nicht nur ein The-\nma
-                      für Juristen, sondern auch Grundlage der Europäi-\nschen Union, denn Europa ist
-                      eine Rechtsgemeinschaft. \nDas spezifische Merkmal dieser Rechtsgemeinschaft liegt
-                      \ngerade darin, dass sich jeder Einzelne, jede Europäerin, \njeder Europäer, gegenüber
-                      nationalen Gerichten auf eu-\nropäisches Recht berufen können muss. Das setzt voraus,
-                      \ndass nationale Gerichte unabhängig sind und die Unab-\nhängigkeit der Gerichte
-                      und die Gewaltenteilung sich \ndamit an die Funktionsbedingungen der Europäischen
-                      \nUnion anpassen. Das Bewusstsein dafür zu schärfen, bei \nuns zu Hause und gleichzeitig
-                      auch in anderen europäi-\nschen Ländern, ist Aufgabe und Verpflichtung von uns \nallen.
-                      Deshalb begrüßt Nordrhein-Westfalen die Zielset-\nzung des zweiten Rechtsstaatlichkeitsberichts
-                      der Euro-\npäischen Union, die Rechtsstaatlichkeit zu stärken und \nProbleme deutlich
-                      zu machen. Der erste Rechtsstaatlich-\nkeitsbericht hat in einigen Ländern europäische
-                      Debatten \nausgelöst, und das ist auch gewünscht und richtig, denn \nder Rechtsstaatlichkeitsbericht
-                      ist ein Instrument des \nDialoges. Debatten sollen angeregt werden, um zu ge-\nmeinsamen
-                      Reformen, Fortschritten und Verbesserungen \nbeitragen zu können.\nDen zweiten Grund,
-                      aus dem wir uns wiederholt mit \ndem Thema Rechtsstaatlichkeit befassen, muss man
-                      \nebenso klar aussprechen: die Mitgliedstaaten der Europä-\nischen Union, in denen
-                      die Unabhängigkeit der Gerichte \nbedroht ist. Auch das ist im Rechtsstaatlichkeitsbericht
-                      \nerwähnt. Gegen Polen und Ungarn laufen Artikel-7-\nVerfahren und Vertragsverletzungsverfahren.
-                      Der Euro-\npäische Gerichtshof hat im Juli 2021 verfügt, dass die \nBundesrat –
-                      1009. Sitzung – 8. Oktober 2021 419\nDisziplinarkammer beim Obersten Gericht in
-                      Polen ihre \nTätigkeit einzustellen hat, weil sie die Unabhängigkeit \nder Richter
-                      verletzt. Trotzdem hat die Kammer weiterge-\narbeitet und im vergangenen Monat die
-                      Immunität von \nRichtern aufgehoben. Um das ganze Ausmaß der Bedro-\nhung der richterlichen
-                      Unabhängigkeit zu sehen, darf \nman nicht nur eine Maßnahme sehen. Wir müssen uns
-                      die \nsogenannte Justizreform in ihrer Gesamtheit ansehen, und \nwir müssen mit
-                      betroffenen Kolleginnen und Kollegen in \ndiesen Ländern sprechen. Dann wird deutlich:
-                      In diesen \nLändern werden die Gewaltenteilung und die Unabhän-\ngigkeit von Richtern
-                      systematisch eingeschränkt. Das \nGleiche gilt übrigens auch für die Pressefreiheit,
-                      gerade \nin Ungarn, aber auch in Polen.\nDas alles benennt der Rechtsstaatlichkeitsbericht.
-                      Er \nzählt aber auch viele andere Punkte auf. Aus Sicht des \nLandes Nordrhein-Westfalen
-                      wäre es sinnvoll, wenn die \nBerichte in Zukunft deutlichere Schwerpunkte setzen.
-                      Sie \nsollten sich stärker auf die Punkte konzentrieren, die für \ndie Wahrung des
-                      Artikels 2 des EU-Vertrages wesentlich \nsind. Es kann nicht sein, dass eine so
-                      fundamentale Frage \nwie die Unabhängigkeit von Richtern neben der Frage \nder Digitalisierung
-                      behandelt wird. Digitalisierung ist \nsehr wichtig, aber der Rechtsstaatlichkeitsbericht
-                      wäre \neffektiver, wenn er Mut zur stärkeren Gewichtung hätte. \nEs muss möglich
-                      sein, gravierende und systematische \nVerstöße der Prinzipien der Rechtsstaatlichkeit
-                      stärker \nvon weniger schwerwiegenden Defiziten zu trennen. Die \nKonferenz zur
-                      Zukunft Europas bietet auch die Chance, \nüber die Weiterentwicklung der Maßnahmen
-                      zum Schutz \nder Rechtsstaatlichkeit zu sprechen. So können wir das \nVertragsverletzungsverfahren
-                      effektiver ausgestalten. Es \ndauert in vielen Fällen viel zu lang. Deshalb könnte
-                      man \ndie Zweistufigkeit des Verfahrens überdenken.\nErwartungsvoll bin ich, was
-                      die Koppelung von euro-\npäischen Haushaltsmitteln an die Einhaltung von rechts-\nstaatlichen
-                      Kriterien angeht. Ich begrüße daher, dass der \ndeutschen Ratspräsidentschaft mit
-                      der Einigung auf den \nMehrjährigen Finanzrahmen auch die Einführung einer \nKonditionalitätsregelung
-                      gelungen ist. Entscheidend ist: \nDas Recht soll Europa nicht trennen, sondern einen.
-                      Auf \nmeinen Reisen, wie zum Beispiel auch in der kommen-\nden Woche nach Slowenien,
-                      ist es mir deshalb sehr wich-\ntig, nicht nur mit Regierungsvertretern zu sprechen,
-                      son-\ndern gleichzeitig auch mit Vertretern der Zivilgesell-\nschaft, Richterinnen
-                      und Richtern. Wir müssen gerade \nmit den Europäerinnen und Europäern Mittel- und
-                      Osteu-\nropas sprechen, die für Weltoffenheit und Rechtsstaat-\nlichkeit in ihren
-                      Ländern eintreten.\nNordrhein-Westfalen wird das Thema Rechtsstaatlich-\nkeit weiterhin
-                      intensiv verfolgen. Es gehört auf die politi-\nsche Agenda des Bundesrates, weil
-                      das europäische\nRecht ein Mehrebenensystem trägt. Das Recht hält die \nverschiedenen
-                      Ebenen zusammen. Die Durchsetzung des \nRechts und damit die Stabilität des Mehrebenensystems
-                      \nbraucht unabhängige Gerichte. Die Entscheidung des \npolnischen Verfassungsgerichtes
-                      bedeutet in seiner kon-\nsequenten Fortsetzung den Abschied Polens aus der eu-\nropäischen
-                      Rechtsordnung. Die Verteidigung der Rechts-\nstaatlichkeit ist ein wichtiger Beitrag
-                      zum europäischen \nFöderalismus. Ich bitte Sie, den Antrag zu unterstützen \nund
-                      den vorliegenden Ausschussempfehlungen zu folgen.\nPräsident Dr. Reiner Haseloff:
-                      Danke, Herr Mi-\nnister Holthoff-Pförtner!\nAls Nächste spricht zu uns Frau Ministerin
-                      Honé aus \nNiedersachsen.\nBirgit Honé (Niedersachsen): Herr Präsident! Liebe \nKolleginnen
-                      und Kollegen! Lange wurde die Europäische \nUnion als reine Wirtschaftsgemeinschaft
-                      verstanden. \nWenngleich die Wirtschaft und das Funktionieren des \nBinnenmarkts
-                      in der Europäischen Union eine wichtige \nRolle spielen, darf aber nicht vergessen
-                      werden – das ist \nja hier heute schon gesagt worden –, dass die EU in erster \nLinie
-                      eine starke Wertegemeinschaft ist. Die überaus \ngroße Bedeutung des Selbstverständnisses
-                      als Wertege-\nmeinschaft macht der Artikel 2 des Vertrags über die \nEuropäische
-                      Union weit vorne im Primärvertrag deutlich.\nEin dort genannter und zentraler Wert
-                      der Europäi-\nschen Union ist die Rechtsstaatlichkeit. Sie ist eine Vo-\nraussetzung
-                      für Frieden, Freiheit und Fortschritt. Die \nAchtung der Rechtsstaatlichkeit ist
-                      zudem eine Grundvo-\nraussetzung für die Wirtschaftlichkeit der Haushaltsfüh-\nrung
-                      und eine wirksame EU-Finanzierung. Sie ist also \nGrundlage einer jeden funktionierenden
-                      demokratischen \nGesellschaft, aber auch der Europäischen Union als dem \nam weitesten
-                      integrierten Staatenbund der Welt. Dabei \nfördert die Europäische Union die Rechtsstaatlichkeit
-                      \nnicht nur in den Mitgliedstaaten. Sie ist selbst eine \nRechtsgemeinschaft. Allerdings
-                      ist auch sie darauf ange-\nwiesen, dass sich die Mitgliedstaaten an die vereinbarten
-                      \nRegeln und deren Auslegung durch den Europäischen \nGerichtshof halten. Ist das
-                      nicht der Fall, so ist die Zu-\nkunft der Europäischen Union in Gefahr, da sie ihre
-                      Ge-\nsetze und Verordnungen schlicht nicht mehr durchsetzen \nkann.\nLiebe Kolleginnen
-                      und Kollegen, leider müssen wir \nfeststellen, dass sich die Rechtsstaatlichkeit
-                      in der Euro-\npäischen Union in einer Krise befindet. Wir betrachten \nbereits seit
-                      Längerem, wie die Rechtsstaatlichkeit in \neinigen EU-Mitgliedstaaten durch autokratische
-                      Struktu-\nren gefährdet wird. Das gestrige Urteil des polnischen \nVerfassungsgerichts,
-                      das ja hier auch schon genannt \nwurde, mit dem Teile des EU-Vertrags für verfassungs-\nwidrig
-                      erklärt wurden, ist ein ausgesprochen trauriger \nHöhepunkt des Konflikts der polnischen
-                      Regierung mit \nder Europäischen Union. Die polnischen Verfassungs-\nrichter vertreten
-                      darin die Auffassung, dass das polnische \nVerfassungsrecht Vorrang vor EU-Recht
-                      haben kann. Die \nMehrheitsentscheidung, der 2 von 14 Richtern wider-\nsprochen
-                      hatten, ist mit größter Sorge zur Kenntnis zu \nnehmen. Sie ist nicht nur geeignet,
-                      das ohnehin schon \nsehr angespannte Verhältnis zwischen Polen und der \n420 Bundesrat
-                      – 1009. Sitzung – 8. Oktober 2021\nEuropäischen Union weiter zu beeinträchtigen,
-                      sondern \nauch, die Integrations- und Handlungsfähigkeit der Euro-\npäischen Union
-                      insgesamt vor – nennen wir es mal so –\ngroße Herausforderungen zu stellen.\nAuch
-                      das Urteil des EuGH von vorgestern im Falle ei-\nnes zwangsversetzten polnischen
-                      Richters führt uns er-\nneut vor Augen, dass es sich bei der Missachtung von \nGrundregeln
-                      der Europäischen Union durch Mitgliedstaa-\nten nicht nur um reine Theorie handelt.
-                      Vielmehr ver-\ndeutlicht die Aushöhlung der staatlichen Gewaltenteilung \ndurch
-                      die polnische Regierung die Notwendigkeit, die \nUnabhängigkeit der nationalen Gerichte,
-                      einen wirksa-\nmen Rechtsschutz und damit die Rechtsstaatlichkeit zu \nstärken.\nDies
-                      zeigt darüber hinaus der Ende Juli bereits zum \nzweiten Mal vorgelegte Bericht
-                      zur Lage der Rechtsstaat-\nlichkeit. Untersucht wurden darin das Justizsystem, der
-                      \nRahmen für die Korruptionsbekämpfung, der Medienplu-\nralismus und die Medienfreiheit
-                      sowie das institutionelle \nGleichgewicht in den Mitgliedstaaten. Im Rechtsstaat-\nlichkeitsbericht
-                      2021 zieht die Kommission für Deutsch-\nland insgesamt eine positive Bilanz. Gleichzeitig
-                      formu-\nliert sie aber auch ernste Besorgnisse in Bezug auf eine \nganze Reihe von
-                      Mitgliedstaaten. Insbesondere mit Blick \nauf Polen und Ungarn hat die EU-Behörde
-                      schwerwie-\ngende strukturelle Bedenken geäußert. Beispielsweise \nwurden bei der
-                      Unabhängigkeit der Justiz oder beim \nSchutz von Minderheiten erhebliche Defizite
-                      festgestellt. \nAber auch die Befunde in einigen anderen Mitgliedstaa-\nten sind
-                      besorgniserregend.\nMeine sehr verehrten Damen und Herren, nun stehen \nwir als
-                      Europäerinnen und Europäer vor der entscheiden-\nden Frage, wie wir diese Krise
-                      bewältigen wollen. Das \nvertraglich vorgesehene Verfahren nach Artikel 7 des \nVertrages
-                      über die Europäische Union kann die beste-\nhenden Probleme allein nicht lösen.
-                      Auch Vertragsverlet-\nzungsverfahren können nur punktuell Abhilfe schaffen. \nGegen
-                      systemische Probleme können sie wenig ausrich-\nten, wenngleich der Europäische
-                      Gerichtshof den einst-\nweiligen Rechtsschutz in der gegenwärtigen Rechts-\nstaatskrise
-                      stark ausgebaut hat. Die Europäische Union \nsetzt nunmehr vermehrt auf eine Rechtsstaatskonditiona-\nlität
-                      in ihrem Haushaltsrecht. Insofern halte ich das der-\nzeitige Vorgehen der Kommission,
-                      die Auszahlung der \nMittel aus der Aufbau- und Resilienzfazilität an Polen \nund
-                      Ungarn aufzuschieben, nicht nur für angemessen, \nsondern auch für dringend notwendig.\nErforderlich
-                      ist auch, den Konditionalitätsmechanis-\nmus endlich auszulösen. Dazu haben wir
-                      jetzt positive \nSignale aus der Kommission bekommen, nicht zuletzt in \nder Rede
-                      der Kommissionspräsidentin zur Lage der Uni-\non; Herr Lederer hat darauf hingewiesen.
-                      Dass der Geld-\nhahn ein wirksames Druckmittel sein kann, zeigt übri-\ngens auch,
-                      dass zwischenzeitlich fast alle betroffenen\npolnischen Gemeinden die stigmatisierende
-                      und inakzep-\ntable Politik sogenannter LGBTI-freier Zonen revidiert \nhaben. Dabei
-                      dürfte der Blick auf Mittel aus REACT-EU \neine große Rolle gespielt haben.\nUm
-                      gemeinsame Fortschritte zu erreichen, ist es das \nZiel der Europäischen Union,
-                      ein Verständnis für rechts-\nstaatliches Regieren in allen Mitgliedstaaten durch
-                      ange-\nregte Debatten zu erwirken. Ein zentralistisches und \npartikulares Verständnis
-                      von Rechtsstaatlichkeit, also von \noben herab, würde der Textur der Europäischen
-                      Union \nSchaden zufügen. Stattdessen muss das Bekenntnis zur \nRechtsstaatlichkeit
-                      von den Mitgliedstaaten selbst ausge-\nhen.\nMeine sehr verehrten Damen und Herren,
-                      dieser As-\npekt führt uns zu dem heutigen Beschlussantrag. Mit \nZuversicht sehen
-                      wir nämlich, dass durch das verglei-\nchende und objektive Monitoring aller Mitgliedstaaten
-                      \nein politischer Dialog ermöglicht wird. Schon der erste \nRechtsstaatsbericht
-                      trug in mehreren europäischen Mit-\ngliedsstaaten zu innenpolitischen Debatten zum
-                      Zustand \nder Rechtsstaatlichkeit bei. Darüber hinaus wurden teil-\nweise sogar
-                      konkretere Formen als Reaktion auf den \nRechtsstaatlichkeitsbericht angestrengt.
-                      Gute Beispiele \nhierfür sind die Slowakei oder Tschechien. Dort sind \nwichtige
-                      und schon lange Zeit notwendige Reformen und \nReforminitiativen, etwa im Justizwesen,
-                      als Antwort auf \nden Rechtsstaatlichkeitsbericht zu verzeichnen. Liebe \nKolleginnen
-                      und Kollegen, ich hoffe sehr, dass die neuen \npositiven Entwicklungen in diesen
-                      Mitgliedstaaten nun \nauch auf diejenigen übergehen, die wir zurzeit noch mit \nernster
-                      Besorgnis betrachten. Denn, meine sehr verehrten \nDamen und Herren, Rechtsstaatlichkeit
-                      ist das Funda-\nment, auf dem die Europäische Union gebaut ist. – Vielen \nDank.\nPräsident
-                      Dr. Reiner Haseloff: Danke, Frau Mi-\nnisterin Honé!\nAls Nächste spricht zu uns
-                      Staatsministerin Meier aus \nSachsen.\nKatja Meier (Sachsen): Sehr geehrter Herr
-                      Präsident! \nSehr geehrte Damen und Herren! Mit dem Bericht der \nEU-Kommission
-                      über die Lage der Rechtstaatlichkeit \n2021 beraten wir heute eine Vorlage, die
-                      vielleicht auf \nden ersten Blick keine große Aufmerksamkeit auf sich \nzieht. Denn
-                      meist werden EU-Mitteilungen hier im Bun-\ndesrat einfach nur zur Kenntnis genommen.
-                      Deshalb bin \nich den antragstellenden Ländern ausgesprochen dankbar, \ndass wir
-                      das Thema Rechtsstaatlichkeit heute hier disku-\ntieren – wir haben ja gesehen:
-                      es ist der Tagesordnungs-\npunkt, zu dem es die meisten Rednerinnen und Redner \ngibt
-                      –, denn die europapolitischen Debatten hierzulande \nleiden nach meiner Überzeugung
-                      darunter, dass wir die \nBedeutung des Prinzips der Rechtsstaatlichkeit für das
-                      \nAnsehen und die Legitimation der EU häufig unterschät-\nzen. Heute ist das anders.
-                      Aber allzu oft neigen wir dazu, \nden Euro, die ökonomischen Vorteile, den Binnenmarkt
-                      \nund seine Freizügigkeit ins Zentrum zu rücken; Frau \nHoné hat es gesagt. Rechtsstaatlichkeit
-                      wird entweder als \nBundesrat – 1009. Sitzung – 8. Oktober 2021 421\neine Selbstverständlichkeit
-                      betrachtet oder als ein abs-\ntrakter Wert, dessen Ausgestaltung den Mitgliedstaaten
-                      \nals „innere Angelegenheit“ überlassen bleibt. Das, meine \nsehr verehrten Damen
-                      und Herren, halte ich für eine sehr \ngefährliche Fehleinschätzung. In Wirklichkeit
-                      ruht das \ngesamte Einigungswerk auf dem Prinzip der Anerken-\nnung der EU als Rechtsgemeinschaft
-                      und der Einhaltung \nihrer Regeln. Das ist das eigentliche Fundament der Ar-\nchitektur
-                      der europäischen Integration, auf dem alles \naufbaut. Wenn sich aber einzelne Mitgliedstaaten
-                      der EU \nnicht mehr auf dem Boden der Rechts- und Wertege-\nmeinschaft bewegen,
-                      dann erodiert dieses Fundament und \ngefährdet die Stabilität der gesamten Architektur
-                      und \ndamit die Zukunft der EU als Ganzes.\nSeit Jahren wächst die Erkenntnis, nicht
-                      nur in den \nMitgliedstaaten, sondern auch in den europäischen Insti-\ntutionen,
-                      dass es ein großes Versäumnis der Vergangen-\nheit war, ein so konstitutives Fundament
-                      der Gemein-\nschaft nicht wirksamer gegen systematische Verletzungen \nzu schützen.
-                      Denn wir erleben ja nicht nur in Europa, \nsondern weltweit: Die Angriffe von außen
-                      und von innen \nauf die Grundlagen westlicher Demokratien, auf die Un-\nabhängigkeit
-                      der Justiz, auf Meinungs- und Pressefreiheit \nund den Kampf gegen Korruption nehmen
-                      zu. Um dieser \nEntwicklung entgegenzusteuern – und dafür bin ich \nHerrn Reynders
-                      sehr dankbar –, wird seit 2020 jährlich \neine Bestandsaufnahme der Rechtsstaatlichkeit
-                      in allen \nMitgliedstaaten durchgeführt. Auf der Basis dieses Be-\nrichts führt
-                      die Kommission Konsultationen, Gespräche \ndurch und erhofft sich dadurch freiwillige
-                      Korrekturen in \nden Mitgliedstaaten. Diesen Prozess bezeichnet die \nKommission
-                      als Teil des Rechtstaatsmechanismus. Laut \ndem aktuellen Bericht gibt es einige,
-                      gravierende Prob-\nleme – wir haben es bei den Vorrednerinnen und -rednern \ngehört
-                      –:\nGerichte werden durch nationale Gesetze daran gehin-\ndert, EU-Recht zum Schutz
-                      der richterlichen Unabhän-\ngigkeit direkt anzuwenden.\nEine Disziplinarkammer,
-                      an deren Legitimität nach \nSicht des EuGH Zweifel geboten sind, hebt die richterli-\nche
-                      Immunität auf.\nEntscheidungen des EuGH werden ignoriert oder gar \nals Form der
-                      „politischen Einflussnahme“ abgetan.\nWeil diese Entwicklungen nicht nur mir große
-                      Sorgen \nbereiten, gilt es, die richtigen Schlüsse aus dem Bericht \nder Kommission
-                      zu ziehen. Denn so wichtig es ist, mit \ndem Rechtsstaatsmechanismus mehr Transparenz
-                      herzu-\nstellen und im Dialog auf Verbesserungen zu drängen, so \nstößt, wenn wir
-                      alle ehrlich miteinander sind, diese Me-\nthode doch erkennbar an ihre Grenzen.
-                      Denn was pas-\nsiert, wenn sich Regierungen in einzelnen Mitgliedstaaten \nweigern,
-                      Verstöße gegen Rechtsstaatsprinzipien abzustel-\nlen? In einer solchen Situation
-                      wirkt ein Bericht über \nDefizite und Verfehlungen in der Hoffnung auf Einsicht
-                      \nder Verantwortlichen, um ehrlich zu sein, vor allem \nhilflos. \nHier kommt der
-                      Mechanismus der Rechtsstaatskondi-\ntionalität zum Tragen. Im November 2020 haben
-                      sich die \nKommission, der Rat und das Europäische Parlament \nnach monatelangen
-                      Verhandlungen auf die Einführung \nder Rechtsstaatskonditionalität geeinigt, das
-                      heißt auf die \nVerknüpfung der Einhaltung von rechtsstaatlichen Prin-\nzipien mit
-                      dem EU-Haushalt und dem Wiederauf-\nbaufonds „NextGenerationEU“. Die Zuweisung von
-                      EU-\nGeldern ist seither an die Einhaltung rechtsstaatlicher \nPrinzipien gebunden.
-                      Wenn Verstöße gegen die Rechts-\nstaatlichkeit in einem Mitgliedstaat festgestellt
-                      werden, \nsind zum Schutz des Haushaltes der Union geeignete \nMaßnahmen zu ergreifen,
-                      das heißt, es greifen entspre-\nchende Sanktionen.\nAn dieser Stelle müssen wir
-                      uns aber unbequeme Fra-\ngen stellen:\nHat die Art und Weise, wie europäische Mittel
-                      verge-\nben werden, die Korruption und das Erstarken autokrati-\nscher Strukturen
-                      in einigen Mitgliedstaaten vielleicht \ngeradezu verstärkt? \nHaben wir zugelassen,
-                      dass Milliarden Euro mangels \nrechtstaatlicher Kontrolle nicht für die eigentlichen
-                      Zwe-\ncke verwendet wurden?\nIch glaube, dafür gibt es einige Anhaltspunkte. Wenn
-                      \nalso der Missbrauch von EU-Geldern und der Abbau des \nRechtsstaats in manchen
-                      Mitgliedstaaten miteinander \nverknüpft sind, dann ist es notwendig, zum Schutz
-                      des \nRechtsstaats genau dort anzusetzen, nämlich beim Geld. \nGenau dafür wurde
-                      der Konditionalitätsmechanismus \ngeschaffen, den es nun anzuwenden gilt. Deswegen
-                      sollte \ndie Kommission ihre Mittel ausschöpfen, um die europäi-\nschen Werte, insbesondere
-                      die Unabhängigkeit der Justiz, \nzu verteidigen und gegen Korruption vorzugehen.
-                      Nur \nwenn die EU glaubhaft für Rechtsstaatlichkeit eintritt, ist \nsie auch legitimiert
-                      und handlungsfähig. Scheitern die \nvorhandenen Instrumentarien, wie bislang, an
-                      den Mehr-\nheitsanforderungen im Rat, dann wird man – Herr Holt-\nhoff-Pförtner
-                      hat es gesagt – auch über Vertragsänderun-\ngen sprechen müssen. Gerade im Zusammenhang
-                      mit der \nKonferenz zur Zukunft Europas sollte das kein Tabuthe-\nma sein.\nZugleich,
-                      meine sehr verehrten Damen und Herren, \nsollten wir angesichts des Rechtsstaatlichkeitsberichts
-                      \nnicht reflexhaft mit dem Finger auf andere Länder zeigen, \nsondern zunächst die
-                      eigenen Defizite zur Kenntnis neh-\nmen und möglichst abstellen. Mit einiger Sorge
-                      lese ich \nauch das Länderkapitel zu Deutschland. Dort ist unter \nanderem von Zweifeln
-                      an der Sicherheit unserer Journa-\nlistinnen und Journalisten die Rede. Bundesweit
-                      sind \nJournalistinnen und Journalisten der Bedrohung, der \nEinschüchterung und
-                      sogar tätlichen Angriffen ausge-\nsetzt. Ich komme aus Sachsen; ich weiß, wovon
-                      ich rede. \n422 Bundesrat – 1009. Sitzung – 8. Oktober 2021\nWenn Journalistinnen
-                      und Journalisten an der Ausübung \nihres Berufs gehindert oder bedroht werden, dann
-                      gefähr-\ndet das die Presse- und Meinungsfreiheit und damit eine \nder Säulen des
-                      Rechtsstaats genauso wie Probleme mit \nder Gewaltenteilung.\nDeswegen haben wir
-                      auch hier in Deutschland einige \nArbeit vor uns. Dafür braucht es vor allem Best-Practice-\nAustausch
-                      und länderübergreifenden Dialog. Sachsen \nmöchte in diesem Zusammenhang seinen
-                      Beitrag leisten. \nIm kommenden Januar wird es in Leipzig das erste Mal \neine hochkarätig
-                      besetzte, trinationale Rechtsstaatskonfe-\nrenz mit Tschechien und Polen geben.
-                      Ziel Sachsens ist \nes, als Mittler in Mitteleuropa einen Beitrag für eine \ngemeinsame
-                      europäische Rechtsstaatskultur zu leisten, \nindem wir einen nachhaltigen wissenschaftlichen
-                      und \npolitischen Trilog zwischen Polen, Tschechien und \nDeutschland in der Gerichtsstadt
-                      Leipzig etablieren. Dass \nwir über solche Fragen breiter und offener debattieren,
-                      ist \nin jedem Fall eine wichtige Folge des Berichts. Zur \nRechtsstaatlichkeit
-                      gehört, dass wir uns diesen Diskussi-\nonen stellen – und zwar in ganz Europa.\nDemokratie,
-                      Rechtsstaatlichkeit, freie Wahlen, Mei-\nnungs- und Pressefreiheit – das sind die
-                      Werte, auf denen \ndie Europäische Union gründet. Herr Lederer hat mit \neinem Zitat
-                      von Frau von der Leyen angefangen. Ich \nmöchte den Reigen der Rednerinnen und Redner
-                      schlie-\nßen mit den Worten der Kommissionspräsidentin, die sie \nbei der Rede zur
-                      Lage der Union am 21. September ge-\nsagt hat: „Wir sind entschlossen, diese Werte
-                      zu verteidi-\ngen. Und wir werden in dieser Entschlossenheit niemals \nnachlassen.“
-                      Neben Dialog bedarf es aber auch eines \nentschlossenen Handelns. Es müssen konkrete
-                      Schlüsse \naus dem Rechtstaatlichkeitsbericht gezogen werden und \nbestehende Instrumente
-                      wie die Rechtsstaatskonditionali-\ntät konsequent genutzt werden. Das schulden wir
-                      allen \nUnionsbürgerinnen und -bürgern, die sich eine starke EU \nals Wertegemeinschaft
-                      an ihrer Seite wünschen, eine \nUnion, die ihre Grundrechte achtet und verteidigt.
-                      – Vie-\nlen Dank.\nPräsident Dr. Reiner Haseloff: Danke, Frau \nStaatsministerin
-                      Meier!\nWir stimmen über die Ausschussempfehlungen ab. \nZur Einzelabstimmung rufe
-                      ich auf:\nZiffer 7! – 49 Stimmen; Mehrheit.\nZiffer 8! – 42 Stimmen; Mehrheit.\nZiffer
-                      10! – 25 Stimmen; Minderheit.\nZiffer 13! – 46 Stimmen; Mehrheit.\nJetzt bitte das
-                      Handzeichen für alle noch nicht erledig-\nten Ziffern der Ausschussempfehlungen!
-                      – Mehrheit.\nDamit hat der Bundesrat entsprechend Stellung ge-\nnommen.\nWir kommen
-                      zur Grünen Liste. Zur gemeinsamen \nAbstimmung nach § 29 Absatz 2 der Geschäftsordnung
-                      \nrufe ich die in dem Umdruck 8/20211 zusammengefass-\nten Beratungsgegenstände
-                      auf. Es sind dies die Tages-\nordnungspunkte:\n11, 15, 16, 18 bis 21, 23 und 25
-                      bis 28.\nWer den Empfehlungen und Vorschlägen folgen \nmöchte, den bitte ich um
-                      das Handzeichen.\nDas ist damit beschlossen.\nEine Erklärung zu Protokoll2 hat abgegeben:
-                      zu \nPunkt 16 Herr Minister Professor Dr. Hoff (Thürin-\ngen).\nWir kommen zu Tagesordnungspunkt
-                      12:\nTOP 12\nVorschlag für eine Verordnung des Europäischen \nParlaments und des
-                      Rates über die allgemeine Pro-\nduktsicherheit, zur Änderung der Verordnung (EU)
-                      \nNr. 1025/2012 des Europäischen Parlaments und des \nRates sowie zur Aufhebung
-                      der Richtlinie \n87/357/EWG des Rates und der Richtlinie \n2001/95/EG des Europäischen
-                      Parlaments und des \nRates\nCOM(2021) 346 final\n(Drucksache 646/21, zu Drucksache
-                      646/21)\nEs liegen keine Wortmeldungen vor.\nZur Abstimmung liegen Ihnen die Ausschussempfeh-\nlungen
-                      und ein Landesantrag vor.\nIch beginne mit den Ausschussempfehlungen. Zur \nEinzelabstimmung
-                      rufe ich auf:\nZiffer 1! – Minderheit.\nZiffer 2! – Mehrheit.\nDamit entfallen die
-                      Ziffern 3 und 4.\nZiffer 6! – Mehrheit.\nZiffer 9! – Mehrheit.\nWir fahren fort
-                      mit dem Landesantrag. Jetzt bitte Ihr \nHandzeichen! – Mehrheit.\nAus den Ausschussempfehlungen
-                      rufe ich auf:\nZiffer 21, zunächst ohne den Buchstaben b! – Mehr-\nheit.\n1 Anlage
-                      3\n2 Anlage 4\nBundesrat – 1009. Sitzung – 8. Oktober 2021 423\nNun bitte das Handzeichen
-                      für den Buchstaben b von \nZiffer 21! – Mehrheit.\nZiffer 40! – Minderheit.\nZiffer
-                      54! – Mehrheit.\nNun bitte das Handzeichen für alle noch nicht erledig-\nten Ziffern
-                      der Ausschussempfehlungen! – Mehrheit.\nDamit hat der Bundesrat entsprechend Stellung
-                      ge-\nnommen.\nWir kommen zu Punkt 13:\nTOP 13\nVorschlag für eine Verordnung des
-                      Europäischen \nParlaments und des Rates über europäische grüne \nAnleihen\nCOM(2021)
-                      391 final\n(Drucksache 637/21, zu Drucksache 637/21)\nEs liegen keine Wortmeldungen
-                      vor.\nWir stimmen über die Ausschussempfehlungen ab. \nZur Einzelabstimmung rufe
-                      ich auf:\nZiffer 4! – Mehrheit.\nZiffer 7! – Mehrheit.\nZiffern 8 und 9 gemeinsam!
-                      – Mehrheit.\nZiffer 10! – Minderheit.\nZiffer 11! – Mehrheit.\nZiffer 12! – Mehrheit.\nZiffer
-                      13! – Mehrheit.\nJetzt bitte das Handzeichen für alle noch nicht erledig-\nten Ziffern
-                      der Ausschussempfehlungen! – Mehrheit.\nDamit hat der Bundesrat entsprechend Stellung
-                      ge-\nnommen.\nPunkt 14:\nTOP 14\nVorschlag für eine Richtlinie des Europäischen
-                      Par-\nlaments und des Rates zur Änderung der Richtlinien \n2013/34/EU, 2004/109/EG
-                      und 2006/43/EG und der \nVerordnung (EU) Nr. 537/2014 hinsichtlich der \nNachhaltigkeitsberichterstattung
-                      von Unterneh-\nmen\nCOM(2021) 189 final\n(Drucksache 548/21, zu Drucksache 548/21)\nEs
-                      liegen keine Wortmeldungen vor.\nZur Abstimmung liegen Ihnen die Ausschussempfeh-\nlungen
-                      vor. Zur Einzelabstimmung rufe ich auf:\nZiffern 2, 3 und 30 gemeinsam! – Mehrheit.\nZiffer
-                      4! – Minderheit.\nZiffer 7! – Mehrheit.\nZiffer 8! – Mehrheit.\nZiffer 9! – Minderheit.\nZiffer
-                      10! – Mehrheit.\nZiffer 11! – Minderheit.\nZiffer 12! – Mehrheit.\nDamit entfällt
-                      Ziffer 13.\nZiffer 14! – Mehrheit.\nZiffer 15! – Minderheit.\nZiffer 16! – Minderheit.\nZiffer
-                      17! – Minderheit.\nZiffern 18 und 20 gemeinsam! – Minderheit.\nZiffer 19! – Minderheit.\nZiffer
-                      21! – Minderheit.\nZiffer 22! – Mehrheit.\nZiffer 24! – Minderheit.\nZiffer 25!
-                      – Minderheit.\nZiffer 26! – Mehrheit.\nDamit entfällt Ziffer 27.\nZiffer 29! – Minderheit.\nZiffer
-                      32! – Mehrheit.\nDamit entfällt Ziffer 33.\nZiffer 34! – Minderheit.\nZiffer 35!
-                      – Minderheit.\nZiffer 36! – Minderheit.\nZiffer 38! – Minderheit.\nZiffer 39! –
-                      Mehrheit.\nZiffer 40! – Minderheit.\nZiffer 41! – Minderheit.\nZiffer 42! – Minderheit.\n424
-                      Bundesrat – 1009. Sitzung – 8. Oktober 2021\nZiffer 43! – Mehrheit.\nZiffer 46!
-                      – Mehrheit.\nZiffer 48! – Mehrheit.\nZiffer 49! – Mehrheit.\nDamit entfällt Ziffer
-                      50.\nZiffer 52! – Mehrheit.\nZiffer 53! – Mehrheit.\nNun bitte Ihr Handzeichen für
-                      alle noch nicht erledig-\nten Ziffern der Ausschussempfehlungen! – Mehrheit.\nDamit
-                      hat der Bundesrat entsprechend Stellung ge-\nnommen.\nPunkt 17:\nTOP 17\nVerordnung
-                      zur Änderung der Landwirtschaftser-\nzeugnisse-Schulprogramm-Teilnahmeverordnung\n(Drucksache
-                      653/21)\nEs liegen keine Wortmeldungen vor.\nWir kommen zur Abstimmung über die
-                      Ausschuss-\nempfehlungen.\nWer ist entsprechend Ziffer 1 dafür, der Verordnung \nzuzustimmen?
-                      Bitte Ihr Handzeichen! – Mehrheit.\nDamit hat der Bundesrat der Verordnung zuge-\nstimmt.\nWir
-                      haben nun noch über eine begleitende Entschlie-\nßung abzustimmen. Ich rufe auf:\nZiffer
-                      2! – Mehrheit.\nZiffer 3! – Mehrheit.\nZiffer 4! – Mehrheit.\nDamit hat der Bundesrat
-                      auch eine Entschließung ge-\nfasst.\nPunkt 22:\nTOP 22\nErste Verordnung zur Änderung
-                      der Bußgeldkata-\nlog-Verordnung (Drucksache 687/21)\nWir haben drei Wortmeldungen.
-                      Es beginnt Herr \nMinister Hermann aus Baden-Württemberg.\nWinfried Hermann (Baden-Württemberg):
-                      Herr \nPräsident! Meine Damen und Herren! Wir beschließen \nheute die Bußgeldkatalog-Verordnung
-                      – ein typischer \nMonsterbegriff aus der Verkehrssprache. Es geht um ein \nganz
-                      praktisches Problem, nämlich um die Sanktionen \nvon Regelverletzungen im Straßenverkehr.\nMeine
-                      Damen und Herren, wenn wir heute beschlie-\nßen, beenden wir eine schier unendliche
-                      Geschichte des \nBußgeldkatalogs und seiner Novelle. Es ist schade, dass \nwir so
-                      lange gebraucht haben. Auch ist bedauerlich, dass \nwir seit gut einem halben Jahr
-                      zwar neue Regeln haben, \naber keine dazu passenden Sanktionsmaßnahmen. Das \nGanze
-                      dient jedoch nicht der Schikane, sondern der Ver-\nkehrssicherheit. Es geht letztendlich
-                      um die Vermeidung \nvon Regelverletzungen und die Vermeidung von Unfäl-\nlen, auch
-                      von tödlichen Unfällen.\nGestatten Sie mir eine kurze Erinnerung an die \nGeschichte!\nWir
-                      haben vor ungefähr anderthalb Jahren mit über-\nwältigender Mehrheit neue Regeln
-                      und neue Sanktions-\nmaßnahmen im Bundesrat beschlossen. Dieser Beschluss \nist
-                      bekanntermaßen an einem Rechtsfehler gescheitert. \nMan muss wissen, dass dem Beschluss
-                      eine mindestens \neinjährige Konsenssuche der Länder mit dem Bund \nvorausgegangen
-                      ist. Es war wirklich schwierig, diesen \nKompromiss zu finden. Insofern war es bedauerlich,
-                      dass \nes diesen Rechtsfehler gab und wir ihn nicht einfach \nformell korrigieren
-                      konnten. Vielmehr hat sich in dieser \nSituation eine neue, inhaltliche Mehrheit
-                      im Bundesrat \nund vor allem aufgrund des Verkehrsministeriums gebil-\ndet, und
-                      wir mussten erneut in der Sache verhandeln. Das \nhat wiederum zu monatelangem Ringen
-                      um die richtigen \nLösungen geführt, etwa: Wie viel schneller darf man \nfahren,
-                      bis man ein zeitweises Fahrverbot bekommt? Was \nsoll es kosten, wenn man Regeln
-                      verletzt?\nSchließlich, im Frühjahr dieses Jahres, haben wir \nmühsam einen Konsens
-                      gefunden. Es hat ein weiteres \nhalbes Jahr gedauert, bis die Bundesregierung eine
-                      \nBeschlussvorlage erarbeitet hat. Vielleicht können wir \nauch sagen: Nach dem
-                      Debakel der ersten Geschichte –\nes hat rechtlich nicht geklappt – haben Sie ein
-                      halbes Jahr \nlang überlegt und hin und her geprüft, ob die Verordnung \nwirklich
-                      richtig ist, und das scheint jetzt der Fall zu sein. \nAuf den letzten Drücker hat
-                      die noch amtierende Regie-\nrung diese Verordnung vorgelegt. Immerhin! Es wird \nhöchste
-                      Zeit.\nWas regeln wir darin?\nEs geht im Wesentlichen darum, dass Regelverstöße
-                      –\nzum Beispiel zu schnelles Fahren oder falsches Parken –\nfür die Menschen auf
-                      der Straße – Kinder, Ältere und so \nweiter – sicherheitsgefährdend sind. Es geht
-                      darum, dass \nwir in diesem Zusammenhang keine Rabatte geben, son-\ndern deutlich
-                      machen: Wer die Regeln verletzt, gefährdet \nund schädigt andere. Insofern ist es
-                      gut, dass wir den \nWeg gefunden haben: Wir verschärfen die Bußgelder in \nfast
-                      allen Bereichen im Grunde genommen um das Dop-\npelte. Diesen Kompromiss verdanken
-                      wir übrigens nicht \nzuletzt der Initiative der VMK-Vorsitzenden, Frau Sena-\nBundesrat
-                      – 1009. Sitzung – 8. Oktober 2021 425\ntorin Schaefer, die wesentlich dazu beigetragen
-                      hat, dass \nwir aus dieser Blockade herausgekommen sind.\nWelche Sanktionen schlagen
-                      wir konkret vor?\nZum Beispiel: Wenn man innerhalb einer Stadt oder \neines Ortes
-                      bis zu 20 Kilometer zu schnell fährt, zahlt \nman zukünftig 70 Euro statt 35, außerhalb
-                      ist die Erhö-\nhung von 30 auf 60 Euro. Zeitweise Fahrverbote gibt es \nimmer noch,
-                      wenn man notorisch zu schnell fährt, aller-\ndings 26 Stundenkilometer zu schnell.
-                      Mit anderen Wor-\nten: Wer regelmäßig mit 61 oder schneller durch die \nTempo-30-Zone
-                      fährt, der muss auf Zeit auf seinen Füh-\nrerschein verzichten. Außerhalb, zum Beispiel
-                      an einer \nBaustelle, wird man erst bei einer Überschreitung von 41 \nStundenkilometern
-                      – statt 80 mehr als 120 – den Führer-\nschein los.\nAber die wesentlichen Punkte
-                      sind die Bußgelder: \nVerdoppelung etwa beim Parken auf Gehwegen oder \nbeim Parken
-                      in der zweiten Reihe oder beim Parken \nfälschlicherweise auf einem Elektroautoladeplatz
-                      oder \nauf einem Carsharing-Platz. All das wird inzwischen \nordentlich mit Bußgeld
-                      bewehrt. Wer die Feuerwehr \nbehindert, zahlt schon mal gleich 100 Euro, und wer
-                      \nmeint, er müsse auf einer Busspur fahren, das Gleiche. \nOder – was besonders
-                      ärgerlich ist –: Wenn Menschen \nversuchen, die Rettungsgasse auf der Autobahn dazu
-                      zu \nnutzen, an allen anderen Autos, die stehen, vorbeizufah-\nren, wird das zukünftig
-                      teuer. Lkw-Fahrer, die rechts \nabbiegen, müssen darauf achten, Schritttempo zu
-                      fahren, \ndamit sie Radfahrer nicht übersehen und überfahren.\nSie sehen: Alle diese
-                      Regeln haben Sinn. Es geht im-\nmer um mehr Sicherheit. Und es geht darum, dass
-                      dieje-\nnigen, die sich nicht an die Regeln halten, das an ihrem \nGeldbeutel spüren
-                      müssen.\nZu Radfahrenden muss zukünftig ein größerer Abstand \neingehalten werden:
-                      1,50 Meter innerorts, 2 Meter außer-\norts. Auch hier sehen Sie: Es geht um den
-                      Schutz von \nRadfahrern. Viele andere Maßnahmen schützen vor allem \ndie Fußgänger.\nMeine
-                      Damen und Herren, ich komme zum Ende. Man \nkann aus dieser unendlichen Geschichte
-                      schon einen \nSchluss ziehen: Wir sollten mühsam gefundene Kom-\npromisse nicht
-                      ohne Not aufgeben, denn es dauert dann \nwieder lange, bis man so weit ist.\nWir
-                      haben im Bereich Bußgelder jetzt einige Verbes-\nserungen geschafft. Ich sage aber
-                      dazu: Die Straßenver-\nkehrs-Ordnung ist dem Geiste und dem Grunde nach eine \nVerordnung
-                      der 60er- und 70er-Jahre, also aus einer Zeit, \nin der vor allen Dingen der fließende
-                      Autoverkehr im \nMittelpunkt des Interesses stand. Eine wirklich moderne \nStraßenverkehrs-Ordnung
-                      muss den Menschen, die Ver-\nkehrssicherheit und Umweltschutzfragen genauso ins
-                      \nZentrum stellen. Deswegen glaube ich, dass eine neue \nKoalition auf Bundesebene
-                      in jedem Fall dafür sorgen \nmuss, dass eine Reform der Straßenverkehrs-Ordnung
-                      im \nSinne von mehr Sicherheit und Menschlichkeit im Ver-\nkehr eingeleitet wird.
-                      – Vielen Dank.\nPräsident Dr. Reiner Haseloff: Danke, Herr \nMinister Hermann!\nEs
-                      folgt Minister Dr. Buchholz aus Schleswig-\nHolstein.\nDr. Bernd Buchholz (Schleswig-Holstein):
-                      Herr \nPräsident! Liebe Kolleginnen und Kollegen! Lieber Kol-\nlege Hermann, was
-                      Sie zum Schluss gesagt haben, macht \nmich ganz unruhig. Nachdem wir diese unendliche
-                      \nGeschichte endlich beenden können, fangen Sie gleich \nwieder damit an, wir müssten
-                      die Straßenverkehrs-\nOrdnung wieder in Angriff nehmen. Mich treibt das um, \ndenn
-                      es ist in der Tat, wie Sie gesagt haben, eine unendli-\nche Geschichte gewesen.\nEine
-                      unendliche Geschichte, die allerdings im Kern \nnotwendig und wichtig ist – ich
-                      bin Frau Kollegin Reh-\nlinger als ehemaliger Vorsitzenden der Verkehrsminister-\nkonferenz
-                      und Frau Schaefer sehr dankbar dafür, dass wir \ndiesen Knoten jetzt durchgeschlagen
-                      haben –, weil es in \neinigen Bereichen auch um sehr wichtige Verschärfungen \nder
-                      Bußgelder geht. Insbesondere vor dem Hintergrund \nder steigenden Zahlen von Unfällen
-                      und Verletzten im \nRadverkehr ist dafür zu sorgen, dass wir das Radfahren in \nden
-                      Städten, das wir ja alle befördern wollen, insgesamt \nsicherer machen. Deshalb
-                      versehen wir wichtige Vor-\nschriften mit entweder neuen oder verschärften Bußgel-\ndern:
-                      Das Parken auf Gehwegen und Radwegen, das \nHalten auf Schutzstreifen für Radfahrer,
-                      aber auch das \nRechtsabbiegen von Lkws in unangemessener Geschwin-\ndigkeit – mehr
-                      als Schritttempo –, das sind alles wichtige \nThemen, um mehr Sicherheit herbeizuführen.
-                      Das war \nnie im Streit, Herr Kollege Hermann. Alle diese Dinge \nhätten wir schon
-                      vor einem Jahr verabschieden können.\nIm Streit war ausschließlich die Frage, ob
-                      derjenige, \nder mehr als 21 Stundenkilometer über der vorgeschrie-\nbenen Geschwindigkeit
-                      fährt, sofort als notorischer Raser \nbezeichnet werden darf und ihm erstmals ein
-                      Fahrverbot \nauferlegt werden kann. Einige haben erst spät in der Dis-\nkussion
-                      verstanden, dass die Grundlage des Bußgeldkata-\nloges und der Straßenverkehrs-Ordnung
-                      das Straßenver-\nkehrsgesetz ist. In § 25 Absatz 1 des Straßenverkehrsge-\nsetzes
-                      steht nun mal, dass ein Fahrverbot erstmalig nur \nausgesprochen werden darf, wenn
-                      es sich um einen „gro-\nben oder beharrlichen“ Verstoß handelt. Insoweit, lieber
-                      \nKollege Hermann: Jemand, der innerorts beharrlich mit \nweniger Überschreitung
-                      als 21 unterwegs ist, kann schon \nheute mit einem Fahrverbot belegt werden – es
-                      muss \n„beharrlich“ sein.\nGenau an dieser Stelle schieden sich die Geister. Des-\nhalb
-                      ist es wichtig, dass wir etwas getan haben, was, wie \nich glaube, vom Geist her
-                      völlig korrekt ist: Wir haben, \nwas unsere Bußgelder angeht, im europäischen Vergleich
-                      \n426 Bundesrat – 1009. Sitzung – 8. Oktober 2021\nein sehr geringes Maß gehabt.
-                      Deshalb sind wir dabei –\nund das ist richtig –, es auf eine Größenordnung anzuhe-\nben,
-                      die im europäischen Vergleich angemessen ist und \ndie durchaus abschreckende Wirkung
-                      haben kann. Aber \nwir haben bei den Fahrverboten nicht das Straßenver-\nkehrsgesetz
-                      ausgehebelt, nicht die groben und beharrli-\nchen Verstöße negiert. Wir sind bei
-                      den Fahrverboten \nnicht in die dramatische Verschärfung gegangen.\nDiesen Kompromiss
-                      halte ich für gut und richtig. Er \nträgt aus meiner Sicht nicht nur zu mehr Sicherheit
-                      im \nVerkehr bei, sondern schafft auch etwas, was gleicher-\nmaßen wichtig ist:
-                      Der Bußgeldkatalog muss auch \nAkzeptanz in der Bevölkerung haben, dass die Dinge
-                      so \nsanktioniert werden, wie es jetzt der Fall ist. Insoweit bin \nich dankbar,
-                      dass Sie, liebe Frau Schaefer, es als neue \nVorsitzende der Verkehrsministerkonferenz
-                      gleich ge-\nschafft haben, Kollegen Hermann und andere in die Spur \nzu bringen,
-                      auf einen ordentlichen Bußgeldkatalog einzu-\nschwenken\n(Vereinzelt Heiterkeit)\nund
-                      jetzt auch die gemeinsamen Regelungen zu beschlie-\nßen. – Herzlichen Dank.\nPräsident
-                      Dr. Reiner Haseloff: Danke, Herr \nMinister Dr. Buchholz, auch für die Einhaltung
-                      der \nGeschäftsordnung!\nFrau Bürgermeisterin Dr. Schaefer hat das Wort.\nDr. Maike
-                      Schaefer (Bremen): Sehr geehrter Herr \nPräsident! Meine sehr geehrten Damen und
-                      Herren! Herr \nBuchholz, mit dem etwas komplizierten Hinweis auf die \ngrünen Verkehrsministerkollegen
-                      machen Sie mir den \nEinstieg nicht so leicht, wie ich gehofft hatte.\nIch freue
-                      mich, dass wir die Erste Verordnung zur \nÄnderung der Bußgeldkatalog-Verordnung,
-                      die die be-\nstehenden Rechtsunsicherheiten wegen eines Zitierfehlers \nnun endlich
-                      beseitigt, heute beschließen.\nUrsprung der Bußgeldnovelle war die europäische \n„Vision
-                      Zero“ zur Reduzierung der Zahl der Unfalltoten. \nDas ist ein deutliches Zeichen
-                      an Autofahrende, sich an \nGeschwindigkeitsbegrenzungen zu halten. Sie dient der
-                      \nVerkehrserziehung, aber auch der gegenseitigen Rück-\nsichtnahme im Straßenverkehr.\nWarum
-                      brauchen wir die Novelle? Das Fahren mit \nunangepasster Geschwindigkeit war laut
-                      Statistik des \nBundesverkehrsministeriums die häufigste Unfallursache \nmit Todesfolge
-                      im letzten Jahr. Fakt ist, dass im Jahr \n2019 bei 32 Prozent der Menschen, die
-                      bei einem Ver-\nkehrsunfall ums Leben kamen, überhöhte Geschwindig-\nkeit die Ursache
-                      war. 2018 verstarben bei Unfällen auf \nAutobahnen 424 Menschen, 196 davon aufgrund
-                      erhöhter \nGeschwindigkeit. Diese Statistiken zeigen, dass wir drin-\ngenden Handlungsbedarf
-                      haben.\nDaher haben wir uns auf die folgenden Maßnahmen \nverständigt – sie wurden
-                      schon genannt, ich möchte sie \ntrotzdem wiederholen, weil es so wichtig ist –:
-                      höhere \nGeldbußen für Geschwindigkeitsverstöße, eine deutliche \nAnhebung der Bußgelder
-                      insbesondere beim Parken auf \nGeh- und Radwegen, beim Halten auf Schutzstreifen
-                      und \nbeim sogenannten Autoposing – ein großes Problem \ngerade in den Großstädten.
-                      Neu ist auch die Pflicht für \nLkws, beim Rechtsabbiegen innerorts nur Schrittge-\nschwindigkeit
-                      zu fahren.\nTeil der Bußgeld-Verordnung ist die Fahrradnovelle, \ndie die Sicherheit
-                      von Fahrradfahrenden in den Mittel-\npunkt stellt. Die deutliche Erhöhung der Strafen
-                      für das \nParken auf Fahrradwegen oder bei Nichteinhaltung des\nMindestabstands
-                      beim Überholen ist ein erster wichtiger\nSchritt auf dem Weg zur Gleichberechtigung
-                      von Auto \nund Fahrrad. Es geht darum, die schwächeren Verkehrs-\nteilnehmenden
-                      zu schützen. Deswegen bleibt die Fuß-\ngängernovelle eine wichtige Aufgabe für die
-                      kommende \nBundesregierung.\nWir setzen heute ein Signal für mehr Verkehrssicher-\nheit.
-                      Darum bitte ich um Zustimmung zur Verordnung.\nNeben der Verkehrssicherheit möchte
-                      ich aber noch \neinen anderen Punkt ansprechen. Sie haben vorhin von \nder „unendlichen
-                      Geschichte“ gesprochen. Was ich an-\nspreche, ist für mich nicht minder wichtig.\nDer
-                      Kompromiss, der heute zur Entscheidung vorliegt, \nist ein bestes Beispiel, wie
-                      ein konstruktiver Prozess über \nalle Parteigrenzen hinweg gelingen kann. Uns in
-                      der \nVerkehrsministerkonferenz ist es im Frühjahr gelungen, \nden entscheidenden
-                      Durchbruch zu erreichen; ja, es hätte \ndanach auch schneller gehen können. Es wurde
-                      schon \ngesagt: 2020 wurde der Bußgeldkatalog schon mal hier \nbeschlossen. Aufgrund
-                      eines Zitierfehlers ist er wieder \naufgemacht worden, und die Diskussionen gingen
-                      von \nvorne los. Ich will nicht alles wiederholen. Die einen \nwollten, dass man
-                      bei Geschwindigkeitsverletzungen den \nFührerschein früher verliert, die anderen
-                      konnten sich das \nnicht vorstellen. Es gab eine wirkliche Blockadesituation, \nund
-                      es ist gelungen, diese aufzubrechen.\nIch möchte mich – auch als Vorsitzende der
-                      Ver-\nkehrsministerkonferenz – bei allen Kolleginnen und Kol-\nlegen aus den anderen
-                      Ländern bedanken, bei Minister \nHermann, aber auch bei meiner Vorgängerin in der
-                      Ver-\nkehrsministerkonferenz, Frau Rehlinger, bei Herrn Buch-\nholz und beim BMVI,
-                      weil wir gemeinsam bewiesen \nhaben, dass es gelingt, in Sachfragen eine Einigung
-                      zu \nerzielen. Wir haben miteinander gerungen, das stimmt. \nEs ist auch nicht immer
-                      so schnell gegangen, wie man es \nsich gewünscht hat. Aber am Ende zählt das Ergebnis.\nDas
-                      ist ehrlicherweise auch das, was die Menschen \nvon Politik erwarten: dass man Lösungen
-                      für anstehende \nProbleme zustande bringt. Deswegen senden wir heute \nBundesrat
-                      – 1009. Sitzung – 8. Oktober 2021 427\nnicht nur ein starkes Signal für die Verkehrssicherheit,
-                      \nsondern auch für die Demokratie. – Herzlichen Dank.\nPräsident Dr. Reiner Haseloff:
-                      Danke, Frau Bür-\ngermeisterin Dr. Schaefer!\nWir kommen zur Abstimmung. Hierzu
-                      liegen Ihnen \ndie Ausschussempfehlungen vor.\nDie beteiligten Ausschüsse empfehlen
-                      in Ziffer 1, der \nVerordnung zuzustimmen. Wer dem folgen möchte, den \nbitte ich
-                      um das Handzeichen. – Das ist einstimmig.\nDamit hat der Bundesrat der Verordnung
-                      zuge-\nstimmt.\nEs bleibt abzustimmen über die empfohlene Entschlie-\nßung.\nIch
-                      frage daher, wer Ziffer 2 der Ausschussempfeh-\nlungen zustimmen möchte. – Auch
-                      Einstimmigkeit; \nMehrheit.\nDamit hat der Bundesrat auch eine Entschließung ge-\nfasst.\nTOP
-                      24:\nTOP 24\nVerordnung zur Novellierung der Preisangabenver-\nordnung (Drucksache
-                      669/21)\nEs liegen keine Wortmeldungen vor.\nWir kommen zur Abstimmung. Hierzu liegen
-                      Ihnen \ndie Ausschussempfehlungen vor. Daraus rufe ich auf:\nZiffer 1! – Mehrheit.\nZiffer
-                      2! – Mehrheit.\nDamit hat der Bundesrat der Verordnung nach Maß-\ngabe der vorangegangenen
-                      Abstimmungen zugestimmt.\nEs bleibt abzustimmen über die empfohlene Entschlie-\nßung.
-                      Ich rufe auf:\nZiffer 4! – Klare Mehrheit.\nZiffer 5! – Mehrheit.\nDamit hat der
-                      Bundesrat eine Entschließung gefasst.\nTOP 29:\nTOP 29\nEntschließung des Bunderates
-                      „Beschleunigung der \nEnergieinfrastrukturzulassungsverfahren für ei-\nnen klimaresilienten
-                      Wiederaufbau nach größe-\nren Schadenslagen“ – Antrag der Länder Nord-\nrhein-Westfalen,
-                      Rheinland-Pfalz gemäß § 36 Ab-\nsatz 2 GO BR – (Drucksache 756/21)\nEine Erklärung
-                      zu Protokoll1 gibt Herr Minister \nDr. Holthoff-Pförtner (Nordrhein-Westfalen) ab.
-                      –\nKeine Wortmeldungen.\nIch weise die Vorlage – federführend – dem Wirt-\nschaftsausschuss
-                      sowie – mitberatend – dem Umwelt-\nausschuss zu.\nSehr geehrte Damen und Herren,
-                      falls niemand einen \nAntrag auf eine Sondersitzung stellt, war dies meine \nletzte
-                      offizielle Leitung als Präsident. Danke für die Dis-\nziplin, die Sie immer haben
-                      walten lassen. Sie haben mir \ndas Leben sehr leicht gemacht. Es war schön mit Ihnen.
-                      \nWir bleiben aber zusammen.\nWir haben die Tagesordnung für heute erledigt.\nDie
-                      nächste Sitzung ist am 5. November 2021, \n9.30 Uhr.\nHalten Sie weiterhin Abstand,
-                      wenn Sie das Haus ver-\nlassen, aber auch darüber hinaus. Bleiben Sie schön \ngesund.
-                      Alles Gute! Und möge uns weiterhin alles gelin-\ngen, was wir uns gemeinsam als
-                      Demokraten vorgenom-\nmen haben. Herzlichen Dank!\n(Beifall)\nDie Sitzung ist geschlossen.\n(Schluss:
-                      11.19 Uhr)\n1 Anlage 5\n428 Bundesrat – 1009. Sitzung – 8. Oktober 2021\nBeschlüsse
-                      im vereinfachten Verfahren (§ 35 GO BR)\nBericht der Bundesregierung über die Entwicklung
-                      der Finanzhilfen des \nBundes und der Steuervergünstigungen für die Jahre 2019 bis
-                      2022 \n(28. Subventionsbericht)\n(Drucksache 690/21)\nAusschusszuweisung: Fz\nBeschluss:
-                      Kenntnisnahme\nErste Verordnung zur Änderung des Außenwirtschaftsgesetzes und der
-                      \nAußenwirtschaftsverordnung\n(Drucksache 700/21)\nAusschusszuweisung: Wi\nBeschluss:
-                      Absehen von Stellungnahme\nFeststellung gemäß § 34 GO BR\nEinspruch gegen die Berichte
-                      über die 1007. und \ndie 1008. Sitzung ist nicht eingelegt worden. Damit \ngelten
-                      die Berichte gemäß § 34 GO BR als geneh-\nmigt.\nBundesrat – 1009. Sitzung – 8.
-                      Oktober 2021 429*\nAnlage 1\nErklärung\nvon Staatsministerin Lucia Puttrich\n(Hessen)\nzu
-                      Punkt 9 der Tagesordnung\nEinleitung\nDie EU hat sich aufgemacht, mit Bürgerinnen
-                      und \nBürgern, Vertretern des Europäischen Parlaments und mit \nVertretern der nationalen
-                      Parlamente über die künftige \nAusgestaltung Europas zu sprechen.\nDieser Prozess
-                      kommt nur sehr langsam voran. Das \nZiel, bereits im nächsten Frühjahr einen überzeugenden
-                      \nAbschluss zu schaffen, mit einer klaren Botschaft, wohin \nder europäische Weg
-                      führen wird, kann vermutlich nicht \nerreicht werden.\nIm Juni dieses Jahres fand
-                      die erste Plenarversamm-\nlung statt, und erst Ende Oktober folgt die zweite. Bis
-                      \nzum heutigen Tag gibt es keine Festlegung über die Rolle \nder künftigen Arbeitsgruppen
-                      und deren Mitglieder. Man \nmerkt der Konferenz deutlich an, dass es lange Unklar-\nheiten
-                      über die Organisation und Struktur gab und noch \nimmer gibt.\nMit dieser Geschwindigkeit
-                      drohen sich die ambitio-\nnierten Ziele der Konferenz ins Gegenteil zu verkehren
-                      –\ngeweckte Hoffnungen werden enttäuscht. Deshalb ist es \nrichtig und wichtig,
-                      dass wir uns als Bundesrat regelmä-\nßig zu Wort melden und somit zum inhaltlichen
-                      Antrei-\nber der Konferenz werden. Vor diesem Hintergrund \nunterstützt Hessen den
-                      vorliegenden Antrag.\nEuropa kann jetzt vieles richtig machen\nDie Zeit ist reif
-                      für Reformen auf europäischer Ebene. \nDie Corona-Krise hat der Debatte um unsere
-                      europäische \nZukunft neues Momentum verliehen, und die Bürgerin-\nnen und Bürger
-                      würden sicherlich eine Reformagenda \nunterstützen. Ein Jahrzehnt nach dem letzten
-                      großen \nIntegrationsschritt, nach Finanzkrisen und dem Brexit \nbraucht Europa
-                      dringend ein Update: Wir müssen wirt-\nschaftlich innovativer, politisch souveräner
-                      und mit Blick \nauf die interne Abstimmung auch demokratischer wer-\nden.\nStattdessen
-                      hangeln wir uns von einer Krise zur nächs-\nten. Im Krisenmanagement als Dauerzustand
-                      wird Europa \njedoch im globalen Wettstreit keine Chance haben. Dazu \nbrauchen
-                      wir Mut nach innen und Entschlossenheit nach \naußen. Den nötigen Reformgeist muss
-                      die Zukunftskon-\nferenz jetzt entwickeln. Es kommt daher entscheidend \ndarauf
-                      an, ob wir Europäer die Kraft finden, gemeinsame \nZiele zu formulieren. Ziele für
-                      ein Europa auf Augenhöhe \nmit anderen Regionen der Welt.\nBürgerbeteiligung\nIch
-                      bin vom Weg der europäischen Integration über-\nzeugt und ich halte das Format der
-                      Zukunftskonferenz \ngrundsätzlich für geeignet, organisiert und strukturiert \neine
-                      ernsthafte Debatte zu führen.\nInsbesondere die starke Einbindung der Bürgerinnen
-                      \nund Bürger in die Konferenz kann dazu beitragen, dass \nam Ende Ergebnisse herauskommen,
-                      die von einem gro-\nßen Teil der Bevölkerung als echter Fortschritt empfun-\nden
-                      werden. Denn darin liegt der Schlüssel für die \nAkzeptanz künftiger Reformschritte.
-                      Es gehört für mich \ndeshalb auch zur Aufgabe der Konferenz, die Europäe-\nrinnen
-                      und Europäer wieder von Europa zu überzeugen. \nDazu muss uns der Nachweis gelingen,
-                      dass wir wirklich \nzuhören können und umsetzen, was die Menschen von \nihrer EU
-                      erwarten.\nDie Bürgerbeteiligung im Rahmen der Zukunftskonfe-\nrenz spielt deshalb
-                      eine besonders wichtige Rolle. Die \naktuellen Zahlen zur Beteiligung an den Online-\nDiskussionsforen
-                      können uns nicht zufriedenstellen. Das \nliegt auch daran, dass sich kaum eine Institution
-                      aktiv für \ndie Konferenz stark macht. Wo sind die Anzeigen, TV-\nSpots oder Veranstaltungen
-                      der EU-Institutionen, die für \neine aktive Beteiligung werben?\nWir müssen die
-                      Zukunftskonferenz zu unser aller Pro-\njekt machen. Unsere Aufgabe muss es sein,
-                      auf die \nZukunftskonferenz und ihre Beteiligungsmöglichkeiten \nhinzuweisen. In
-                      Hessen, aber auch in anderen Ländern\nwird daran bereits gearbeitet.\nDie Zukunftskonferenz
-                      ist kein Selbstzweck. Sie soll \nnicht dazu dienen, sich gegenseitig für den erreichten
-                      \nStatus quo auf die Schultern zu klopfen, sondern sie soll \nuns dazu befähigen,
-                      die drängenden Probleme der \nZukunft zu lösen. Klimaschutz, Digitalisierung und
-                      ja, \nauch die wirtschaftlichen Herausforderungen. Dazu \nbraucht es die Kraft und
-                      den Willen und – lassen Sie\nmich das ausdrücklich ergänzen – auch das Vertrauen
-                      in \nden Zukunftswillen der EU.\nAnlage 2\nErklärung\nvon Ministerin Birgit Honé\n(Niedersachsen)\nzu
-                      Punkt 9 der Tagesordnung\nDie vorliegende Stellungnahme würdigt zu Recht die \neuropaweit
-                      stattfindenden Diskussionen im Rahmen der \nKonferenz zur Zukunft Europas. Die Konferenz
-                      ist \neine große Chance, die Europäische Union auf ein noch \nstärkeres von seinen
-                      Bürgerinnen und Bürgern getragenes \n430* Bundesrat – 1009. Sitzung – 8. Oktober
-                      2021\nFundament zu setzen und den europäischen Reformpro-\nzess voranzubringen.\nBereits
-                      seit April dieses Jahres können die Bürgerin-\nnen und Bürger ihre Ideen und Vorschläge
-                      zur Gestaltung \nder Europäischen Union auf der digitalen Plattform der \nKonferenz
-                      einbringen. Und erfreulicherweise sind bereits\nüber 8.000 solcher Ideen eingegangen.\nZudem
-                      geht es jetzt – endlich – auch richtig los. Die \nverschiedenen Europäischen Bürgerforen
-                      tagen derzeit,\nund bald werden auch die Arbeitsgruppen der Plenarver-\nsammlung
-                      ihre Arbeit aufnehmen.\nDer Erfolg der Konferenz liegt im Interesse aller, die \ndas
-                      Projekt der Europäischen Union weiter voranbringen \nwollen. Vor diesem Hintergrund
-                      freue ich mich sehr, den \nBundesrat zusammen mit meiner hessischen Kollegin in
-                      \nder Plenarversammlung der Konferenz vertreten zu dür-\nfen.\nEin zentraler Aspekt
-                      ist es dabei, sicherzustellen, dass \nsich die Ideen der Bürgerinnen und Bürger
-                      auch im \nErgebnisdokument der Konferenz wiederfinden werden. \nDenn es ist von
-                      fundamentaler Bedeutung, dass die Bür-\ngerinnen und Bürger erleben, dass ihre Anregungen
-                      in \nden weiteren Prozess einfließen und sie die Zukunft der \nEuropäischen Union
-                      dadurch mitgestalten können. Eine \nUnion, die mehr ist als nur ein Wirtschaftsraum.
-                      Eine \nUnion, die Identität stiftet und den sozialen Zusammen-\nhalt stärkt. Eine
-                      Union, die von ihren Bürgerinnen und \nBürgern getragen wird. Deswegen unterstütze
-                      ich die \nForderung der vorliegenden Stellungnahme mit Nach-\ndruck, sich im Rahmen
-                      der Konferenz auch mit der Frage \nzu befassen, unter welchen institutionellen Bedingungen
-                      \ndie aktuellen Herausforderungen bewältigt werden kön-\nnen.\nDabei ist klar: Ein
-                      starkes Europa funktioniert nur, \nwenn auch die nationale Ebene der Mitgliedstaaten
-                      aus-\nreichend mitgedacht wird. Eine gute Zusammenarbeit \nzwischen den Institutionen
-                      der Europäischen Union und \nden nationalen Parlamenten ist von hohem Mehrwert für
-                      \nalle Beteiligten.\nLassen Sie mich an dieser Stelle aber auch ein paar \nkritische
-                      Punkte zur Zukunftskonferenz anmerken:\nDer Start der Konferenz war nicht einfach.
-                      Zunächst \nhatte es lange gedauert, bis die Konferenz tatsächlich im \nMai offiziell
-                      eröffnet wurde.\nDarüber hinaus sind – teilweise bis heute – die genau-\nen Rahmenbedingungen
-                      noch nicht abschließend geklärt.\nZudem gibt es seitens der Zivilgesellschaft die
-                      aus \nmeiner Sicht berechtigte Kritik, dass die weiteren Verfah-\nrensschritte und
-                      der Umgang mit den späteren Ergebnis-\nsen der Konferenz noch nicht klar kommuniziert
-                      sind.\nHier gibt es also noch „Luft nach oben“ und Verbesse-\nrungspotential. Aber
-                      ich bin mir sicher, dass wir auch \nhier im konstruktiven Dialog zu Lösungen kommen
-                      wer-\nden.\nWir stehen vor großen Herausforderungen. Die Bewäl-\ntigung der Pandemie,
-                      die notwendige sozial-ökologische \nTransformation, die Digitalisierung und die
-                      Verteidigung \nund Wahrung unserer Grundwerte, um nur einige zu \nnennen. Die Konferenz
-                      gibt uns einen Rahmen, in dem \nwir diese Herausforderungen angehen und Lösungen
-                      \nentwickeln können. Daher kommt die Konferenz aus \nmeiner Sicht gerade zum richtigen
-                      Zeitpunkt. Aber eine \nehrliche und kritische Auseinandersetzung mit der Kon-\nferenz
-                      ist wichtig. Denn nur dann sind wir glaubwürdig \nund haben auch die Möglichkeit,
-                      an diesen Punkten zu \narbeiten und die Konferenz zu einem Erfolg zu bringen.\nLassen
-                      Sie uns gemeinsam daran arbeiten, dass die \nKonferenz ein Erfolg wird. Zum einen,
-                      indem wir selbst \nVeranstaltungen durchführen und uns – wie mit dieser \nStellungnahme
-                      – aktiv an der Diskussion über die \nZukunft Europas beteiligen. Zum anderen, indem
-                      wir alle \nBürgerinnen und Bürger dazu aufrufen, sich aktiv in die \nZukunftskonferenz
-                      einzubringen. Ich bin überzeugt: \nGemeinsam können wir die EU für die großen Aufgaben
-                      \nunserer Zeit wappnen.\nDieser Aspekt führt uns zu dem heutigen Beschlussan-\ntrag.\nMit
-                      Zuversicht sehen wir nämlich, dass durch das ver-\ngleichende und objektive Monitoring
-                      aller Mitgliedstaa-\nten ein politischer Dialog ermöglicht wird. Schon der \nerste
-                      Rechtsstaatsbericht trug in mehreren europäischen \nMitgliedstaaten zu innerpolitischen
-                      Debatten zum \nZustand der Rechtsstaatlichkeit bei. Darüber hinaus wur-\nden teilweise
-                      sogar konkrete Reformen als Reaktion auf \nden Rechtsstaatlichkeitsbericht angestrengt.
-                      Gute Bei-\nspiele sind hierfür die Slowakei oder Tschechien. Dort \nsind wichtige
-                      und schon lange Zeit notwendige Reformen \nund Reforminitiativen etwa im Justizwesen
-                      als Antwort \nauf den Rechtsstaatlichkeitsbericht zu verzeichnen.\nIch hoffe sehr,
-                      dass die neuen positiven Entwicklun-\ngen in diesen Mitgliedstaaten nun auch auf
-                      diejenigen \nübergehen, die wir zurzeit noch mit ernster Besorgnis \nbeobachten.
-                      Denn Rechtsstaatlichkeit ist das Fundament, \nauf dem die EU gebaut ist.\nBundesrat
-                      – 1009. Sitzung – 8. Oktober 2021 431*\nAnlage 3\nUmdruck 8/2021\nZu den folgenden
-                      Punkten der Tagesordnung der \n1009. Sitzung des Bundesrates möge der Bundesrat
-                      \ngemäß den vorliegenden Empfehlungen und Vor-\nschlägen beschließen:\nI.\nZu den
-                      Vorlagen die Stellungnahmen abzugeben \noder ihnen nach Maßgabe der Empfehlungen
-                      zuzu-\nstimmen, die in der jeweils zitierten Empfehlungs-\ndrucksache wiedergegeben
-                      sind:\nPunkt 11\nMitteilung der Kommission an das Europäische Par-\nlament, den
-                      Rat, den Europäischen Wirtschafts- und \nSozialausschuss und den Ausschuss der Regionen\nFörderung
-                      eines europäischen Konzepts für künst-\nliche Intelligenz\nCOM(2021) 205 final\n(Drucksache
-                      561/21, Drucksache 561/1/21)\nPunkt 19\nVerordnung zur Anpassung nationaler Rechtsvor-\nschriften
-                      an unionsrechtliche Vorschriften über \nAromen und Aromen enthaltende Lebensmittel\n(Drucksache
-                      656/21, Drucksache 656/1/21)\nII.\nDen Vorlagen ohne Änderung zuzustimmen:\nPunkt
-                      15\nVerordnung zur Änderung der Wahlordnung, der \nWahlordnung Seeschifffahrt und
-                      der Verordnung zur \nDurchführung der Betriebsratswahlen bei den Post-\nunternehmen
-                      (Drucksache 666/21)\nPunkt 16\nVerordnung zur Bestimmung des für die Fortschrei-\nbung
-                      der Regelbedarfsstufen nach § 28a und des Teil-\nbetrags nach § 34 Absatz 3a Satz
-                      1 des Zwölften \nBuches Sozialgesetzbuch maßgeblichen Prozentsatzes \nsowie zur
-                      Ergänzung der Anlagen zu §§ 28 und 34 des \nZwölften Buches Sozialgesetzbuch für
-                      das Jahr 2022 \n(Regelbedarfsstufen-Fortschreibungsverordnung \n2022 – RBSFV 2022)
-                      (Drucksache 719/21)\nPunkt 18\nVerordnung zur Änderung der Zweiten Verordnung \nzur
-                      Änderung der InVeKoS-Verordnung (Drucksa-\nche 654/21)\nPunkt 20\nVerordnung zur
-                      Stärkung der Organisationen und Lie-\nferketten im Agrarbereich (Agrarorganisationen-\nund-Lieferketten-Verordnung
-                      – AgrarOLkV) \n(Drucksache 667/21)\nPunkt 21\nZweite Verordnung zur Änderung der
-                      Direktzahlun-\ngen-Durchführungsverordnung (Drucksache \n668/21)\nPunkt 23\nVerordnung
-                      zur Änderung der Kehr- und Überprü-\nfungsordnung und weiterer Vorschriften (Drucksache
-                      \n658/21)\nIII.\nDer Verordnung zuzustimmen und die in der Emp-\nfehlungsdrucksache
-                      angeführte Entschließung zu \nfassen:\nPunkt 25\nVerordnung zur Änderung der Niederdruck-\nanschlussverordnung
-                      (Drucksache 670/21, Drucksa-\nche 670/1/21)\nIV.\nEntsprechend den Anregungen und
-                      Vorschlägen zu \nbeschließen:\nPunkt 26\nBestellung eines Mitglieds des Verwaltungsrates
-                      der \nKreditanstalt für Wiederaufbau (Drucksache \n692/21, Drucksache 692/1/21)\nPunkt
-                      27\nBenennung eines Mitglieds für den Beirat Deutsch-\nlandstipendium beim Bundesministerium
-                      für Bildung \nund Forschung (Drucksache 673/21, Drucksache \n673/1/21)\nPunkt 28\nBenennung
-                      eines stellvertretenden Mitglieds für den \nBeirat der Bundesnetzagentur für Elektrizität,
-                      Gas, \nTelekommunikation, Post und Eisenbahnen\n(Drucksache 742/21)\n432* Bundesrat
-                      – 1009. Sitzung – 8. Oktober 2021\nAnlage 4\nErklärung\nvon Minister Prof. Dr. Benjamin-Immanuel
-                      Hoff\n(Thüringen)\nzu Punkt 16 der Tagesordnung\nFür die Länder Thüringen und Bremen
-                      gebe ich fol-\ngende Erklärung zu Protokoll:\nDie Länder Thüringen und Bremen stellen
-                      fest, dass \ndie in der Regelbedarfsstufen-Fortschreibungs-\nverordnung 2022 vorgesehene
-                      Erhöhung der Regelbe-\ndarfe um 0,76 Prozent beziehungsweise 2 bis 3 Euro \nnicht
-                      ausreichend ist, um die steigenden Verbraucherprei-\nse zum Beispiel bei Nahrungsmitteln,
-                      Hygieneprodukten \noder Telekommunikation auszugleichen. Zudem werden \ndie Regelbedarfe
-                      nach wie vor als nicht ausreichend \nerachtet, um das soziokulturelle Existenzminimum
-                      abzu-\nsichern. Die grundsätzliche Kritik am Verfahren der \nErmittlung und der
-                      Bemessung der Regelbedarfe bleibt \ninsofern bestehen.\nVor dem Hintergrund der
-                      Corona-Pandemie wäre \nunter anderem die monatliche Zahlung eines Zuschlages \nin
-                      Höhe von 100 Euro für Leistungsbeziehende in den \nRechtskreisen der Sozialgesetzbücher
-                      II und XII sowie \ndes Asylbewerberleistungsgesetzes geboten, um wirt-\nschaftliche
-                      und soziale Probleme der Betroffenen abzu-\nmildern. Leider wurde dieser Vorschlag,
-                      der auch breite \nUnterstützung aus dem Kreis der Sozialverbände erfahren \nhat,
-                      nicht aufgegriffen.\nThüringen und Bremen bekräftigen darüber hinaus die \nKritik
-                      an der Ermittlung und Höhe der Regelbedarfe für \nKinder und Jugendliche und unterstreichen
-                      die Forderung \nnach Einführung einer Kindergrundsicherung. Gerade \nauch in der
-                      Corona-Pandemie hat sich der Bedarf an\nWeiterentwicklung der Berechnungsmethode
-                      sowie neu-\nen Maßstäben für die Bemessung eines kind- und \njugendgerechten Existenz-
-                      und Teilhabeminimums sehr \ndeutlich gezeigt. Das Existenzminimum soll dabei nicht
-                      \nnur den notwendigen Lebensunterhalt sichern, sondern \nauch den Bedarf an Bildungs-
-                      und Teilhabeleistungen \nabdecken. Die aktuell vorgesehene Erhöhung des Betra-\nges
-                      zur Ausstattung mit persönlichem Schulbedarf wird \nals viel zu gering eingeschätzt.\nAnlage
-                      5\nErklärung\nvon Minister Dr. Stephan Holthoff-Pförtner\n(Nordrhein-Westfalen)\nzu
-                      Punkt 29 der Tagesordnung\nIch freue mich, dass wir heute ein Thema zur \nBeschleunigung
-                      von Zulassungsverfahren auf der \nTagesordnung haben. Unabhängig von der Frage,
-                      wer an \nder neuen Bundesregierung beteiligt ist, ist die Energie-\nwende eine der
-                      zentralen Herausforderungen der nächs-\nten Legislaturperiode, wenn wir bis zum
-                      Jahr 2045 das \nZiel der Klimaneutralität in Deutschland erreichen wol-\nlen. Diese
-                      können wir nur bewältigen, wenn die hierfür \nbenötigten Energieinfrastrukturen
-                      zügig geplant, geneh-\nmigt und gebaut werden.\nDer von Rheinland-Pfalz und Nordrhein-Westfalen
-                      \neingebrachte Entschließungsantrag enthält konkrete Vor-\nschläge, um die Zulassungsverfahren
-                      für Energieinfra-\nstrukturen zu beschleunigen. Wir bitten die kommende \nBundesregierung,
-                      die im Antrag enthaltenen Anregungen \nschnellstmöglich auf die politische Agenda
-                      zu setzen. \nEinen Aufschub können wir uns nicht leisten, wenn wir \ndie nationalen
-                      Klimaschutzziele erreichen wollen.\nDer Antrag enthält insbesondere Anregungen für
-                      einen \nbeschleunigten Wiederaufbau der Energieinfrastrukturen \nnach größeren Schadenslagen.
-                      Infolge des Starkregens \nund des Hochwassers im Juli dieses Jahres in Rheinland-\nPfalz
-                      und Nordrhein-Westfalen kam es zu schweren \nSchäden an der Infrastruktur, insbesondere
-                      auch an Lei-\ntungen zur Versorgung mit Gas und Strom. Der Bundes-\nrat hat mit
-                      Beschluss vom 10. September 2021 festge-\nstellt, dass der Klimawandel zu einer
-                      Zunahme von \nextremen Wetterereignissen und damit einhergehenden \nSchäden und
-                      Beeinträchtigungen der Infrastruktur führt. \nDie verheerenden Ereignisse haben
-                      gezeigt, dass in kur-\nzer Zeit versorgungsrelevante Infrastrukturen erheblich in
-                      \nMitleidenschaft gezogen oder gar zerstört werden kön-\nnen. Wir müssen in der
-                      Lage sein, in der Zukunft derarti-\nge Schäden so schnell wie möglich zu beheben.
-                      In die-\nsem Zusammenhang bat der Bundesrat die Bundesregie-\nrung per Beschluss,
-                      die Regelungen des Planungssicher-\nstellungsgesetzes bei der Digitalisierung von
-                      Verwal-\ntungsverfahrensschritten in unbefristetes Recht zu über-\nführen. Dies
-                      ist ein wichtiger Schritt in die richtige Rich-\ntung. Jede Chance, Zulassungsverfahren
-                      zu flexibilisieren \nund zu beschleunigen, müssen wir nutzen.\nDoch welche weiteren
-                      Möglichkeiten zur Vereinfa-\nchung und Beschleunigung der Genehmigungsverfahren
-                      \nhaben wir? Auf einige konkrete Maßnahmen möchte ich \neingehen.\nWenn extreme
-                      Wetterlagen die Energieinfrastruktur \nbeschädigen, können die Netzbetreiber nur
-                      in seltenen \nFällen sofort mit dem Wiederaufbau beginnen. Oftmals \nBundesrat –
-                      1009. Sitzung – 8. Oktober 2021 433*\nsind die beschädigten Leitungen nach Katastrophen
-                      nicht \nsofort zugänglich. In rechtlicher Hinsicht ist ein Wieder-\naufbau nicht
-                      ohne Weiteres von der bestehenden Geneh-\nmigung umfasst. Dies ist nur dann der
-                      Fall, wenn der \nWiederaufbau exakt in der bereits genehmigten Form \nerfolgt. Ein
-                      solcher Aufbau ist aber nicht unbedingt \nzweckmäßig. So kann es beispielsweise
-                      sinnvoll sein, die \nLeitungsführung zu ändern, um erneute Schadensfälle bei \nWetterereignissen
-                      und deren Folgen zu vermeiden. Bei-\nspielsweise baut man eine vom Hochwasser beschädigte
-                      \nLeitung sinnvollerweise in einem größeren Abstand zu \neinem in der Nähe gelegenen
-                      Fluss wieder auf, anstatt sie \nwieder an derselben, gefährdeten Stelle zu verlegen.\nDa
-                      solche – wenn auch nur geringfügige – Änderun-\ngen nicht vom Genehmigungsumfang
-                      erfasst sind, müss-\nten sie nach derzeitigem Recht neu zugelassen werden. \nHierfür
-                      brauchen wir schnelle und unkomplizierte Zulas-\nsungsverfahren. Das zeitaufwändige
-                      Planfeststellungsver-\nfahren mit Öffentlichkeitsbeteiligung und Umweltver-\nträglichkeitsprüfung
-                      kann bei geringfügigen Abweichun-\ngen nicht der richtige Weg sein. Unwesentliche
-                      Ände-\nrungen können bereits nach aktuell gültigem Recht im \nschlanken Anzeigeverfahren
-                      zugelassen werden. Dies \nmuss selbstverständlich auch bei geringfügigen Änderun-\ngen
-                      beim Wiederaufbau von Energieinfrastrukturen nach \nKatastrophenfällen regelmäßig
-                      vereinfacht möglich sein.\nVereinfachungen brauchen wir allerdings auch bei \nwesentlichen
-                      Änderungen, wenn es um den Wiederauf-\nbau geht. Auch sollte hier der Baubeginn
-                      vereinfacht \nvorzeitig zugelassen werden können. Es bestehen bereits \nRegelungen
-                      im Fachplanungsrecht, an die wir hierfür \nanknüpfen können.\nEine weitere Maßnahme
-                      wäre eine separate Planfest-\nstellungsfähigkeit für die bislang nur als Nebenanlagen
-                      \nim Zusammenhang mit Energieversorgungsleitungen \nenergierechtlich zulassungsfähigen
-                      Anlagen wie bei-\nspielsweise Umspannwerke. Dies würde nicht nur beim \nWiederaufbau
-                      der Versorgungsstrukturen an sichereren \nOrten die Resilienz erhöhen, sondern angesichts
-                      zuneh-\nmender Punktmaßnahmen auch die weitere Optimierung \nder Energieinfrastrukturen
-                      für die Energiewende erleich-\ntern.\nAuf diese Weise können wir sicherstellen,
-                      dass der \nWiederaufbau zügig in die Wege geleitet werden kann \nund nicht an langen
-                      Genehmigungsverfahren scheitert \noder zu sehr in die Länge gezogen wird.\nLassen
-                      Sie uns zum Abschluss gemeinsam einen Blick \nin die Zukunft wagen: Bereits eingangs
-                      habe ich das Ziel \nder Klimaneutralität im Jahr 2045 erwähnt. Die hierfür \nnotwendigen
-                      Veränderungen unserer Energieerzeugung \nund der Energieinfrastrukturen sind enorm.
-                      Wir werden \ndie damit verbundenen Herausforderungen nur dann \nrichtig angehen,
-                      wenn wir alle Energieträger in ein Lang-\nfristszenario einbinden. Die Netzentwicklungsplanung
-                      für \nStrom, Gas und Wasserstoff muss langfristig aufeinander \nabgestimmt und synchronisiert
-                      werden. Nur dann können \nSynergieeffekte bei der Planung der Energieinfrastruktu-\nren
-                      erzielt werden.\nIch möchte Sie um Unterstützung unseres Antrags bit-\nten. Er ist
-                      ein weiterer wichtiger Schritt auf dem Weg zu \nunserem gemeinsamen Ziel der Klimaneutralität."
-                    fundstelle:
-                      pdf_url: https://dserver.bundestag.de/brp/1009.pdf
-                      id: '5431'
-                      dokumentnummer: '1009'
-                      datum: '2021-10-08'
-                      dokumentart: Plenarprotokoll
-                      herausgeber: BR
-                      urheber: [ ]
-
-                cursor: AoJwwNOKm/oCNFBsZW5hcnByb3Rva29sbC01NDIz
-        '401':
-          $ref: "#/components/responses/UnauthorizedError"
-        '404':
-          $ref: "#/components/responses/NotFoundError"
-
-  /plenarprotokoll-text/{id}:
-    get:
-      summary: Volltexte der Plenarprotokolle
-      description: Soweit vorhanden werden zusätzlich die Volltexte der Plenarprotokolle ausgegeben
-      tags:
-        - plenarprotokoll      
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-            example: 908
-          required: true
-          description: ID des Plenarprotokolles
-        - in: query
-          name: format
-          schema:
-            type: string
-            enum:
-              - json
-              - xml
-          description: Format
-          example: "json"
-          required: false
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-              example:
-                id: '908'
-                dokumentart: Plenarprotokoll
-                typ: Dokument
-                dokumentnummer: 19/1
-                wahlperiode: 19
-                herausgeber: BT
-                datum: '2017-10-24'
-                titel: Protokoll der 1. Sitzung des 19. Deutschen Bundestages
-                text: "Plenarprotokoll 19/1\nDeutscher Bundestag\nStenografischer Bericht\n1. Sitzung\nBerlin,
-                  Dienstag, den 24. Oktober 2017 \nInhalt:\nAlterspräsident Dr. Hermann Otto Solms
-                  . . . .  1 A\nTagesordnungspunkt 1:\nEröffnung der Sitzung durch den Alterspräsi-\ndenten\nDrucksache
-                  19/2 . . . . . . . . . . . . . . . . . . . . . . .  1 C\nAlterspräsident Dr. Hermann
-                  Otto Solms . . . .  1 C\nTagesordnungspunkt 2:\nBeschlussfassung über die \n– Geschäftsordnung
-                  des Deutschen Bundes-\ntages\n– Gemeinsame Geschäftsordnung des Bun-\ndestages und
-                  des Bundesrates für den Aus-\nschuss nach Artikel 77 des Grundgesetzes \n(Vermittlungsausschuss)\n–
-                  Geschäftsordnung für den Gemeinsamen \nAusschuss \n– Geschäftsordnung für das Verfahren
-                  nach \nArtikel 115d des Grundgesetzes\n– Richtlinien zur Überprüfung auf eine Tä-\ntigkeit
-                  oder politische Verantwortung für \ndas Ministerium für Staatssicherheit/Amt \nfür
-                  Nationale Sicherheit der ehemaligen \nDeutschen Demokratischen Republik \nDrucksache
-                  19/1 . . . . . . . . . . . . . . . . . . . . . . .  4 D\nCarsten Schneider (Erfurt)
-                  (SPD) . . . . . . . . . .  5 A\nDr. Bernd Baumann (AfD) . . . . . . . . . . . .
-                  . . .  6 A\nJan Korte (DIE LINKE) . . . . . . . . . . . . . . . . .  6 D\nMichael
-                  Grosse-Brömer (CDU/CSU) . . . . . . .  8 A\nDr. Marco Buschmann (FDP) . . . . .
-                  . . . . . . . .  9 A\nBritta Haßelmann (BÜNDNIS 90/ \nDIE GRÜNEN) . . . . . . .
-                  . . . . . . . . . . . . . . .  10 A\nTagesordnungspunkt 3:\nWahl des Präsidenten
-                  verbunden mit Na-\nmensaufruf und Feststellung der Beschlussfä-\nhigkeit . . . .
-                  . . . . . . . . . . . . . . . . . . . . . . . . . . .  12 A\nVolker Kauder (CDU/CSU)
-                  \ . . . . . . . . . . . . . .  12 A\nAlterspräsident Dr. Hermann Otto Solms . .
-                  . .  12 B\nDr. Wolfgang Schäuble (CDU/CSU)  . . . . . . .  12 B\nAlterspräsident
-                  Dr. Hermann Otto Solms . . . .  12 B\nTagesordnungspunkt 4:\nAmtsübernahme durch
-                  den Präsidenten mit \nAnsprache . . . . . . . . . . . . . . . . . . . . . . . .
-                  . . . .  13 B\nPräsident Dr. Wolfgang Schäuble . . . . . . . . . .  13 B\nTagesordnungspunkt
-                  5:\nFestlegung der Zahl der Stellvertreterinnen \nund Stellvertreter des Präsidenten
-                  \nDrucksache 19/3 . . . . . . . . . . . . . . . . . . . . . . .  16 B\nTagesordnungspunkt
-                  6:\nWahl der Stellvertreterinnen und Stellvertreter \ndes Präsidenten . . . . .
-                  . . . . . . . . . . . . . . . . . . .  16 C\nDr. Hans-Peter Friedrich (Hof)  \n(CDU/CSU)
-                  . . . . . . . . . . . . . . . . . . . . . . . . .  17 C\nThomas Oppermann (SPD)
-                  . . . . . . . . . . . . . . .  17 C\nWolfgang Kubicki (FDP)  . . . . . . . . . .
-                  . . . . . .  17 D\nPetra Pau (DIE LINKE)  . . . . . . . . . . . . . . . . .  17
-                  D\nClaudia Roth (Augsburg) (BÜNDNIS 90/ \nDIE GRÜNEN) . . . . . . . . . . . . .
-                  . . . . . . . . .  18 A\nPräsident Dr. Wolfgang Schäuble . . . . . . . . . .  18
-                  C\nDeutscher Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 24.
-                  Oktober 2017II\nTagesordnungspunkt 7:\nNationalhymne  . . . . . . . . . . . . .
-                  . . . . . . . . . . .  18 D\nNächste Sitzung  . . . . . . . . . . . . . . . . .
-                  . . . . . .  19 A\nAnlage 1\nListe der entschuldigten Abgeordneten . . . . . .  21
-                  A\nAnlage 2\nNamensverzeichnis der Mitglieder des Deut-\nschen Bundestages, die
-                  an der Wahl des Präsi-\ndenten des Deutschen Bundestages teilgenom-\nmen haben .
-                  . . . . . . . . . . . . . . . . . . . . . . . . . . .  21 A\nAnlage 3\nNamensverzeichnis
-                  der Mitglieder des Deut-\nschen Bundestages, die an der Wahl der Stell-\nvertreterinnen
-                  und Stellvertreter des Präsiden-\nten des Deutschen Bundestages teilgenommen \nhaben
-                  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .  24 B\nAnlage 4\nNamensverzeichnis
-                  der Mitglieder des Deut-\nschen Bundestages, die an der Wahl eines \nStellvertreters
-                  des Präsidenten des Deutschen \nBundestages teilgenommen haben (2. Wahl-\ngang)
-                  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .  28 A\nAnlage 5\nNamensverzeichnis
-                  der Mitglieder des Deut-\nschen Bundestages, die an der Wahl eines \nStellvertreters
-                  des Präsidenten des Deutschen \nBundestages teilgenommen haben (3. Wahl-\ngang)
-                  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .  31 B\nAnlage 6\nAmtliche
-                  Mitteilungen  . . . . . . . . . . . . . . . . . .  35 A\n(A) (C)\n(B) (D)\nDeutscher
-                  Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 2017
-                  1\n1. Sitzung\nBerlin, Dienstag, den 24. Oktober 2017\nBeginn: 11.00 Uhr\nAlterspräsident
-                  Dr. Hermann Otto Solms: \nGuten Morgen, liebe Kolleginnen und Kollegen! Neh-\nmen
-                  Sie bitte Platz.\nMeine sehr verehrten Damen und Herren! Liebe \nKolleginnen und
-                  Kollegen! Ich begrüße Sie zur konsti-\ntuierenden Sitzung des 19. Deutschen Bundestages.
-                  Es \nentspricht der ständigen Übung, zu Beginn der konsti-\ntuierenden Sitzung nach
-                  den Regelungen der bisherigen \nGeschäftsordnung des Deutschen Bundestages zu ver-\nfahren.\n§
-                  1 Absatz 2 der Geschäftsordnung des Deutschen \nBundestages sieht vor, dass das
-                  am längsten dem Bun-\ndestag angehörende Mitglied, das hierzu bereit ist, den \nVorsitz
-                  übernimmt, bis der Deutsche Bundestag einen \nPräsidenten gewählt hat.\nDie Fraktion
-                  der AfD widerspricht diesem Verfahren \nund hat auf Drucksache 19/2 beantragt, einen
-                  Versamm-\nlungsleiter zu wählen, der die konstituierende Sitzung \neröffnen soll.
-                  Über diesen Antrag lasse ich sofort abstim-\nmen. Wer dem Antrag der Fraktion der
-                  AfD zustimmt, \nden bitte ich um sein Handzeichen. – Gegenstimmen? – \n(Lachen bei
-                  Abgeordneten der AfD)\nEnthaltungen? – Der Antrag ist damit mit den Stimmen \naller
-                  Fraktionen bei Zustimmung der AfD-Fraktion ab-\ngelehnt.\nWir verfahren nunmehr
-                  entsprechend § 1 Absatz 2 \nder bisherigen Geschäftsordnung. Herr Dr. Wolfgang \nSchäuble
-                  ist das Mitglied, das dem Deutschen Bundes-\ntag am längsten angehört. Er hat jedoch
-                  auf das Amt des \nAlterspräsidenten verzichtet. Damit rückt das am zweit-\nlängsten
-                  dem Bundestag angehörende Mitglied nach. \nIch war von 1980 bis 2013, also 33 Jahre,
-                  Mitglied des \nDeutschen Bundestages. Ist jemand unter Ihnen, der dem \nBundestag
-                  länger angehört? –\n(Heiterkeit)\nDas scheint offenkundig nicht der Fall zu sein.
-                  Dann trifft \nes also tatsächlich zu, dass die Rolle des Alterspräsiden-\nten auf
-                  mich zukommt. Es ist mir eine Ehre und Freude \nzugleich, den Vorsitz bis zur Amtsübernahme
-                  durch den \nneugewählten Präsidenten des Deutschen Bundestages \nzu übernehmen.\nDamit
-                  rufe ich nun den Tagesordnungspunkt 1 auf:\nEröffnung der Sitzung durch den Alterspräsiden-\nten\nDrucksache
-                  19/2\nIch eröffne als Alterspräsident die erste Sitzung der \n19. Wahlperiode und
-                  begrüße zunächst den Bundespräsi-\ndenten Herrn Dr. Frank-Walter Steinmeier.\n(Beifall)\nWir
-                  freuen uns, Herr Bundespräsident, dass Sie unter uns \nsind und dieser Konstituierung
-                  beiwohnen. \nDes Weiteren begrüße ich herzlich die ehemalige \nPräsidentin des Deutschen
-                  Bundestages Frau Dr. Rita \n Süssmuth\n(Beifall)\nsowie die ehemaligen Präsidenten
-                  des Deutschen Bun-\ndestages Herrn Dr. Wolfgang Thierse\n(Beifall)\nund natürlich
-                  den hochgeschätzten Kollegen Dr. Norbert \nLammert, der bis heute dem Bundestag
-                  vorgesessen hat.\n(Anhaltender Beifall)\nEs ist mir ein besonderes Anliegen, Frau
-                  Inge Deutsch-\nkron zu begrüßen, die im Jahre 2013 aus Anlass des Ho-\nlocaust-Gedenktages
-                  eine sehr bewegende Rede hier im \nDeutschen Bundestag gehalten hat.\n(Beifall)\nMein
-                  Gruß gilt auch den anwesenden Botschaftern \nund Missionschefs sowie allen weiteren
-                  Gästen, die auf \nder Tribüne an dieser Sitzung teilnehmen.\n(Beifall)\nAußerdem
-                  möchte ich dem Kollegen Reinhold \nSendker zu seinem heutigen 65. Geburtstag gratulieren.\n(Beifall)\nDeutscher
-                  Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 20172\n(A)
-                  (C)\n(B) (D)\nAls Nächstes habe ich gemäß § 1 Absatz 3 der Ge-\nschäftsordnung die
-                  vorläufigen Schriftführerinnen und \nSchriftführer zu ernennen. \nNach Absprache
-                  mit den Fraktionen benenne ich als \nvorläufige Schriftführerinnen und Schriftführer
-                  die Da-\nmen und Herren Abgeordneten – ich verlese jetzt die Lis-\nte –: Artur Auernhammer,
-                  Doris Barnett, Heike Baehrens, \nDr. Karamba Diaby, Sabine Dittmar, Katharina Dröge,
-                  \nDr. Fritz Felgentreu, Dr. Thomas Gebhart, Christian \nHaase, Mariana Harder-Kühnel,
-                  Sebastian Hartmann, \nMark Helfrich, Karsten Hilse, Thomas Hitschler, Dieter \nJanecek,
-                  Kerstin Kassner, Ronja Kemmer, Jens Koeppen, \nMarkus Koob, Dr. Katja Leikert, Alexander
-                  Müller, \nBettina Müller, Norbert Müller, Beate Müller-Gemmeke, \nVolker Münz, Dr.
-                  Alexander Neu, Ulli Nissen, Omid \nNouripour, Friedrich Ostendorff, Tabea Rößner,
-                  Manuel \nSarrazin, Ulle Schauws, Dr. Wieland Schinnenburg, \nBenjamin Strasser,
-                  Katrin Werner, Nicole Westig, Kai \nWhittaker, Wolfgang Wiehle, Gülistan Yüksel,
-                  Hubertus \nZdebel, Stefan Zierke, Pia Zimmermann.\nDie Abgeordneten Jens Koeppen
-                  und Doris Barnett \nbitte ich, neben mir Platz zu nehmen.\nLiebe Kolleginnen und
-                  Kollegen! Meine sehr verehr-\nten Damen und Herren! Bitte haben Sie Verständnis,
-                  dass \nich meinen Ausführungen eine sehr persönliche Erklä-\nrung vorausschicken
-                  möchte.\nIch freue mich ganz außerordentlich, dass gerade ich \nals Mitglied der
-                  Fraktion der Freien Demokraten die Sit-\nzungsperiode des 19. Deutschen Bundestages
-                  eröffnen \ndarf. Nach vier schwierigen Jahren in der außerparla-\nmentarischen Opposition
-                  haben wir das Vertrauen der \nWählerinnen und Wähler zurückgewonnen. Jetzt kön-\nnen
-                  wir der liberalen Stimme im Deutschen Bundestag \nwieder Gehör verschaffen, und
-                  das war unsere zentrale \nAufgabe und unser Ziel. Vielen Dank für Ihr Verständnis.\nMeine
-                  Damen und Herren, vorweg möchte ich allen \nKolleginnen und Kollegen zu ihrer Wiederwahl
-                  bzw. \nNeuwahl in den Deutschen Bundestag herzlich gratulie-\nren. Abgeordneter
-                  des Deutschen Bundestages zu sein, \nist eine große Ehre, aber eine noch viel größere
-                  Ver-\npflichtung; dieser müssen wir alle in den nächsten Jahren \ngerecht werden.\nDer
-                  Deutsche Bundestag ist das einzige direkt vom \nVolk legitimierte Staatsorgan. Er
-                  steht damit im Mittel-\npunkt unserer staatlichen Ordnung, auf den sich alle an-\nderen
-                  Organe beziehen. \nDer Deutsche Bundestag ist darüber hinaus eines der \neinflussreichsten
-                  demokratischen Parlamente der Welt. \nDas wird schon dadurch deutlich, dass sich
-                  der Bundes-\ntag seine Regierung wählt, diese beauftragt, kontrolliert \nund gegebenenfalls
-                  wieder ersetzen kann. Die Regierung \nist also immer auf das Vertrauen des Bundestages
-                  ange-\nwiesen. \nDer Bundestag wählt seine Regierung, nicht die Re-\ngierung ihren
-                  Bundestag. Das wird in der öffentlichen \nÜbertragung häufig nicht eindeutig dargestellt.
-                  Die in \nder Verfassung vorgesehene Richtlinienkompetenz des \nBundeskanzlers bzw.
-                  der Bundeskanzlerin bezieht sich \nnur auf das Handeln der Regierung und nicht auf
-                  die Ent-\nscheidungsfindung im Deutschen Bundestag, auch wenn \ndas in den Medien
-                  häufig anders dargestellt wird. \n(Beifall bei Abgeordneten der AfD und der \nFDP)\nDer
-                  Bundestag bestimmt die politischen Zielsetzun-\ngen und die grundsätzlichen Lösungswege.
-                  Die Regie-\nrung führt sie aus. \nAn zwei Beispielen möchte ich deutlich machen,
-                  \nwie weit die Entscheidungsbefugnisse des Bundesta-\nges reichen. Zu Beginn der
-                  90er-Jahre verklagte die \nFDP-Bundestagsfraktion die eigene Regierung vor dem \nBundesverfassungsgericht
-                  wegen der Zulässigkeit der \nOut-of-Area-Einsätze der Bundeswehr. Als damaliger
-                  \nFraktionsvorsitzender habe ich die Klage vor dem Bun-\ndesverfassungsgericht vertreten,
-                  genauso wie der bis \nheute unvergessene Kollege Peter Struck, der die gleich-\nzeitige
-                  Klage der damaligen Oppositionsfraktion SPD \nvertreten hat. \nAufgrund des Urteils
-                  des Bundesverfassungsgerichts \nbedürfen seither alle Auslandseinsätze der Bundeswehr
-                  \nder Zustimmung des Parlamentes. Deswegen sprechen \nwir ja heute von einer Parlamentsarmee.
-                  Das ist der Zu-\nsammenhang: eine Verantwortung, die in anderen Län-\ndern unbekannt
-                  ist und häufig auf Verwunderung stößt, \nsich aber bei uns nach meiner Meinung bewährt
-                  hat. \n(Beifall bei Abgeordneten im ganzen Hause)\nDiese Regelung, die Staat und
-                  Soldatinnen und Soldaten \nvor leichtfertigen Entscheidungen schützt, sollte bei
-                  ei-\nner Einbettung der Bundeswehr in europäische Verteidi-\ngungsstrukturen grundsätzlich
-                  beibehalten werden. \n(Beifall bei Abgeordneten der FDP und der \nLINKEN)\nAuch
-                  im Rahmen der Euro-Stabilisierung haben wir \nein Höchstmaß an parlamentarischer
-                  Kontrolle erreicht \nund im September 2011 Rechtsgeschichte geschrieben. \nDamals
-                  ist es zum ersten Mal gelungen, einen flächende-\nckenden Parlamentsvorbehalt gegenüber
-                  den Vorrechten \nder Regierung bei der Außenvertretung des Staates zu in-\nstallieren.
-                  Dieser gilt bei allen die Haushaltsverantwor-\ntung des Bundestages betreffenden
-                  Entscheidungen der \nBundesregierung zur Euro-Stabilisierung. \nWir haben dieses
-                  Königsrecht des Parlaments, näm-\nlich das Haushaltsrecht, in Gesetze gegossen,
-                  welche die-\nses Recht garantieren. Das Recht des Parlamentes, über \ndie Einnahmen
-                  und Ausgaben des Staates zu bestimmen, \ndarf auch in Zukunft nicht eingeschränkt
-                  werden. In die-\nser Auffassung hat uns damals das Bundesverfassungsge-\nricht bestärkt.
-                  Ich zitiere:\nFür die Einhaltung des Demokratiegebots kommt es \nvielmehr entscheidend
-                  darauf an, dass der Deutsche \nBundestag der Ort bleibt, an dem eigenverantwort-\nlich
-                  über Einnahmen und Ausgaben entschieden \nwird, auch im Hinblick auf internationale
-                  und euro-\npäische Verbindlichkeiten.\nEnde des Zitats.\nLiebe Kolleginnen und Kollegen,
-                  das Wahlergeb-\nnis vom 24. September hat die Kräfteverhältnisse im \nAlterspräsident
-                  Dr. Hermann Otto Solms\nDeutscher Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin,
-                  Dienstag, den 24. Oktober 2017 3\n(A) (C)\n(B) (D)\n19. Deutschen Bundestag stärker
-                  verändert, als gemein-\nhin erwartet wurde, und zugleich auch die politischen \nRollen
-                  neu verteilt. Diese Entscheidung der Wähler ha-\nben wir zu akzeptieren. \n(Beifall
-                  bei der AfD sowie bei Abgeordneten \nder FDP)\nDas Parlament muss ein Spiegelbild
-                  der Meinungsviel-\nfalt in der Bevölkerung sein. Ich warne davor, Sonder-\nregelungen
-                  zu schaffen, auszugrenzen oder gar zu stig-\nmatisieren. \n(Beifall bei der CDU/CSU,
-                  der SPD, der AfD \nund der FDP sowie bei Abgeordneten des \nBÜNDNISSES 90/DIE GRÜNEN)\nWir
-                  alle haben das gleiche Mandat, gleiche Rechte, aber \nauch gleiche Pflichten. \n(Beifall
-                  im ganzen Hause)\nEs ist klug, sich im politischen Wettbewerb auf inhaltli-\nche
-                  Auseinandersetzungen zu konzentrieren. Dabei gilt: \nJeder, der hier das Wort ergreift,
-                  übernimmt persönlich \ndie Verantwortung für das Gesagte. Durch die Wahl sind \nwir
-                  jetzt die Repräsentanten des Volkes, und der Wille \ndes Volkes, von dem alle Staatsgewalt
-                  ausgeht, ist Maß-\nstab unseres Handelns. \nSelbstverständlich fühlen wir uns alle
-                  auch verant-\nwortlich gegenüber unseren Parteien, die uns als Kan-\ndidaten nominiert
-                  haben. Das Grundgesetz bestimmt, \ndass die Parteien bei der politischen Willensbildung
-                  \nmitwirken. Ohne Parteien ist dies auch gar nicht zu or-\nganisieren. Wer Demokratie
-                  bejaht, muss auch demokra-\ntische Parteien bejahen. Es ist zu bedauern, wie wenig
-                  \ndie Mitgliedschaft in einer Partei oder die Unterstützung \ndemokratischer Parteien
-                  in der Öffentlichkeit gewürdigt \nwerden. Wir dürfen die ehrenamtliche und unentgeltliche
-                  \nArbeit Zehntausender Politiker gerade auf kommuna-\nler und regionaler Ebene nicht
-                  vergessen, ohne die die \ndemokratische Willensbildung überhaupt nicht möglich \nwäre.\n(Beifall
-                  im ganzen Hause)\nDeshalb danke ich heute besonders allen, die bei der \nBundestagswahl,
-                  bei Landtags- oder Kommunalwahlen \nkandidiert, aber kein Mandat erhalten haben.
-                  Sie haben \nmit ihrem Engagement einen besonderen Beitrag für die \nlebendige Demokratie
-                  geleistet.\n(Beifall im ganzen Hause)\nParteien stellen das politische Personal,
-                  die Kandida-\nten für politische Ämter, und nehmen zusätzlich Einfluss \nauf die
-                  Rekrutierung und Besetzung von leitenden Posi-\ntionen in Verwaltung und Gerichten.
-                  Das ist viel Macht, \ndie große Verantwortung mit sich bringt und ein hohes \nMaß
-                  an Selbstkontrolle und Selbstdisziplin einfordert. \nWichtig ist dabei – das sollten
-                  wir nie vergessen –: Die \nVerantwortung gegenüber dem jeweiligen Parteivotum \nmuss
-                  zurückstehen hinter der Verantwortung gegenüber \nden Wählern und der Gesellschaft.\n(Beifall
-                  bei der AfD und der FDP sowie bei \nAbgeordneten der CDU/CSU, der SPD und \ndes
-                  BÜNDNISSES 90/DIE GRÜNEN)\nIch erinnere an Artikel 38 unseres Grundgesetzes. Darin
-                  \nheißt es in Absatz 1 Satz 2: Die Abgeordneten des Deut-\nschen Bundestages „sind
-                  Vertreter des ganzen Volkes, an \nAufträge und Weisungen nicht gebunden und nur
-                  ihrem \nGewissen unterworfen“. Es bleibt dabei: Es gibt kein im-\nperatives Mandat.
-                  \nLiebe Kolleginnen und Kollegen, heute wird unsere \nDemokratie erneut herausgefordert.
-                  Die gefühlte Distanz \nzwischen Bürgern und Politik steigt. Entscheidungen, die
-                  \nin parlamentarischen und rechtsstaatlichen Verfahren ge-\ntroffen werden, stoßen
-                  mitunter auf Unverständnis oder \ngar auf Protest. \nDie Bürger erwarten politische
-                  Führung und Reform-\nfähigkeit; aber sie wollen auch demokratische Verstän-\ndigung,
-                  Moderation und Ausgleich. Immer mehr Bürger \norganisieren ihre Interessen und Initiativen
-                  außerhalb der \nklassischen parteipolitischen Strukturen. Zugleich ziehen \nsich
-                  leider zu viele Menschen ganz aus der politischen \nÖffentlichkeit zurück. \nIn
-                  den sozialen Medien werden Rassismus, Antise-\nmitismus, Sexismus, Misstrauen, Ressentiments
-                  und \npopulistische Hetze kultiviert. Wir dürfen unsere Mit-\nbürgerinnen und Mitbürger
-                  nicht diesen Stimmen und \nStimmungen überlassen. \n(Beifall im ganzen Hause)\nEs
-                  ist vielmehr unsere Pflicht, das Vertrauen in die wehr-\nhafte, engagierte und lernende
-                  Demokratie zu stärken – \ndurch unser Reden und durch unser Handeln.\n(Beifall bei
-                  Abgeordneten der CDU/CSU, der \nAfD und der FDP)\nLiebe Kolleginnen und Kollegen,
-                  wir können stolz \nsein auf unsere lebendige Demokratie. In ihr geht es nicht \nnur
-                  darum, dass am Ende Mehrheiten entscheiden, son-\ndern auch darum, dass Minderheiten
-                  genauso ihre Rechte \nwahrnehmen können und dass die Menschen erkennen, \ndass im
-                  Deutschen Bundestag alle Überzeugungen zur \nSprache gebracht werden können, und
-                  zwar von allen \nBürgern, egal woher sie auch kommen, woran sie glau-\nben, welchen
-                  Geschlechts sie auch sind oder welchen \nBildungsgrad sie besitzen. \n(Beifall bei
-                  der AfD und der FDP sowie bei \nAbgeordneten der CDU/CSU, der SPD und \nder LINKEN
-                  und der Abg. Kerstin Andreae \n[BÜNDNIS 90/DIE GRÜNEN])\nDabei ist es die vornehmste
-                  Aufgabe des Parlaments, die \nFreiheits- und Grundrechte aller Bürger zu wahren
-                  und \nzu sichern, damit die Bürger im Rahmen dieser Gesetze \nihr Leben möglichst
-                  frei gestalten können und ihre Pri-\nvatsphäre geschützt wird.\n(Beifall bei Abgeordneten
-                  im ganzen Hause)\nUnsere gemeinsame Aufgabe muss es sein, dafür zu \nsorgen, die
-                  gesellschaftlichen Debatten unserer Zeit wie-\nder dahin zurückzuholen, wo sie hingehören,
-                  nämlich \nhierhin, in den Deutschen Bundestag.\n(Beifall bei Abgeordneten im ganzen
-                  Hause)\nAlterspräsident Dr. Hermann Otto Solms\nDeutscher Bundestag – 19. Wahlperiode
-                  – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 20174\n(A) (C)\n(B) (D)\nGenau hier
-                  ist der Platz der Auseinandersetzung der \nverschiedenen politischen Ausrichtungen
-                  und Überzeu-\ngungen. Hier im Deutschen Bundestag sind die Parteien \nin dem Maße
-                  vertreten, wie sie in freier Wahl bestimmt \nworden sind. Deshalb kommen hier die
-                  unterschiedli-\nchen politischen Strömungen zur Geltung, und zwar in \ndem Verhältnis,
-                  wie sie von den Wählern Unterstützung \nerhalten haben. Das Zerrbild von der Politik,
-                  wie es bei-\nspielsweise in den sozialen Medien oder in manchen \nFernseh-Talkshows
-                  dargeboten wird, gibt diese faire Re-\npräsentation nicht wieder.\n(Beifall bei
-                  Abgeordneten der AfD und der \nFDP)\nBei letzteren werden häufig Vertreter auffälliger
-                  Positi-\nonen eingeladen, weil dies eine höhere Einschaltquote \nverspricht.\nWas
-                  bedeutet das für uns? Wir müssen den Menschen \nauf Augenhöhe begegnen und ihnen
-                  Orientierung geben. \nWir brauchen eine lebendige, lebensnahe Debattenkultur. \nWir
-                  müssen dabei eine Sprache sprechen, die verstanden \nwird. Wir müssen die unterschiedlichen
-                  Positionen klar \nund deutlich herausarbeiten, damit sich die Wähler bei \nihrer
-                  Wahlentscheidung daran orientieren können. Es \nmuss für uns der lateinische Grundsatz
-                  gelten: „Suavi-\nter in modo, fortiter in re“. – Also: Maßvoll im Ton, be-\nstimmt
-                  in der Sache. \nWie auch Bundespräsident Frank-Walter Steinmeier \nbei seiner Rede
-                  zur deutschen Einheit sagte: Kontro-\nversen, ja; aber aus Differenzen darf keine
-                  Unversöhn-\nlichkeit entstehen. – Ich kann ihm nur zustimmen. Wir \nbrauchen weniger
-                  ideologische Grabenkämpfe und mehr \nproblemorientierte Lösungen.\n(Beifall bei
-                  Abgeordneten der CDU/CSU, der \nSPD, der AfD und der FDP)\nLiebe Kolleginnen und
-                  Kollegen, zum Schluss möch-\nte ich noch auf die aktuelle Größe des Bundestages
-                  zu \nsprechen kommen. Sie verspüren alle selbst, dass der \nBundestag mit 709 Mitgliedern
-                  eine unerwartet hohe \nAnzahl an Abgeordneten erreicht hat. Die Größe dieses \naufgeblähten
-                  Parlaments trägt eher dazu bei, dass die \nArbeitsfähigkeit des Bundestages genauso
-                  wie sein An-\nsehen bei den Bürgern leidet – auch wegen der dadurch \ngestiegenen
-                  Kosten.\n(Beifall bei Abgeordneten der AfD)\nWie der bisherige Bundestagspräsident
-                  Norbert Lammert \nrege auch ich an, dass sich der Bundestag rasch mit einer \nReform
-                  des Wahlrechts befasst.\n(Beifall bei der CDU/CSU, der AfD und der \nFDP sowie bei
-                  Abgeordneten der LINKEN \nund des BÜNDNISSES 90/DIE GRÜNEN)\nIm Interesse der Funktionsfähigkeit
-                  des Parlaments darf \nes dabei keine taktischen Machtspiele geben.\n(Beifall bei
-                  der AfD sowie bei Abgeordneten \nder CDU/CSU und der FDP)\nMeiner Meinung nach war
-                  das alte Wahlrecht im Wesent-\nlichen von allen politischen Kräften akzeptiert.
-                  Wenn es \nkeine schnelle Einigung gibt, sollte der Bundestag dieses \nwieder in
-                  Kraft setzen, notfalls mit verfassungsändernder \nMehrheit.\n(Beifall bei Abgeordneten
-                  der AfD und der \nFDP)\nFür die neue Legislaturperiode wünsche ich uns al-\nlen
-                  das notwendige Verantwortungsgefühl für faire und \nsachgerechte Auseinandersetzungen
-                  mit Klarheit und \nAugenmaß. Lassen Sie uns den Bürgerinnen und Bürgern \nbeweisen,
-                  dass unsere Demokratie hohe Integrationskraft \nbesitzt, dass wir nicht sprachlos
-                  gegenüber Hetze und Pa-\nrolen sind, dass wir Provokationen Argumente entgegen-\nsetzen
-                  und dass wir ernsthaft Lösungen für die Probleme \nder Zukunft finden.\n(Beifall
-                  bei der CDU/CSU, der AfD und der \nFDP sowie bei Abgeordneten der SPD, der \nLINKEN
-                  und des BÜNDNISSES 90/DIE \nGRÜNEN)\nIch freue mich auf eine gute Zusammenarbeit.\nIch
-                  danke Ihnen für Ihre Aufmerksamkeit.\n(Beifall im ganzen Hause)\nJetzt rufe ich
-                  den Tagesordnungspunkt 2 auf:\nBeschlussfassung über die \n– Geschäftsordnung des
-                  Deutschen Bundesta-\nges\n– Gemeinsame Geschäftsordnung des Bundes-\ntages und des
-                  Bundesrates für den Ausschuss \nnach Artikel 77 des Grundgesetzes (Vermitt-\nlungsausschuss)\n–
-                  Geschäftsordnung für den Gemeinsamen Aus-\nschuss \n– Geschäftsordnung für das Verfahren
-                  nach Ar-\ntikel 115d des Grundgesetzes\n– Richtlinien zur Überprüfung auf eine Tätigkeit
-                  \noder politische Verantwortung für das Minis-\nterium für Staatssicherheit/Amt
-                  für Nationale \nSicherheit der ehemaligen Deutschen Demo-\nkratischen Republik\nDrucksache
-                  19/1 \nEs liegt ein Antrag der Fraktion der CDU/CSU zur \nWeitergeltung der Geschäftsordnung
-                  des Deutschen \nBundestages sowie weiterer Geschäftsordnungen und \nRichtlinien
-                  vor. Weiterhin liegen ein Änderungsantrag \nder Fraktion der SPD, zwei Änderungsanträge
-                  der Frak-\ntion der AfD sowie zwei Änderungsanträge der Fraktion \nDie Linke vor.
-                  \nMir ist mitgeteilt worden, dass das Wort gewünscht \nwird. Die Fraktionen haben
-                  sich auf eine fünfminütige \nRunde verständigt. Sind Sie damit einverstanden? –
-                  Das \nist der Fall. \nDas Wort hat als erster Redner der Kollege Carsten \nSchneider
-                  von der SPD-Fraktion.\n(Beifall bei der SPD)\nAlterspräsident Dr. Hermann Otto Solms\nDeutscher
-                  Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 2017
-                  5\n(A) (C)\n(B) (D)\nCarsten Schneider (Erfurt) (SPD): \nSehr geehrter Herr Präsident!
-                  Sehr geehrte Kolle-\nginnen und Kollegen! Mit der heutigen Konstituierung \nnimmt
-                  der Deutsche Bundestag zum 19. Mal seine Arbeit \nauf. Er ist die wichtigste Institution
-                  im Parlamentarismus \nin Deutschland, und er ist zugleich die Herzkammer un-\nserer
-                  Demokratie; denn nur wir Abgeordneten sind vom \nVolk gewählt und damit unmittelbar
-                  legitimiert.\nIn diesem Haus debattieren wir über die besten po-\nlitischen Lösungen,
-                  streiten um die besten Argumente \nund ringen um Mehrheiten. Alle vier Jahre tun
-                  wir das \nin Wahlkämpfen, dazwischen aber hier. Debatten im \nBundestag sind daher
-                  das Thermometer für die Leben-\ndigkeit unserer Demokratie. Nur dann, wenn sich
-                  die \nBürgerinnen und Bürger in unseren Debatten wiederfin-\nden, identifizieren
-                  sie sich auch mit unserem Parlament. \nWenn aber am Küchentisch zu Hause oder am
-                  Stamm-\ntisch heftige politische Diskussionen stattfinden, die sich \nim Bundestag
-                  so nicht wiederfinden, dann verlieren wir \nals Abgeordnete unseren Rückhalt in
-                  der Bevölkerung. \nSelbstkritisch füge ich hinzu: Das war durchaus in den \nletzten
-                  Jahren der Fall und muss sich dringend ändern.\n(Beifall bei der SPD sowie bei Abgeordneten
-                  \nder LINKEN und der Abg. Britta Haßelmann \n[BÜNDNIS 90/DIE GRÜNEN])\nDer Bundestag
-                  muss wieder zur zentralen Bühne der \npolitischen Auseinandersetzung werden – und
-                  nicht Talk-\nshows im Fernsehen oder Einzelinterviews von Journa-\nlisten, Frau
-                  Bundeskanzlerin.\n(Beifall bei der SPD sowie bei Abgeordneten \nder FDP und der
-                  LINKEN)\nIhr Politikstil, Frau Merkel, ist ein Grund dafür, dass wir \nheute eine
-                  rechtspopulistische Partei hier im Bundestag \nhaben.\n(Beifall bei der SPD sowie
-                  bei Abgeordneten \nder LINKEN – Lachen bei Abgeordneten der \nAfD) \nSie haben in
-                  diesem Wahlkampf jeden politischen Streit \num die besseren Ideen und Konzepte,
-                  jede Debatte um \ndie besten Argumente verweigert. \n(Lachen bei Abgeordneten der
-                  CDU/CSU)\nDiese Vernebelungsstrategie mag in den vergangenen \nbeiden Wahlkämpfen
-                  funktioniert haben. \n(Zuruf des Abg. Volker Kauder [CDU/CSU])\nDiesmal führte sie
-                  aber dazu, dass die politischen Ränder \nstärker wurden denn je. \n(Beifall bei
-                  der SPD sowie bei Abgeordneten \ndes BÜNDNISSES 90/DIE GRÜNEN)\nDeshalb, liebe Kolleginnen
-                  und Kollegen, muss der \nBundestag wieder lebendiger werden. Er braucht keine \nRegierung,
-                  um zu arbeiten – im Gegenteil: wir halten uns \neine Regierung –, aber er braucht
-                  Regeln, die wir uns \nhier mit der gleich zu beschließenden Geschäftsordnung \nselbst
-                  geben werden. Diese Regeln müssen dem An-\nspruch des Parlaments, die Herzkammer
-                  der Demokratie \nzu sein, gerecht werden und diesen auch abbilden. Dass \ndiese
-                  Regeln reformbedürftig sind, ist nicht neu. Daran \nhaben wir bereits in der vergangenen
-                  Legislaturperiode \ngearbeitet und waren uns auch in vielen Punkten einig. \n(Katrin
-                  Göring-Eckardt [BÜNDNIS 90/DIE \nGRÜNEN]: Was?)\nGleichwohl hat Ihre Fraktion, Frau
-                  Bundeskanzlerin, die \nUnion – wenn man denn noch von einer Union sprechen \nkann
-                  –, \n(Lachen bei Abgeordneten der CDU/CSU)\nam Ende eine Einigung blockiert. \nDoch
-                  wir wollen heute nach vorne schauen. Deshalb \nbeantragen wir, dass die Frau Bundeskanzlerin,
-                  so sie \ndenn im Bundestag gewählt wird, sich viermal im Jahr \neiner direkten Befragung
-                  im Parlament stellt. Viermal im \nJahr ist nicht zu viel. \n(Beifall bei der SPD
-                  sowie bei Abgeordneten \nder AfD und der LINKEN)\nUnd – eigentlich eine Selbstverständlichkeit
-                  –: Wir wol-\nlen selbst festlegen, wozu wir die Regierung in der Re-\ngierungsbefragung
-                  befragen. Meine Damen und Herren, \ndagegen kann doch niemand sein. \n(Beifall bei
-                  der SPD sowie bei Abgeordneten \nder AfD und der LINKEN)\nOhne die Blockade der
-                  Union in der letzten Legislatur \nhätten wir diese Meilensteine schon längst beschlossen.
-                  \nIch gebe zu: Wir waren an einen Koalitionsvertrag ge-\nbunden. Deswegen, weil
-                  die Union das verhindert hat, \nhaben wir das nicht beschließen können. \n(Zurufe
-                  von Abgeordneten der CDU/CSU: \nOh!)\n– Selbstkritik gehört dazu. \n(Volker Kauder
-                  [CDU/CSU]: Warum habt ihr \ndas bei Gerhard Schröder nicht gemacht?)\nWir haben
-                  jetzt allerdings keinen Koalitionsvertrag. Oder \nhaben wir den schon, meine Damen
-                  und Herren? \nWir geben uns heute hier eine Geschäftsordnung, in \nfreier Entscheidung,
-                  und Sie haben die Möglichkeit, heu-\nte frei darüber zu entscheiden. Springen Sie
-                  auch! \n(Beifall bei der SPD sowie bei Abgeordneten \nder LINKEN)\nMachen wir heute
-                  einen Neustart, und geben wir uns Re-\ngeln, die das Parlament stärken! \nDer Bundestag
-                  hat mehr Kompetenzen als die meisten \nanderen Parlamente in Europa. Deswegen schauen
-                  auch \nviele in Europa auf uns. Bei unseren Kompetenzen sind \nwir Vorbild. Bei
-                  der Art und Weise, wie wir hier debattie-\nren, müssen wir noch besser werden. \n(Beifall
-                  bei der SPD sowie bei Abgeordneten \nder AfD)\nVielen Dank.\n(Beifall bei der SPD)\nDeutscher
-                  Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 20176\n(A)
-                  (C)\n(B) (D)\nAlterspräsident Dr. Hermann Otto Solms: \nDas Wort hat jetzt der Kollege
-                  Dr. Bernd Baumann \nvon der AfD-Fraktion.\n(Beifall bei der AfD)\nDr. Bernd Baumann
-                  (AfD): \nHerr Präsident! Meine Damen und Herren! Immer \ndeutlicher zeigte sich
-                  im Verlauf dieses Jahres, dass die \nAfD in den Bundestag einziehen würde und dass
-                  sie auch \nden Alterspräsidenten stellen würde, weil sie neben vie-\nlen jungen
-                  Abgeordneten eben auch den ältesten Abge-\nordneten mit an Bord hatte. \n(Zurufe
-                  von der SPD)\nAls dies deutlich wurde, änderten Sie hier im alten Bun-\ndestag ganz
-                  schnell die Geschäftsordnung – knapp vor \nder Wahl, zwei Wochen vor Ende Sitzungsperiode.
-                  Mei-\nne Damen und Herren, das war ein so durchsichtiges Ma-\nnöver; das lassen
-                  wir Ihnen hier nicht durchgehen! \n(Beifall bei der AfD)\nEine List, mit der Sie
-                  die AfD ausgrenzen wollten! Das \nkann so nicht weitergehen! \n(Zuruf von der FDP:
-                  Mir kommen die Trä-\nnen!)\nDie AfD hatte gerade den 13. Wahlsieg in Folge er-\nzielt
-                  – eine Triumphserie bei Landtagswahlen, die so zu-\nvor keine Partei nach ihrer
-                  Gründung erzielt hatte.\n(Beifall bei der AfD – Zuruf von der FDP: \nZur Sache!)\nDer
-                  alte Bundestag aber änderte die Geschäftsordnung \nplötzlich so, dass nicht mehr
-                  der älteste Abgeordnete, \nsondern der mit der längsten Dienstzeit die erste Sitzung
-                  \nals Alterspräsident eröffnen sollte. Und das würde dann \nnicht mehr ein AfD-Abgeordneter
-                  sein. Sie begründeten \ndies damit, dass nur der dienstälteste Abgeordnete eine
-                  \nkorrekte Sitzungsleitung sicherstellen könne. Das war \ndas Argument. Aber, meine
-                  Damen und Herren, seit 1848 \nist in Deutschland Tradition, dass die konstituierende
-                  Sit-\nzung natürlich vom ältesten Mitglied der Versammlung \neröffnet wird. \n(Beifall
-                  bei der AfD – Dr. Marco Buschmann \n[FDP]: Traditionen wollten Sie doch direkt \nbrechen!)
-                  \nDas war eine Tradition von der Frankfurter Paulskir-\nche bis Gustav Stresemann,
-                  von Adenauer über Brandt \nbis Kohl, ja bis zu der ersten Regierung Merkel. Alle
-                  \nReichstage, alle Bundestage konnten dem Argument \n„Dienstalter“ nichts abgewinnen.
-                  Das ist ja auch klar. In \n150 Jahren Parlamentsgeschichte blieb die Regel des Al-\nterspräsidenten
-                  unangetastet. \n(Christian Lindner [FDP]: Stimmt gar nicht!)\nUnangetastet? Es gab
-                  eine Ausnahme: 1933 hat Hermann \nGöring die Regel gebrochen, weil er politische
-                  Gegner \nausgrenzen wollte, damals Clara Zetkin. \n(Beifall bei der AfD – Martin
-                  Schulz [SPD]: \nDa kennt ihr euch ja aus!)\nWollen Sie sich auf solch schiefe Bahn
-                  begeben? Kom-\nmen Sie zurück auf die Linie der großen deutschen De-\nmokraten!
-                  Dazu fordere ich Sie hier auf. \n(Beifall bei der AfD)\nDenn stets eröffnete der
-                  Parlamentarier, der aufgrund \nvon Lebenserfahrung und Altersweisheit Versammlun-\ngen
-                  besonders umsichtig eröffnen konnte. Das waren die \nIdee und die Tradition über
-                  150 Jahre. Denn zur bloßen \nEröffnung ist ja kein geballtes Geschäftsordnungswissen
-                  \nvonnöten. Es wird sofort ein Versammlungspräsident ge-\nwählt, der versiert in
-                  der Sache ist. Auch deshalb ist Ihr \nArgument, der Dienstälteste müsse aus fachlichen
-                  Grün-\nden eröffnen, schlichtweg unsinnig, meine Damen und \nHerren. \n(Beifall
-                  bei der AfD)\nSelbst die Presse, die uns ja nicht durchgängig ge-\nwogen ist, warnte,
-                  dass dieses Manöver gegen die AfD \ndurchsichtig sei, und sprach von Lex AfD. Der
-                  „Tages-\nspiegel“ sprach von „Trickserei“. „Focus“ resümierte: \nDie Entscheidung
-                  wirft kein gutes Licht auf die par-\nlamentarische Kultur in Deutschland. \nRecht
-                  hat er, meine Damen und Herren! \n(Beifall bei der AfD)\nWie groß, frage ich Sie,
-                  muss die Angst vor der AfD \nund ihren Wählern sein, wenn Sie zu solchen Mitteln
-                  \ngreifen? \n(Michael Theurer [FDP]: Rabulisten!)\nDeswegen fordere ich Sie auf:
-                  Kehren Sie um! Vertrau-\nen Sie wie wir den bewährten Traditionen des deutschen
-                  \nParlamentarismus! Stimmen Sie unserem Antrag zu!\n(Beifall bei der AfD)\nMeine
-                  Damen und Herren, nehmen Sie zur Kenntnis: \nDer alte Bundestag, in dem Sie alles
-                  untereinander regeln \nund die Konkurrenz wegdrücken konnten wie hier bei \nder
-                  Frage des Alterspräsidenten, wurde abgewählt. Das \nVolk hat entschieden. Nun beginnt
-                  eine neue Epoche. \n(Beifall bei der AfD)\nVon dieser Stunde an werden hier Themen
-                  neu verhan-\ndelt, nicht nur Ihre Manöver und Tricks bei der Ge-\nschäftsordnung,
-                  sondern künftig auch Euro, gigantische \nSchuldenübernahmen, riesige Einwanderungszahlen,
-                  of-\nfene Grenzen und immer brutalere Kriminalität auf unse-\nren Straßen, meine
-                  Damen und Herren. \n(Beifall bei der AfD)\nAlterspräsident Dr. Hermann Otto Solms:\nDas
-                  Wort hat jetzt der Kollege Jan Korte von der Frak-\ntion Die Linke. \n(Beifall bei
-                  der LINKEN)\nJan Korte (DIE LINKE): \nHerr Präsident! Liebe Kolleginnen und Kollegen!
-                  \nSehr geehrte Damen und Herren! Bei aller Kritik an der \nparlamentarischen Demokratie,
-                  der Geschäftsordnung \nDeutscher Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin,
-                  Dienstag, den 24. Oktober 2017 7\n(A) (C)\n(B) (D)\nund vielem anderen mehr will
-                  ich zumindest an eines er-\ninnern: Wir sitzen hier aufgrund von freien Wahlen.
-                  Das \nhaben Millionen andere nicht. \n(Beifall bei der LINKEN, der SPD und dem \nBÜNDNIS
-                  90/DIE GRÜNEN sowie bei Ab-\ngeordneten der CDU/CSU, der AfD und der \nFDP)\nUnd
-                  wir sind dem Grundgesetz verpflichtet, das nicht \neinfach irgendein Gesetz ist,
-                  sondern das die humane \nund demokratische Antwort auf die Verheerung und die \nLeichenberge
-                  des NS-Faschismus gewesen ist. Das gilt \nes jeden Tag zu verteidigen.\n(Beifall
-                  bei der LINKEN sowie bei Abgeord-\nneten der SPD, der FDP und des BÜNDNIS-\nSES
-                  90/DIE GRÜNEN)\nAber es gibt natürlich auch berechtigte Kritik an unse-\nrem Verfahren
-                  hier, am Parlamentarismus. Dieser müssen \nwir uns stellen, und wir müssen das bessern.
-                  Deswegen \nhaben wir als Linke zwei Änderungsanträge eingebracht, \ndie ich kurz
-                  vorstellen will. \nWir wollen das Ganze lebendiger machen. Wir brau-\nchen natürlich
-                  wirklich eine bessere Kontrolle des Regie-\nrungshandelns, und wir müssen die Abgeordnetenrechte
-                  \nund den Bundestag als solchen stärken. Jeder, der einmal \ndie Regierungsbefragung
-                  und die Fragestunde gesehen \nhat – oder besser gesagt: ertragen musste –, entweder
-                  live \nhier oder bei Phoenix, weiß, dass wir diese grundlegend \nreformieren müssen.
-                  Dazu hat der geschätzte Präsident \nLammert viel Richtiges gesagt. \n(Beifall bei
-                  der LINKEN sowie bei Abge-\nordneten der SPD, der AfD, der FDP und des \nBÜNDNISSES
-                  90/DIE GRÜNEN) \nDazu gehört zwingend, dass die Fraktionen, besonders \nnatürlich
-                  die Oppositionsfraktionen, hier Themen vor-\nschlagen können, die zum Beispiel –
-                  so sie denn gewählt \nist – der Bundeskanzlerin und der Bundesregierung sehr \nunangenehm
-                  sind. Das ist ganz zentral. \nIch will eines sagen: Was wirklich nicht geht, ist,
-                  dass \nes eine Befragung der Bundeskanzlerin lediglich in der \nBundespressekonferenz
-                  gibt. Das geht nicht, liebe Kolle-\nginnen und Kollegen. \n(Beifall bei der LINKEN,
-                  der SPD, der AfD \nund dem BÜNDNIS 90/DIE GRÜNEN sowie \nbei Abgeordneten der FDP)\nIch
-                  glaube, wir sollten das auch noch aus einem an-\nderen Grunde tun: Erstens wollen
-                  wir hier besser wer-\nden: besser arbeiten, bessern streiten, wofür man übri-\ngens
-                  Sachargumente und viele Stunden Zeit braucht. Ich \nglaube ferner, dass es auch
-                  politisch sinnvoll ist, heute \nein Zeichen an diejenigen zu senden, die sich abgewandt
-                  \nhaben, die gar keine Teilhabe an dieser Demokratie mehr \nhaben, die nicht mehr
-                  wählen gehen, die damit nichts \nmehr zu tun haben wollen. Dafür ist es, finde ich,
-                  das \nMindeste, zu versuchen, es besser zu machen. \nIn diesem Zusammenhang komme
-                  ich zum zweiten \nAntrag, den meine Fraktion, Die Linke, einbringt. Wir \nmöchten
-                  – so wie es im Grundgesetz vorgeschrieben \nist – sofort, also heute, die vier im
-                  Grundgesetz zwin-\ngend vorgeschriebenen Ausschüsse des Bundestages \neinsetzen.
-                  Das sind der Auswärtige Ausschuss, der Eu-\nropaausschuss, der Verteidigungsausschuss
-                  und der Pe-\ntitionsausschuss. \nWarum? Erstens. Wir alle hier – deswegen sitzen
-                  wir \nzusammen – sind gewählt. Das hat nichts mit Koalitions-\nverhandlungen zu
-                  tun. Der Bundestag ist gewählt! Wir \nsollten mit der Arbeit beginnen, liebe Kolleginnen
-                  und \nKollegen.\n(Beifall bei der LINKEN sowie bei Abgeord-\nneten der AfD)\nZweitens.
-                  Wählerinnen und Wähler haben logischer-\nweise gerade in diesen Zeiten einen Anspruch
-                  darauf, \ndass das Parlament arbeitet, dass wir miteinander streiten \nund ringen.
-                  Wir müssen in den nächsten Monaten Aus-\nlandseinsätze der Bundeswehr verlängern,
-                  besser: ableh-\nnen. Aber dafür muss man beraten und Expertise einho-\nlen. Das
-                  ist doch eigentlich völlig logisch. \nOb Jamaika nun kommt oder nicht, werden wir
-                  alles \nsehen. Aber die Verhandlungen können doch nicht allen \nErnstes dazu führen,
-                  dass wir monatelang den Bundes-\ntag in Geiselhaft nehmen, bis Sie Ihre Befindlichkeiten
-                  in \nIhrer Koalition gelöst haben; das geht nicht. Lassen Sie \nuns als Bundestag
-                  arbeiten und streiten! \n(Beifall bei der LINKEN sowie bei Abgeord-\nneten der AfD)\nDer
-                  letzte Punkt, den ich ansprechen möchte, ist: Das \nhat auch etwas mit dem Selbstbild
-                  des Bundestages zu \ntun. Sind wir als Abgeordnete so selbstbewusst, zu sagen: \n„Die
-                  innere Organisation des Bundestages hängt nicht an \nKoalitionsverhandlungen, egal
-                  wie sie aussehen“? Ich \nfinde, dieses Selbstbewusstsein sollten wir haben, liebe
-                  \nKolleginnen und Kollegen. \n(Beifall bei der LINKEN sowie bei Abgeord-\nneten
-                  der SPD und der AfD)\nDeswegen zielen unsere Anträge auf die Stärkung des \nBundestages,
-                  auf mehr Diskurs in diesem Bundestag und \nheute vor allem als ein Zeichen an diejenigen,
-                  die sich \nabgewandt haben, aber für die wir auch hier sitzen und \ndie wir zurückgewinnen
-                  müssen, für demokratische Lö-\nsungen, für Streit, für die Menschenwürde und für
-                  das \nKenntlichmachen, wo in diesem Haus die fundamenta-\nlen Unterschiede liegen.
-                  Dafür ist erforderlich, dass wir \nals Bundestag beginnen, zu arbeiten. Das müsste
-                  doch \neigentlich auf der Hand liegen. Deshalb bitte ich um Zu-\nstimmung für unsere
-                  Änderungsanträge. \n(Beifall bei der LINKEN sowie bei Abgeord-\nneten der SPD und
-                  der AfD)\nAlterspräsident Dr. Hermann Otto Solms: \nDas Wort hat jetzt Herr Kollege
-                  Michael Grosse-\nBrömer von der CDU/CSU-Fraktion.\n(Beifall bei der CDU/CSU sowie
-                  bei Abge-\nordneten der FDP)\nJan Korte\nDeutscher Bundestag – 19. Wahlperiode –
-                  1. Sitzung. Berlin, Dienstag, den 24. Oktober 20178\n(A) (C)\n(B) (D)\nMichael Grosse-Brömer
-                  (CDU/CSU): \nHerr Präsident! Sehr verehrte Gäste! Meine lieben \nKolleginnen und
-                  Kollegen! Lieber Kollege Schneider, \nich verstehe, dass man mit 20 Prozent als
-                  Bundestags-\nwahlergebnis nach einem Schuldigen sucht. Ich empfeh-\nle, nicht immer
-                  nur ins Kanzleramt zu gucken. \n(Ulli Nissen [SPD]: Wie viel haben Sie denn \nverloren?)\nSuchen
-                  Sie im Willy-Brandt-Haus! Dort ist der Erfolg \ngrößer, dass Sie einen Schuldigen
-                  finden. Das geht dann \nvor allen Dingen auch schneller.\n(Beifall bei der CDU/CSU
-                  und der FDP)\nDavon abgesehen stehen wir heute am Beginn einer \nLegislaturperiode.
-                  Wir haben bald – sofort nach der \nKonstituierung – Arbeitsfähigkeit hergestellt.
-                  Wir haben \n289 Kolleginnen und Kollegen als neu gewählte Abge-\nordnete unter uns,
-                  die in der letzten Legislaturperiode \ndiesem Bundestag nicht angehört haben. Zwei
-                  Fraktio-\nnen sind neu ins Parlament gezogen. Diese neuen Ab-\ngeordneten werden
-                  jetzt mit teils umfangreichen Ände-\nrungsanträgen zur Geschäftsordnung begrüßt.\n(Zurufe
-                  von der SPD und der LINKEN: Oh!)\nIch halte das weder für besonders stilvoll noch
-                  für \nsachlich gerechtfertigt und fair.\n(Beifall bei der CDU/CSU und der FDP)\nDie
-                  neuen Kolleginnen und Kollegen hatten weder die \nGelegenheit, sich mit Ihren Anträgen
-                  auseinanderzuset-\nzen, \n(Widerspruch bei der SPD)\nnoch hatten sie Gelegenheit,
-                  jemals live eine Regierungs-\nbefragung oder das, was Sie ändern wollen, überhaupt
-                  \nzur Kenntnis zu nehmen oder zu erfahren. \n(Martin Schulz [SPD]: Wir helfen gerne!)
-                  \nDeswegen sagen wir: Ungeachtet der Möglichkeit, et-\nwas zu ändern, wollen wir
-                  nicht, dass heute über die An-\nträge abgestimmt wird. Wir wollen sie überweisen,
-                  damit \nsie in Ruhe und mit der gebotenen Sachlichkeit beraten \nwerden können.\n(Martin
-                  Schulz [SPD]: Ach!)\nInsofern soll sich zunächst der Ältestenrat damit beschäf-\ntigen.
-                  \n(Beifall bei der CDU/CSU sowie bei Abge-\nordneten der FDP)\nWeil wir am Anfang
-                  der Beratungen stehen, möchte \nich nur ein paar Anmerkungen machen.\nErstens: zum
-                  Änderungsantrag der AfD bezüglich des \nAlterspräsidenten. Hermann Otto Solms hat
-                  heute bewie-\nsen, dass es sinnvoll ist, nicht nur auf Lebensalter zu set-\nzen,
-                  sondern auch auf politische Erfahrung. Deswegen \nsehe ich da keinen Änderungsbedarf.\n(Beifall
-                  bei Abgeordneten der CDU/CSU und \nder FDP)\nZweitens: zu den Anträgen von SPD und
-                  Linken zu \nÄnderungen bei der Regierungsbefragung. Sie wollen \neine lebendige
-                  und informative Regierungsbefragung. \nGar keine Frage, das wollen wir auch. Das
-                  Fragerecht \nmuss aber Instrument der parlamentarischen Kontrolle \nbleiben und
-                  sollte nicht Kampfinstrument der Opposition \nwerden. Ich glaube, es liegt in unserem
-                  gemeinsamen In-\nteresse,\n(Matthias W. Birkwald [DIE LINKE]: Wer \nkontrolliert
-                  denn die?)\ndass wir sachlich argumentieren und nicht versuchen, nur \npersönlich
-                  zu attackieren. Deswegen habe ich da Beden-\nken. Aber um auch das klar zu sagen:
-                  Wir sind bereit, da-\nrüber zu reden – in der gebotenen Sachlichkeit und nicht \nim
-                  Hauruckverfahren. Ich kann verstehen, Herr Kollege \nSchneider, dass die SPD möglichst
-                  schnell in die Oppo-\nsition will. \n(Carsten Schneider [Erfurt] [SPD]: Wir sind
-                  \nes schon!)\nWir werden Sie dabei unterstützen, aber dieses Antrags \nbedarf es
-                  dazu nicht.\n(Beifall bei der CDU/CSU sowie bei Abge-\nordneten der FDP)\nDrittens:
-                  zum Antrag der Linken auf unmittelbare Ein-\nsetzung der vier im Grundgesetz genannten
-                  Ausschüsse. \nIch möchte betonen: Dieser Bundestag, der 19. Deutsche \nBundestag,
-                  ist ab heute jederzeit in der Lage, zu arbei-\nten und Entscheidungen zu treffen,
-                  er ist arbeitsfähig und \nentscheidungsfähig, um das einmal klar zu sagen. Sie ha-\nben
-                  hier suggeriert, wir müssten diese Ausschüsse einset-\nzen. Das müssen wir nicht.\n(Jan
-                  Korte [DIE LINKE]: Müssen wir aber!)\nEs gibt keine Fristen im Grundgesetz oder
-                  sonst wo, die \nuns vorgeben, diese Ausschüsse heute einzusetzen. Wir \nhaben eine
-                  parlamentarische Gepflogenheit, Ausschüsse \nspiegelbildlich zu den vorhandenen
-                  Ministerien einzuset-\nzen. \n(Dr. Petra Sitte [DIE LINKE]: Was ist denn \nmit dem
-                  Petitionsrecht?)\nWenn die aber noch nicht da sind, wird es schwierig mit \ndieser
-                  parlamentarischen Gepflogenheit. Deswegen bin \nich dafür: Wir machen es so, wie
-                  es sich bewährt hat.\n(Widerspruch bei der LINKEN – Matthias W. \nBirkwald [DIE
-                  LINKE]: Es gibt kein Ministe-\nrium für die Opposition, Herr Kollege!)\nIch denke,
-                  der parlamentarischen Praxis ist hier erneut \nVorrang einzuräumen. Einzelne Fachausschüsse
-                  vorzu-\nziehen, dieses Schrittes bedarf es nicht.\nAbschließend zum Antrag der AfD
-                  zu Minderhei-\ntenrechten. Aufgrund einer starken Großen Koalition \nbestand in
-                  der 18. Wahlperiode Anlass, darüber nachzu-\ndenken, ob Minderheitenrechte in ausreichendem
-                  Maße \ngewährleistet werden können, zugegeben bei einer da-\nmals recht kleinen
-                  Opposition. Die Minderheitenrechte \nwaren Reaktion auf Mehrheitsverhältnisse, und
-                  es gibt \ndeshalb auch keinen Grund, sie zu verlängern. Die  GroKo \nDeutscher Bundestag
-                  – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 2017 9\n(A) (C)\n(B)
-                  (D)\nist nicht mehr vorhanden. Interessant ist ja auch, dass die \nAfD das Quorum
-                  auf 65 Abgeordnete senken will. Mög-\nlicherweise ist das die vorbeugende Reaktion
-                  auf weitere \nAustritte aus Ihrer Fraktion. Das weiß ich nicht.\n(Beifall bei der
-                  CDU/CSU, der SPD, der FDP \nund dem BÜNDNIS 90/DIE GRÜNEN)\nMal sehen, ob bei 65
-                  Schluss ist. Sie haben ja noch aus-\nreichend Zeit.\nMeine Damen und Herren, liebe
-                  Kolleginnen und \nKollegen, die Anträge, die wir hier vorgestellt bekom-\nmen haben,
-                  gehören nicht in die konstituierende Sitzung. \nWir haben viel Wichtigeres zu tun.
-                  Sie gehören in Ruhe \nberaten, damit man sich auch fachlich damit auseinan-\ndersetzen
-                  kann. Dafür sorgen wir als CDU/CSU-Bundes-\ntagsfraktion.\nVielen Dank.\n(Beifall
-                  bei der CDU/CSU sowie bei Abge-\nordneten der FDP)\nAlterspräsident Dr. Hermann
-                  Otto Solms: \nDas Wort hat jetzt der Kollege Dr. Marco Buschmann \nvon der FDP-Fraktion.\n(Beifall
-                  bei der FDP sowie bei Abgeordneten \nder CDU/CSU)\nDr. Marco Buschmann (FDP): \nHerr
-                  Präsident! Meine lieben Kolleginnen und Kolle-\ngen! Die konstituierende Sitzung
-                  des Deutschen Bundes-\ntages ist eines der schönsten Hochämter der deutschen \nDemokratie.
-                  Es gibt kaum einen größeren, einen bedeu-\ntenderen Anlass als diesen, wo wir uns
-                  gemeinsam hin-\nter dem Prinzip der repräsentativen Demokratie versam-\nmeln. So
-                  groß, wie dieser Anlass ist, so klein muss man \ndenken, wenn man diese Sitzung
-                  als Bühne für die Sucht \nnach Aufmerksamkeit und Öffentlichkeit missbrauchen \nmöchte.
-                  \n(Beifall bei der FDP sowie bei Abgeordneten \nder CDU/CSU)\nGenau das tun aber
-                  alle Antragsteller. Alle wollen sie ihre \neingeübten Rollen spielen. \nDie AfD
-                  geriert sich – ganz bewährt – als Opfer einer \nfinsteren Verschwörung. Das kennen
-                  wir zur Genüge, das \nhaben wir oft genug erlebt. Ich wollte dazu eigentlich gar
-                  \nnichts mehr sagen. \n(Lachen bei der AfD)\nAber, lieber Herr Kollege Dr. Baumann,
-                  indem Sie sich \nhier ernsthaft mit den Opfern Hermann Görings vergli-\nchen haben,
-                  haben Sie sich an Geschmacklosigkeit wie-\nder selbst übertroffen.\n(Beifall bei
-                  der FDP, der CDU/CSU, der SPD, \nder LINKEN und dem BÜNDNIS 90/DIE \nGRÜNEN) \nAuch
-                  Die Linke hat ihre bewährte Rolle. Sie gibt hier \ndie Scheinheilige. Herr Korte
-                  trägt vor, es ginge darum, \ndas Parlament schnell arbeitsfähig zu machen. Sie ken-\nnen
-                  die Praxis des Parlamentarismus in Deutschland \nganz genau. Wir wissen heute nicht,
-                  welche Ausschüs-\nse es insgesamt geben wird, wie groß sie sein werden, \nwelche
-                  Kollegen wohin gehen müssen. Dass das in den \nFraktionen natürlich besprochen werden
-                  muss, ist Ihnen \nbekannt. \n(Petra Pau [DIE LINKE]: Gucken Sie mal in \ndas Grundgesetz!)\nEs
-                  geht Ihnen um nichts anderes, als hier wieder ein \nStück Aufmerksamkeit für sich
-                  in Anspruch zu nehmen. \nDarin unterscheiden Sie sich mit Ihrem Anliegen kein \nbisschen
-                  von der AfD. \n(Beifall bei der FDP sowie bei Abgeordneten \nder CDU/CSU – Matthias
-                  W. Birkwald [DIE \nLINKE]: Unverschämtheit!)\nWissen Sie, dass die extreme Rechte
-                  und die extreme \nLinke \n(Lachen bei der AfD)\nversuchen, diese Bühne zu missbrauchen,
-                  war gewisser-\nmaßen sogar erwartbar. Aber dass die altehrwürdige SPD \n(Widerspruch
-                  bei der SPD)\nin diesen Chor einstimmt, kann einen wirklich nur ver-\nwundern. \nAuch
-                  bei uns gibt es zahlreiche Ideen dazu, wie man \ndiese Geschäftsordnung verbessern
-                  kann. Wir sind sehr \nfür mehr Transparenz, wir haben auch Ideen, die darüber \nhinausgehen.
-                  Aber dass man versucht, in der konstituie-\nrenden Sitzung in ein komplexes Regelwerk
-                  einzustei-\ngen, ohne vernünftige Beratung, ohne Austausch, ohne \nArbeit am Detail
-                  leisten zu können, zeigt doch in Wahr-\nheit, dass es Ihnen gar nicht um die Sache
-                  geht. Es geht \nIhnen in Wahrheit doch um etwas ganz anderes.\n(Beifall bei der
-                  FDP sowie bei Abgeordneten \nder CDU/CSU)\nWir wissen auch, worum es Ihnen dabei
-                  geht. Es geht \nIhnen um nichts anderes – Sie haben zum Teil wort-\ngleiche Initiativen
-                  der Fraktion Bündnis 90/Die Grünen \nübernommen –, als die Grünenkollegen in eine
-                  peinliche \nSituation zu bringen. Sie wollen erzwingen, dass die ihre \neigenen
-                  Anträge ablehnen. Das ist offen gestanden für \ndie konstituierende Sitzung des
-                  Deutschen Bundestages \neine ganz kleine parteipolitische Münze. Das hat dieses
-                  \nHohe Haus nicht verdient, meine Damen und Herren. \n(Beifall bei der FDP und der
-                  CDU/CSU)\nLiebe Kolleginnen und Kollegen, ich kann Ihnen zum \nheutigen Tage nicht
-                  sagen, ob die Fraktion der Freien De-\nmokraten eine Regierung tragen wird oder
-                  den Gang in \ndie Opposition antreten wird. \n(Lachen bei der AfD)\nAber ich kann
-                  Ihnen eines sagen: Wenn wir den Gang in \ndie Opposition antreten, dann nicht mit
-                  solcher Effekt-\nhascherei. Das hat das deutsche Volk und das haben die \nWähler
-                  nicht verdient. \n(Beifall bei der FDP sowie bei Abgeordneten \nder CDU/CSU)\nMichael
-                  Grosse-Brömer\nDeutscher Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag,
-                  den 24. Oktober 201710\n(A) (C)\n(B) (D)\nAlterspräsident Dr. Hermann Otto Solms:
-                  \nDas Wort hat jetzt die Kollegin Britta Haßelmann von \nBündnis 90/Die Grünen.\n(Beifall
-                  beim BÜNDNIS 90/DIE GRÜNEN)\nBritta Haßelmann (BÜNDNIS 90/DIE GRÜNEN): \nSehr geehrter
-                  Herr Präsident! Meine Damen und Her-\nren! Kommen wir einmal zum Kern der Debatte
-                  zurück. \n(Beifall beim BÜNDNIS 90/DIE GRÜNEN \nsowie bei Abgeordneten der SPD und
-                  der \nLINKEN)\nEs geht um das Thema Parlamentsrechte. Das, was wir in \nden letzten
-                  vier Jahren erlebt haben, war kein Glanzstück \nparlamentarischer Auseinandersetzung,
-                  wenn damit in-\nhaltliche Debatten gemeint sind. \n(Beifall bei der AfD sowie bei
-                  Abgeordneten \ndes BÜNDNISSES 90/DIE GRÜNEN)\nDeshalb ist es gut, wenn wir uns alle
-                  wechselseitig daran \nerinnern – auch die, die heute vielleicht andere Rollen \neinnehmen,
-                  und all die, die noch nicht wissen, welche \nRolle sie einnehmen werden –, was für
-                  ermüdende und \nlangatmige Debatten wir hier in Zeiten dieser so Großen \nKoalition
-                  geführt haben. Ich kann mich sehr gut an die \nvielen Vorstöße aus unserer Fraktion
-                  erinnern, das The-\nma „Rechte des Parlaments stärken“ hier mehrheitsfähig \nzu
-                  machen. Wir sind leider immer wieder damit geschei-\ntert; ich nenne nur: das Thema
-                  Parlamentskultur, die \nFrage der Debattenkultur, die Frage nach Transparenz \nund
-                  Öffentlichkeit von Ausschüssen und auch das Fra-\ngerecht oder die Regierungsbefragung.
-                  Außer mit dem \nBundestagspräsidenten a. D., der auf der Tribüne sitzt, \nund vielleicht
-                  Einzelnen aus den Fraktionen gab es kei-\nne Übereinstimmung in dieser Frage. Und
-                  deshalb ist die \nRegierungsbefragung so, wie sie immer war, auch heute \nnoch.
-                  Da braucht es dringend eine Änderung. Das sehen \nauch Bündnis 90/Die Grünen so.
-                  \n(Beifall beim BÜNDNIS 90/DIE GRÜNEN \nsowie bei Abgeordneten der SPD und der \nAfD)\nMeine
-                  Damen und Herren, ich wüsste nicht – deshalb \nkann ich das Gefeixe aus den Reihen
-                  der SPD gar nicht \nverstehen –, warum wir heute einfach Ihrem Antrag oder \naber
-                  – es liegen ja zwei Anträge vor – dem Antrag der \nLinken folgen sollten, der wiederum
-                  anders ist. Auch \nwir haben Vorschläge zur Regierungsbefragung und zur \nFragestunde
-                  gemacht. Im Antrag der SPD finden sich \nunsere Punkte nicht in Gänze wieder. Warum
-                  haben Sie \nin Ihrem Antrag zum Beispiel auf die Abschaffung der \nKonsumtionsregel
-                  verzichtet? Das ist doch ein wichtiges \nInstrument, gerade für die Opposition,
-                  meine Damen und \nHerren. \n(Beifall beim BÜNDNIS 90/DIE GRÜNEN)\nOder warum wollen
-                  Sie die Dringlichen Fragen abschaf-\nfen? \n(Zuruf des Abg. Dr. Dietmar Bartsch
-                  [DIE \nLINKE])\nDas ist ein super Instrument für die Opposition; das wür-\nde ich
-                  mir noch mal überlegen. \n(Beifall beim BÜNDNIS 90/DIE GRÜNEN)\nDie Frage ist auch:
-                  Warum wollen Sie eigentlich keine \nBefragung zu europäischen Themen? \n(Claudia
-                  Roth [Augsburg] [BÜNDNIS 90/\nDIE GRÜNEN]: Ja, das habe ich mich auch \ngefragt!)\nWir
-                  haben doch hier im Parlament den Anspruch, euro-\npäische Themen zu beraten, meine
-                  Damen und Herren. \n(Beifall beim BÜNDNIS 90/DIE GRÜNEN \nsowie bei Abgeordneten
-                  der CDU/CSU, der \nAfD und der FDP)\nAlso jetzt mal Karten auf den Tisch: Warum
-                  sind all diese \nSachen in Ihrem Antrag nicht enthalten? \n(Michael Grosse-Brömer
-                  [CDU/CSU]: Das \npassiert, wenn man das nicht ordentlich vor-\nbereitet!)\nWarum
-                  die Lacherei darüber, dass Sie uns hier heute \nvorführen wollen? Das ist doch absurd.
-                  Ich möchte mit \nIhnen darüber diskutieren, warum Sie auf all diese we-\nsentlichen
-                  Sachen verzichten wollen. \n(Beifall beim BÜNDNIS 90/DIE GRÜNEN \nsowie bei Abgeordneten
-                  der FDP)\nIch möchte mit der CDU/CSU darüber diskutieren, \ndass bei diesem Thema
-                  – auch bei der CDU/CSU – mal \nlangsam ein bisschen Bewegung aufkommen muss, dass
-                  \nwir hier eine Veränderung brauchen. Herr Buschmann \nhat ja schon für die FDP
-                  erklärt, dass auch sie sich beim \nThema Regierungsbefragung und Fragestunde etwas
-                  an-\nderes vorstellt. \n(Jan Korte [DIE LINKE]: Ihr habt noch kei-\nnen Koalitionsvertrag!)\nDeshalb
-                  habe ich kein Verständnis dafür, liebe Kollegin-\nnen und Kollegen von SPD und Linken,
-                  warum Sie mei-\nnem Vorschlag im Vor-Ältestenrat nicht gefolgt sind, es \nzu überweisen,
-                  sich alle Vorschläge aller Fraktionen im \nDeutschen Bundestag anzuschauen und dann
-                  sehr zeit-\nnah darüber zu reden, wie wir es wirklich ändern.\n(Zuruf des Abg. Dr.
-                  Dietmar Bartsch [DIE \nLINKE])\nSie wollten uns mit der Geschichte heute einfach
-                  vorfüh-\nren, und da machen wir nicht mit – deshalb der Antrag \nauf Überweisung.\n(Beifall
-                  beim BÜNDNIS 90/DIE GRÜNEN, \nbei der CDU/CSU und der FDP)\nIch meine das sehr ernst
-                  und sehr eindrücklich: Ich wün-\nsche mir, dass wir zur Stärkung des Parlamentes
-                  etwas \nverändern, dass wir beim Thema Transparenz etwas ver-\nändern. Dazu gehört
-                  die Regierungsbefragung, dazu hat \nunsere Fraktion auch noch weiter gehende Vorstellun-\ngen.
-                  Ich fände es toll, wir berieten das sehr zeitnah und in \nRuhe, meine Damen und
-                  Herren. \nDeutscher Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag,
-                  den 24. Oktober 2017 11\n(A) (C)\n(B) (D)\nJetzt noch zum Antrag auf Einsetzung
-                  der Ausschüsse. \nJan Korte, es ist ja nicht so, dass Sie den Antrag stellen, \nAusschüsse
-                  einzusetzen. Nein, Sie beantragen, dass vier \nAusschüsse in der Geschäftsordnung
-                  zwingend festge-\nlegt werden. Wir sollten mal in Ruhe darüber diskutieren, \nwarum
-                  es eigentlich diese vier Ausschüsse sein sollen, \nderen Einsetzung Sie heute fordern,
-                  \n(Petra Pau [DIE LINKE]: Weil es im Grund-\ngesetz steht!)\nwarum es zum Beispiel
-                  nicht der Geschäftsordnungs- \nund der Immunitätsausschuss sind. \n(Beifall bei
-                  Abgeordneten des BÜNDNIS-\nSES 90/DIE GRÜNEN – Michael Grosse-\nBrömer [CDU/CSU]:
-                  Gute Frage!)\nEs gibt ab heute hier im Haus allein zwei oder drei Mit-\nglieder
-                  – das habe ich der Presse entnommen –, deren \nAngelegenheiten wir im Immunitätsausschuss
-                  zwingend \ndiskutieren müssten, nicht hier im Plenum. \n(Jan Korte [DIE LINKE]:
-                  Das können wir \ndoch ergänzen!)\nIch fände es gut, wenn wir darüber mal in Ruhe
-                  redeten.\nMeine Damen und Herren, ich finde, wir sollten uns \nim Deutschen Bundestag
-                  sehr zeitnah wieder mit der Fra-\nge der Änderungen bei Transparenz und Parlamentsrech-\nten
-                  befassen, nachdem alle Fraktionen ihre Vorstellungen \neingebracht haben, damit
-                  wir es dann hoffentlich sehr \nschnell zu einem Ergebnis führen. \nDanke.\n(Beifall
-                  beim BÜNDNIS 90/DIE GRÜNEN \nsowie bei Abgeordneten der CDU/CSU und \nder FDP –
-                  Dr. Dietmar Bartsch [DIE LINKE]: \nIhr seid noch nicht an der Regierung! Noch \nnicht!)\nAlterspräsident
-                  Dr. Hermann Otto Solms: \nWir kommen nun zur Abstimmung.\nÄnderungsantrag der Fraktion
-                  der SPD auf Drucksa-\nche 19/8 mit dem Titel „Weitergeltung von Geschäftsord-\nnungsrecht“
-                  – Fragestunde und Befragung der Bundesre-\ngierung. Die Fraktion der SPD wünscht
-                  Abstimmung in \nder Sache. Die Fraktionen der CDU/CSU, des Bündnis-\nses 90/Die
-                  Grünen und der FDP wünschen Überweisung \nan den Ältestenrat.\nWir stimmen nach
-                  ständiger Übung zuerst über den \nAntrag auf Ausschussüberweisung ab. Ich frage
-                  deshalb: \nWer stimmt für den Antrag der drei genannten Fraktionen \nauf Überweisung
-                  in den Ältestenrat? – Gegenstimmen? – \nEnthaltungen? – Damit ist der Antrag mit
-                  den Stimmen \nder Fraktionen der CDU/CSU, der FDP und des Bündnis-\nses 90/Die Grünen
-                  gegen die Stimmen der SPD, der AfD \nund der Linken angenommen. \n(Martin Schulz
-                  [SPD]: Jamaika steht!) \nDamit stimmen wir heute über den Antrag auf Drucksa-\nche
-                  19/8 nicht in der Sache ab.\nÄnderungsantrag der Fraktion der AfD auf Drucksa-\nche
-                  19/4 mit dem Titel „Weitergeltung von Geschäfts-\nordnungsrecht (Alterspräsident)“.
-                  Die Fraktion der AfD \nwünscht, über ihren Antrag in der Sache abzustimmen. \nDie
-                  Fraktionen CDU/CSU, Bündnis 90/Die Grünen und \nFDP wünschen Überweisung an den
-                  Ältestenrat. \nWir stimmen nach ständiger Übung zuerst über den \nAntrag auf Überweisung
-                  ab. Wer stimmt dem Antrag auf \nÜberweisung zu? – Gegenstimmen? – Enthaltungen?
-                  – \nDer Antrag ist angenommen mit den Stimmen der CDU/\nCSU-Fraktion, FDP-Fraktion,
-                  der Linken und Grünen \nbei Gegenstimmen bei AfD und SPD und bei Enthaltung \nder
-                  Fraktionslosen.\nÄnderungsantrag der Fraktion der AfD auf Drucksa-\nche 19/5 mit
-                  dem Titel „Weitergeltung von Geschäftsord-\nnungsrecht (Minderheitenrechte)“. Die
-                  Fraktionen der \nCDU/CSU, des Bündnisses 90/Die Grünen und der FDP \nwünschen Überweisung
-                  an den Ältestenrat. Die Frakti-\non der AfD wünscht Überweisung an den Ausschuss
-                  für \nWahlprüfung, Immunität und Geschäftsordnung. \nIch lasse zuerst abstimmen
-                  über den Antrag der Frak-\ntion der AfD auf Überweisung an den Ausschuss für \nWahlprüfung,
-                  Immunität und Geschäftsordnung. Wer \nstimmt für diesen Überweisungsvorschlag? –
-                  Wer stimmt \ndagegen? – Enthaltungen? – Der Überweisungsvorschlag \nist mit den
-                  Stimmen aller Fraktionen gegen die Stimmen \nder Fraktion der AfD bei Enthaltung
-                  der Fraktionslosen \nabgelehnt worden.\nIch lasse nun abstimmen über den Überweisungs-\nvorschlag
-                  der Fraktionen der CDU/CSU, der FDP und \ndes Bündnisses 90/Die Grünen. Wer stimmt
-                  für diesen \nÜberweisungsvorschlag? – Gegenstimmen? – Enthal-\ntungen? – Der Überweisungsvorschlag
-                  ist angenommen \nmit den Stimmen der CDU/CSU, der FDP, des Bündnis-\nses 90/Die
-                  Grünen und der Fraktion Die Linke bei Ge-\ngenstimmen der SPD-Fraktion und Enthaltung
-                  der AfD – \nsowie der beiden fraktionslosen Abgeordneten; die sehe \nich immer nicht.\nÄnderungsantrag
-                  der Fraktion Die Linke auf Druck-\nsache 19/6 mit dem Titel „Weitergeltung von Geschäfts-\nordnungsrecht
-                  (Einsetzung der vom Grundgesetz vor-\ngeschriebenen Ausschüsse in der konstituierenden
-                  \nSitzung)“. Die Fraktion Die Linke wünscht Abstimmung \nin der Sache. Die Fraktionen
-                  CDU/CSU, FDP und Bünd-\nnis 90/Die Grünen wünschen Überweisung an den Äl-\ntestenrat.
-                  \nAuch hier stimmen wir nach ständiger Übung zuerst \nüber den Antrag auf Ausschussüberweisung
-                  ab. Ich frage \ndeshalb: Wer stimmt für die beantragte Überweisung? – \nGegenstimmen?
-                  – Enthaltungen? – Die Überweisung ist \nangenommen mit den Stimmen der Fraktionen
-                  CDU/\nCSU, FDP und Bündnis 90/Die Grünen bei Gegenstim-\nmen von SPD, AfD und der
-                  Fraktion Die Linke und – \njetzt sehe ich sie – bei Enthaltung der zwei fraktionslosen
-                  \nAbgeordneten. \nÄnderungsantrag der Fraktion Die Linke auf Drucksa-\nche 19/7
-                  mit dem Titel „Weitergeltung von Geschäftsord-\nnungsrecht (Fragestunde und Befragung
-                  der Bundesre-\ngierung)“. Die Fraktion Die Linke wünscht Abstimmung \nBritta Haßelmann\nDeutscher
-                  Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 201712\n(A)
-                  (C)\n(B) (D)\nin der Sache. Die Fraktionen CDU/CSU, FDP und Bünd-\nnis 90/Die Grünen
-                  wünschen Überweisung an den Ältes-\ntenrat. Wer stimmt für diesen Überweisungsvorschlag?
-                  – \nGegenstimmen? – Enthaltungen? – Dann ist der Antrag \nangenommen mit den Stimmen
-                  von CDU/CSU, FDP und \nBündnis 90/Die Grünen gegen die Stimmen der anderen \nFraktionen,
-                  keine Enthaltungen. \nAntrag der Fraktion der CDU/CSU auf Drucksa-\nche 19/1 zur
-                  Weitergeltung von Geschäftsordnungsrecht. \nWer stimmt für diesen Antrag? – Gegenstimmen?
-                  – Ent-\nhaltungen? – Dann ist der Antrag mit den Stimmen aller \nFraktionen gegen
-                  die Stimmen der AfD bei Enthaltung \nder zwei fraktionslosen Abgeordneten angenommen.\nIch
-                  rufe den Tagesordnungspunkt 3 auf:\nWahl des Präsidenten   \nverbunden mit Namensaufruf
-                  \  \nund Feststellung der Beschlussfähigkeit\nEs entspricht der parlamentarischen
-                  Tradition, dass \ndie stärkste Fraktion einen Kandidaten vorschlägt. Ich \ndarf
-                  also den Herrn Abgeordneten Volker Kauder um ei-\nnen Vorschlag bitten.\nVolker
-                  Kauder (CDU/CSU): \nDie CDU/CSU-Bundestagsfraktion schlägt Herrn \nDr. Wolfgang
-                  Schäuble vor.\n(Beifall bei der CDU/CSU und der FDP sowie \nbei Abgeordneten des
-                  BÜNDNISSES 90/DIE \nGRÜNEN)\nAlterspräsident Dr. Hermann Otto Solms: \nDer Kollege
-                  Dr. Wolfgang Schäuble ist vorgeschla-\ngen. – Ich darf Sie fragen: Sind Sie bereit,
-                  zu kandidie-\nren?\nDr. Wolfgang Schäuble (CDU/CSU): \nJa, Herr Präsident.\nAlterspräsident
-                  Dr. Hermann Otto Solms: \nDas ist der Fall. – Ich sehe keine weiteren Vorschläge.\nDann
-                  bitte ich jetzt um Ihre Aufmerksamkeit für eini-\nge Hinweise zum Wahlverfahren
-                  – das sind technische \nHinweise, die aber wichtig sind, damit Sie an der Wahl \nerfolgreich
-                  teilnehmen können –: Die Wahl findet mit \nverdeckten Stimmkarten, also geheim,
-                  statt. Gewählt ist, \nwer die Stimmen der Mehrheit der Mitglieder des Bun-\ndestages,
-                  also mindestens 355 Stimmen, erhält. Für diese \nWahl und für die spätere Wahl der
-                  Vizepräsidentinnen \nund Vizepräsidenten benötigen Sie Ihre Wahlausweise \naus den
-                  Stimmkartenfächern in der Lobby. Für die Wahl \ndes Präsidenten sind der Wahlausweis
-                  und die Stimmkar-\nte gelb. Bitte kontrollieren Sie, ob dieser Wahlausweis \nIhren
-                  Namen trägt. Die gelbe Stimmkarte und den amt-\nlichen Wahlumschlag erhalten Sie
-                  nach Aufruf Ihres Na-\nmens von den Schriftführerinnen und Schriftführern an \nden
-                  Ausgabetischen hier oben neben den Wahlkabinen. \nNachdem Sie die Stimmkarte in
-                  einer Wahlkabi-\nne gekennzeichnet und dort in den Wahlumschlag ge-\nlegt haben,
-                  gehen Sie bitte zu den Wahlurnen hier vor \ndem Rednerpult. Sie dürfen Ihre Stimmkarte
-                  nur in der \nWahlkabine ankreuzen und müssen ebenfalls noch in der \nWahlkabine
-                  die Stimmkarte in den Umschlag legen. Die \nSchriftführerinnen und Schriftführer
-                  sind verpflichtet, \njeden, der seine Stimmkarte außerhalb der Wahlkabine \nkennzeichnet
-                  oder in den Umschlag legt, zurückzuwei-\nsen. Die Stimmabgabe kann in diesem Falle
-                  jedoch vor-\nschriftsmäßig wiederholt werden. \nGültig sind nur Stimmkarten mit
-                  einem Kreuz bei \n„Ja“, „Nein“ oder „Enthalte mich“. Ungültig sind Stim-\nmen auf
-                  nichtamtlichen Stimmkarten sowie Stimmkar-\nten, die mehr als ein Kreuz, kein Kreuz,
-                  andere Namen \noder Zusätze enthalten.\nBevor Sie die Stimmkarte in eine der Wahlurnen
-                  wer-\nfen, übergeben Sie bitte Ihren Wahlausweis einer der \nSchriftführerinnen
-                  oder einem der Schriftführer an der \nWahlurne. Der Nachweis der Teilnahme an der
-                  Wahl \nkann nur durch die Abgabe des Wahlausweises erbracht \nwerden.\nIch bitte
-                  jetzt die eingeteilten Schriftführerinnen und \nSchriftführer, die vorgesehenen
-                  Plätze einzunehmen. – \nDie beiden Schriftführer neben mir werden nun Ihre \nNamen
-                  in alphabetischer Reihenfolge aufrufen. Ich bitte \nSie, den Namensaufruf zu verfolgen
-                  und sich nach dem \nAufruf Ihres Namens zur Entgegennahme der Stimmkar-\nte zu den
-                  Ausgabetischen vor den Wahlkabinen zu bege-\nben.\nHaben alle Schriftführerinnen
-                  und Schriftführer die \nPlätze eingenommen? – Ich eröffne die Wahl und bitte, \nmit
-                  dem Aufruf der Namen zu beginnen.\n(Namensaufruf und Wahl) \nDer Namensaufruf ist
-                  beendet. Ich darf fragen, ob alle \nMitglieder des Hauses, auch die Schriftführerinnen
-                  und \nSchriftführer, ihre Stimme abgegeben haben. – Nein, da \nkommt noch jemand.
-                  \nHaben jetzt alle Mitglieder des Hauses ihre Stimme \nabgegeben? – Das scheint
-                  der Fall zu sein. Ich schließe \ndie Wahl und bitte die Schriftführerinnen und Schriftfüh-\nrer,
-                  mit der Auszählung zu beginnen. Zur Auszählung \nunterbreche ich die Sitzung für
-                  etwa 30 Minuten. Der \nWiederbeginn der Sitzung wird rechtzeitig durch Klin-\ngelsignal
-                  angekündigt. \n(Unterbrechung von 12.42 bis 13.09 Uhr) \nAlterspräsident Dr. Hermann
-                  Otto Solms: \nDie unterbrochene Sitzung ist wieder eröffnet. Liebe \nKolleginnen
-                  und Kollegen, nehmen Sie bitte Platz, damit \nwir fortfahren können. \nIch gebe
-                  das Ergebnis der Wahl des Präsidenten des \n19. Deutschen Bundestages bekannt: abgegebene
-                  Stim-\nmen 705, ungültige Stimmen 1, gültige Stimmen 704. \nMit Ja haben gestimmt
-                  501 Kolleginnen und Kollegen. \n(Anhaltender Beifall bei der CDU/CSU, der \nSPD,
-                  der FDP, der LINKEN und dem BÜND-\nNIS 90/DIE GRÜNEN)\nAlterspräsident Dr. Hermann
-                  Otto Solms\nDeutscher Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag,
-                  den 24. Oktober 2017 13\n(A) (C)\n(B) (D)\nMit Nein haben gestimmt 173 Kolleginnen
-                  und Kollegen, \nEnthaltungen gab es 30. Herr Dr. Wolfgang Schäuble hat \ndie erforderliche
-                  Mehrheit erhalten und ist zum Präsiden-\nten des 19. Deutschen Bundestages gewählt.1)\n(Beifall
-                  bei der CDU/CSU, der SPD, der FDP, \nder LINKEN und dem BÜNDNIS 90/DIE \nGRÜNEN)\nIch
-                  frage Sie, Herr Schäuble: Nehmen Sie die Wahl \nan? \nDr. Wolfgang Schäuble (CDU/CSU):
-                  \nHerr Präsident, ich nehme die Wahl an.\n(Beifall bei der CDU/CSU, der SPD, der
-                  FDP, \nder LINKEN und dem BÜNDNIS 90/DIE \nGRÜNEN – Abgeordnete aller Fraktionen
-                  \ngratulieren dem Präsidenten)\nAlterspräsident Dr. Hermann Otto Solms: \nHerr Präsident,
-                  ich darf Ihnen im Namen des ganzen \nHauses sehr herzlich zu Ihrer Wahl gratulieren.
-                  Ich wün-\nsche Ihnen eine glückliche Hand. Verstand muss ich Ih-\nnen nicht wünschen,
-                  den haben Sie sowieso. Ich bitte Sie \njetzt, das Amt zu übernehmen.\nVielen Dank.\n(Beifall
-                  bei der CDU/CSU, der SPD, der FDP, \nder LINKEN und dem BÜNDNIS 90/DIE \nGRÜNEN
-                  sowie bei Abgeordneten der AfD)\nTagesordnungspunkt 4: \nAmtsübernahme durch den
-                  Präsidenten  \nmit Ansprache\nPräsident Dr. Wolfgang Schäuble: \nHerr Bundespräsident!
-                  Verehrte Kolleginnen und Kol-\nlegen!\n(Zurufe: Mikro!)\n– Muss ich selber drücken?\n(Heiterkeit
-                  und Beifall bei der CDU/CSU, der \nSPD, der FDP und dem BÜNDNIS 90/DIE \nGRÜNEN
-                  sowie bei Abgeordneten der LIN-\nKEN)\nAller Anfang ist schwer; also fangen wir
-                  noch einmal \nvon vorne an.\nHerr Bundespräsident! Liebe Kolleginnen und Kolle-\ngen!
-                  Meine sehr verehrten Damen und Herren! Ich habe \nzunächst zu danken. Ich danke
-                  Ihnen für das Vertrauen, \ndas Sie mir mit der Wahl zum Bundestagspräsidenten \nentgegenbringen.
-                  Ich danke Hermann Otto Solms. Mit \nseiner langen parlamentarischen Erfahrung hat
-                  er die von \nmir übernommene Aufgabe, diesen 19. Deutschen Bun-\ndestag als dienstältester
-                  Abgeordneter zu eröffnen, mit \ngroßer Umsicht wahrgenommen. Und er hat die Heraus-\nforderungen
-                  für unser Parlament klar umrissen.\n1)  Namensverzeichnis der Teilnehmer an der
-                  Wahl siehe Anlage 2\nIch möchte den vielen ausgeschiedenen Kolleginnen \nund Kollegen
-                  danken. Sie schauen zum Teil auf jahrzehn-\ntelanges parlamentarisches Wirken zurück.
-                  Ich nenne \nstellvertretend Heinz Riesenhuber. Er war gleich zwei-\nmal Alterspräsident,
-                  bei den konstituierenden Sitzungen \nder beiden zurückliegenden Legislaturperioden.
-                  Ich dan-\nke aus dem Präsidium des 18. Deutschen Bundestages \nden ausgeschiedenen
-                  Vizepräsidenten Edelgard Bulmahn \nund Johannes Singhammer. Ich danke natürlich
-                  auch den \nbeiden Vizepräsidentinnen, die dem nächsten Präsidium \nvermutlich nicht
-                  angehören werden. Damit nehme ich \njetzt die Wahl vorweg; das ist ein bisschen
-                  schwierig.\nVor allen Dingen aber, meine sehr verehrten Damen \nund Herren, möchte
-                  ich Norbert Lammert danken. Er war \nzwölf Jahre ein großartiger Bundestagspräsident.\n(Beifall
-                  bei der CDU/CSU, der SPD, der LIN-\nKEN und dem BÜNDNIS 90/DIE GRÜNEN)\nLieber Herr
-                  Lammert, Sie hatten eine ganz besondere \nBegabung als Redner, und Sie hatten immer
-                  klare Vor-\nstellungen davon, was dieses Parlament leisten soll und \nwas es leisten
-                  kann, wenn es denn will.\nLiebe Kolleginnen und Kollegen, ich freue mich auf \ndie
-                  neue Aufgabe. Im Parlament schlägt das Herz unse-\nrer Demokratie. Ich freue mich
-                  auf die Zusammenarbeit \nmit Ihnen, liebe Kolleginnen und Kollegen, wie mit allen
-                  \nMitarbeiterinnen und Mitarbeitern, die diesem Haus die-\nnen. \nIch bin Parlamentarier
-                  aus Leidenschaft. Ich habe mei-\nne Abgeordnetentätigkeit immer als hohe Verantwortung
-                  \nund das Mandat als meine demokratische Legitimation \nverstanden. Ich habe im
-                  Übrigen im Deutschen Bundes-\ntag beides erlebt: Abgeordneter zu sein in der Opposition
-                  \nwie in einer Regierungsfraktion. \nZunächst war ich zehn Jahre in der Opposition.
-                  Als \nich 1972 zum ersten Mal als Abgeordneter im Deutschen \nBundestag saß, wurde
-                  um die Ostverträge gestritten – mit \nleidenschaftlichen Debatten, damals in Bonn.
-                  Die Stim-\nmung war aufgeladen. Überhaupt prägte seinerzeit eine \nextrem spannungsvolle
-                  Atmosphäre dieses Land. Die \nGesellschaft der Bundesrepublik hatte sich seit Mitte
-                  der \n60er-Jahre in einem bis dahin nicht gekannten Maße poli-\ntisiert, mobilisiert
-                  und polarisiert. Geschadet hat es nicht, \ngenauso wenig wie die Erregung Anfang
-                  der 80er-Jahre. \nDa war ich Abgeordneter in der großen Regierungsfrak-\ntion, als
-                  es etwa um den NATO-Doppelbeschluss ging. \nSieben Jahre später fiel dann die Mauer.
-                  Veränderung war \nalso immer, und vieles wird im Übrigen in der Rückschau \nanders
-                  bewertet als mitten im Streit. Auch deshalb, also \nweil ich aus eigenem Erleben
-                  weiß, dass Erregung und \nKrisengefühle so neu nicht wirklich sind, sehe ich mit
-                  \nGelassenheit den Auseinandersetzungen entgegen, die \nwir in den kommenden Jahren
-                  führen werden und die wir \nim Parlament zu führen haben, stellvertretend für die
-                  Ge-\nsellschaft, aus der heraus wir gewählt sind. Denn diese \nGesellschaft müssen
-                  wir nicht nur in ihrem Grundkon-\nsens, sondern auch in ihrer Vielheit und Verschiedenheit
-                  \nAlterspräsident Dr. Hermann Otto Solms\nDeutscher Bundestag – 19. Wahlperiode
-                  – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 201714\n(A) (C)\n(B) (D)\nrepräsentieren.
-                  Wir dürfen das eine nicht gegen das an-\ndere ausspielen. \n(Beifall bei der CDU/CSU,
-                  der SPD, der FDP \nund dem BÜNDNIS 90/DIE GRÜNEN sowie \nbei Abgeordneten der LINKEN)\nIn
-                  einem demokratischen Gemeinwesen ist kein The-\nma es wert, über den Streit das
-                  Gemeinsame in Verges-\nsenheit geraten zu lassen. 289 Abgeordnete ziehen heu-\nte
-                  erstmals ins Parlament ein – das sind gut 40 Prozent \naller Mitglieder dieses Hauses.
-                  Selten unterschied sich \nein Bundestag so sehr von seinem Vorgänger wie dieser.
-                  \nSieben Parteien und sechs Fraktionen – so viele gab es \nseit 60 Jahren nicht
-                  mehr. \nDiese neue Konstellation hier im Haus spiegelt die \nVeränderungen wider,
-                  die unsere Gesellschaft erlebt: \nVerunsicherungen wachsen angesichts des raschen
-                  Wan-\ndels durch Globalisierung und Digitalisierung. Zusam-\nmenhänge lösen sich
-                  auf, Zugehörigkeiten brechen auf \nund neue entstehen. Alte Gewissheiten und Identitäten
-                  \nwerden infrage gestellt, und neue, vermeintliche Gewiss-\nheiten werden in Stellung
-                  gebracht gegen zunehmende \nSorgen und Zweifel. \nDas menschliche Bedürfnis nach
-                  Geborgenheit in \nvertrauten Lebensräumen trifft auf eine zunehmend als \nungemütlich
-                  empfundene Welt voller Konflikte, Krisen, \nKriege und medial präsentem Schrecken.
-                  Vor diesem \nHintergrund verschärft sich die Tonlage der gesellschaft-\nlichen Debatten.
-                  All das können wir übrigens vielerorts \nin Europa beobachten. \nMit dem ungeheuer
-                  schnellen gesellschaftlichen Wan-\ndel, den wir erleben, geht eine Fragmentierung
-                  unserer \nDebatten und Aufmerksamkeiten einher. Das stellt die \npolitische Ordnung,
-                  die demokratischen Institutionen \nund Verfahren vor große Herausforderungen. Jedem
-                  er-\nscheint etwas anderes wichtig. Jeder scheint gelegentlich \nnur noch seine
-                  eigenen Probleme wahrzunehmen. Es gibt \nnicht mehr das eine Thema. \nDas Überhandnehmen
-                  von Möglichkeiten und Opti-\nonen kann auch überfordern. Über dieses „Unbehagen
-                  \nim Kapitalismus“ hat Uwe Jean Heuser schon 2000 ge-\nschrieben. Wie alles ist
-                  auch Freiheit durch Übermaß ge-\nfährdet. Deswegen müssen wir immer wieder die richtige
-                  \nBalance auch im Umgang mit Freiheit lernen. \nHinzu kommt der Wandel der Medien
-                  und ihrer Nut-\nzung durch die Veränderungen in der Informationstech-\nnologie.
-                  Die Zersplitterung in viele Teilöffentlichkeiten \nführt dazu, dass uns eine erkennbar
-                  gemeinsame Sicht \nauf politische Prioritäten verloren geht. Da kann dieses \nParlament
-                  ein Ort der Bündelung, der Fokussierung, der \nKonzentration auf die wichtigen Fragen
-                  unserer gesell-\nschaftlichen Zukunft in Deutschland wie in Europa sein. \nWir Abgeordnete,
-                  liebe Kolleginnen und Kollegen, \nsind für die Mitbürger im Wahlkreis manchmal fast
-                  eine \nArt Ombudsmann. Mit unserer Arbeit und unseren Be-\ngegnungen vor Ort vermitteln
-                  wir diese Wirklichkeit auf \ndie Ebene der Bundespolitik. Unsere Vielzahl an Erfah-\nrungen
-                  und Qualifikationen aus beruflicher, sozialer, eh-\nrenamtlicher Tätigkeit bildet
-                  eine ganze Menge Experti-\nse. Vielleicht wissen und fühlen wir Abgeordnete durch
-                  \nunsere Verwurzelung bei den Menschen manchmal bes-\nser als die Forschungsinstitute,
-                  was die Menschen wirk-\nlich bewegt.\n(Beifall bei der CDU/CSU und der FDP sowie
-                  \nbei Abgeordneten der SPD, der LINKEN und \ndes BÜNDNISSES 90/DIE GRÜNEN) \nZugleich
-                  sind wir alle, wie Artikel 38 unseres Grund-\ngesetzes sagt, Abgeordnete des ganzen
-                  Volkes. Dazu \nmüssen wir diese Vielzahl von Interessen, Meinungen, \nBefindlichkeiten
-                  mit den Begrenztheiten und der End-\nlichkeit der Realität zusammenbringen, und
-                  das zwingt \nzu Kompromissen und zu Entscheidungen durch Mehr-\nheit. Je besser
-                  das gelingt, umso weniger fühlen sich \nMenschen in der demokratischen Wirklichkeit
-                  zurückge-\nlassen.\nImmanuel Kant, dem wir viele Gedanken von Rechts-\nstaat und
-                  Republik verdanken, hat gesagt – ich drücke \nes halb mit meinen Worten aus –: Handle
-                  stets so, dass \ndas Prinzip Deiner Handlung immer auch das Prinzip der \nHandlungen
-                  aller anderen sein könnte, dass es immer \nauch allgemeines Gesetz sein könnte.
-                  – Also: Handle so, \ndass menschliches Miteinander nicht zusammenbräche, \nwenn
-                  alle so handelten wie Du selbst.\nDas, verehrte Kolleginnen und Kollegen, gilt gerade
-                  \nauch für Parlamentsabgeordnete, und das ist eine gute \nMaxime für unser repräsentatives
-                  System.\n(Beifall bei der CDU/CSU, der SPD, der FDP, \nder LINKEN und dem BÜNDNIS
-                  90/DIE \nGRÜNEN sowie bei Abgeordneten der AfD)\nAuch die Vertretung partikularer
-                  Interessen darf, wie \nalles, nicht exzessiv werden. Andere Demokratien in der \nWelt
-                  sind da übrigens schon weit auf die abschüssige \nBahn geraten.\nWas aber sehr wohl
-                  sein darf und sein muss, ist, dass \nder parlamentarische Prozess hier im Hause
-                  sichtbar \nmacht, wie schwierig sowohl die Durchsetzung als auch \nder Ausgleich
-                  von Interessen in einer liberalen Demo-\nkratie sind. Da darf Streit nicht nur sein;
-                  das geht nur \nüber Streit. Den müssen wir führen, und den müssen wir \naushalten,
-                  ertragen. Demokratischer Streit ist notwendig, \naber es ist ein Streit nach Regeln,
-                  und es ist mit der Be-\nreitschaft verbunden, die demokratischen Verfahren zu \nachten
-                  und die dann und so zustandegekommenen Mehr-\nheitsentscheidungen nicht als illegitim
-                  oder verräterisch \noder sonst wie zu denunzieren, \n(Beifall bei der CDU/CSU, der
-                  SPD, der FDP \nund dem BÜNDNIS 90/DIE GRÜNEN sowie \nbei Abgeordneten der AfD und
-                  der LINKEN)\nsondern die Beschlüsse der Mehrheit zu akzeptieren. Das \nist parlamentarische
-                  Kultur. \nUnd da kommt es dann auch auf den Stil an, in dem \nwir uns hier streiten
-                  und in dem wir füreinander Respekt \nsignalisieren können. \nEs gab in den vergangenen
-                  Monaten in unserem Land \nTöne der Verächtlichmachung und Erniedrigung. Ich fin-\nPräsident
-                  Dr. Wolfgang Schäuble\nDeutscher Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin,
-                  Dienstag, den 24. Oktober 2017 15\n(A) (C)\n(B) (D)\nde, das hat keinen Platz in
-                  einem zivilisierten Miteinan-\nder. \n(Beifall im ganzen Hause)\nDie überwältigende
-                  Mehrheit der Bürgerinnen und \nBürger in diesem Land will ein zivilisiertes Miteinan-\nder.
-                  In aufgewühlten Zeiten wie unseren wächst das Be-\ndürfnis nach Formen des Verhaltens,
-                  über die man lange \nnicht mehr geredet hat, weil man sie als selbstverständ-\nlich
-                  ansah. Es wird wieder über Anstand gesprochen – \nsogar Bücher werden darüber geschrieben
-                  und kommen \nauf die Bestsellerlisten –, und es wird auch über die Fra-\nge gesprochen,
-                  wie wir in der Gesellschaft miteinander \numgehen sollen: Respekt füreinander haben,
-                  nicht jeden \npersönlichen Spielraum maximal ausnutzen, ein offenes \nOhr haben
-                  für die Argumente des anderen, ihn anerken-\nnen mit seiner anderen Meinung. \nEs
-                  geht um Fairness. Hundertprozentige Gerechtigkeit \ngibt es nicht, aber Fairness
-                  ist möglich in dem Sinne, dass \nsich möglichst alle angesprochen fühlen und nicht
-                  ausge-\nschlossen bleiben.\n(Beifall bei Abgeordneten der AfD sowie des \nAbg. Michael
-                  Grosse-Brömer [CDU/CSU])\nDie Art, wie wir hier miteinander reden, kann vorbild-\nlich
-                  sein für die gesellschaftliche Debatte. Prügeln soll-\nten wir uns hier nicht, wie
-                  es ja zum Teil auch in Europa \nin anderen Parlamenten bisweilen geschieht. \n(Heiterkeit
-                  bei Abgeordneten der CDU/CSU, \nder FDP und des BÜNDNISSES 90/DIE \nGRÜNEN) \nWir
-                  sollten das übrigens auch nicht verbal tun. Wir kön-\nnen vielmehr zeigen, dass
-                  man sich streiten kann, ohne \ndass es unanständig wird. Dazu müssen wir zeigen,
-                  dass \nauch ein Bundestag mit sechs Fraktionen schafft, wozu \ner da ist: Entscheidungen
-                  herbeizuführen, die als legitim \nempfunden werden. \nDas Parlament besteht aus
-                  Abgeordneten, und diese \nAbgeordneten sind nicht „abgehoben“, wie so gern ober-\nflächlich
-                  dahingeredet wird. Wir sind aus der Mitte der \nBürgerinnen und Bürger gewählt.
-                  \nAber niemand vertritt alleine das Volk. So etwas wie \nVolkswille entsteht überhaupt
-                  erst in und mit unseren \nparlamentarischen Entscheidungen. \n(Beifall bei der CDU/CSU,
-                  der SPD, der AfD, \nder FDP und dem BÜNDNIS 90/DIE GRÜ-\nNEN sowie bei Abgeordneten
-                  der LINKEN)\nDeswegen haben wir die Pflicht, diesen Ort wertzuhal-\nten, als Ort
-                  des nachvollziehbaren sachlichen wie auch \nemotionalen Streits – ja, auch Gefühle
-                  gehören dazu –, \nstellvertretend für die Mitbürgerinnen und Mitbürger die \nDinge,
-                  die alle angehen, argumentativ gegeneinander \noder miteinander auszumachen und
-                  dann mit Mehrheit \nzu entscheiden. \nWir müssen das Vertrauen in das repräsentative
-                  Prin-\nzip wieder stärken. Das ist übrigens keine nur nationa-\nle Frage. Die europäischen
-                  oder westlichen Werte, die \nGrundlage unserer verfassungsmäßigen Ordnung sind,
-                  \nwirken vielerorts fragil und erfreuen sich doch zugleich \nweltweit großer Attraktivität.
-                  Freiheit, Rechtsstaatlich-\nkeit, sozialer Zusammenhalt, ökologische Nachhaltig-\nkeit:
-                  Ohne Parlamentarismus geht all das nicht. \nNach ernsthaftem Streit der Meinungen
-                  stellvertre-\ntend für alle Bürgerinnen und Bürger Entscheidungen zu \ntreffen:
-                  Die befriedende Wirkung, die das hat, wenn es \ngelingt, brauchen wir überall in
-                  der Welt – in einer Welt, \nwo ja überall immer mehr Menschen nicht nur Anspruch
-                  \nauf wirtschaftliche Teilhabe, sondern auch auf politische \nMitsprache erheben.
-                  \nIn Zeiten zunehmender Globalisierung heißt das auch, \ndie Kompliziertheit unserer
-                  Welt auszuhalten. Aber wir \nhaben zugleich auch die Chance, der Welt, die sich
-                  uns \nnähert, zu zeigen, dass der Parlamentarismus etwas taugt, \ndass er funktioniert
-                  und dass er zu Lösungen für die Pro-\nbleme und Herausforderungen fähig ist. \nNorbert
-                  Lammert hat immer sehr elegant die Tage, an \ndenen er sprach, danach befragt, was
-                  an ihnen in vergan-\ngenen Jahren und Jahrhunderten geschah und an was uns \ndas
-                  erinnern sollte. Ich will das heute noch einmal im \nSinne einer kleinen Hommage
-                  tun. Um es chronologisch \nrückwärts zu machen: Dieser 24. Oktober ist der Tag der
-                  \nVereinten Nationen. 1945 trat am 24. Oktober die Charta \nder Vereinten Nationen
-                  in Kraft. Am 24. Oktober 1929 \nendete am Schwarzen Donnerstag die jahrelange Haus-\nse
-                  der New Yorker Börse, und es begann die Weltwirt-\nschaftskrise mit all ihren Folgen.
-                  \nUnd am 24. Oktober 1648 wurde der Westfälische \nFrieden zur Beendigung des Dreißigjährigen
-                  Krieges \nunterzeichnet, eines Krieges, an dessen Beginn wir uns \nkommendes Jahr
-                  erinnern. Herfried Münkler hat ihm \ngerade ein Opus Magnum gewidmet, in dem er
-                  zeigt, \ndass dieser bis heute längste Krieg auf deutschem Bo-\nden – zugleich übrigens
-                  der erste im vollen Sinne euro-\npäische Krieg – uns besser als alle späteren Konflikte
-                  die \nKriege unserer Gegenwart verstehen lässt. Wer es nicht \nglaubt, der lese
-                  noch einmal im „Simplicissimus“ von \n Grimmelshausen nach. Er ist übrigens in meinem
-                  Wahl-\nkreis geschrieben worden. \n(Heiterkeit – Martin Schulz [SPD]: Im „Sil-\nbernen
-                  Stern“!)\nAll das, liebe Kolleginnen und Kollegen, erinnert uns \nan den Charakter
-                  der Aufgaben, die vor uns liegen. Es \nerinnert uns daran, dass wir die Entscheidungen,
-                  die wir \nhier treffen, in weltpolitische Zusammenhänge einzubet-\nten haben. \nEuropa
-                  und die Globalisierung: Das ist heute der Rah-\nmen für das, was wir hier debattieren
-                  und entscheiden. \nDas hat nichts mit einem Aufgeben nationaler Selbstbe-\nstimmung
-                  zu tun, schon gar nichts mit einem Aufgeben \ndes Anspruchs, dass dies hier der
-                  Ort ist, an dem im-\nmer wieder neu die Souveränität des deutschen Volkes \ngreifbar
-                  und wirklich wird. Vielmehr beschreibt es die \nAufgabe, der wir gerecht werden
-                  müssen, den Weg einer \nselbstbewussten Einordnung in immer weitere Zusam-\nPräsident
-                  Dr. Wolfgang Schäuble\nDeutscher Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin,
-                  Dienstag, den 24. Oktober 201716\n(A) (C)\n(B) (D)\nmenhänge zu finden, mit dem
-                  Ziel, dazu beizutragen, in \ndieser Welt unsere Zukunft gestalten zu können.\n(Beifall
-                  bei der CDU/CSU, der SPD, der FDP, \nder LINKEN und dem BÜNDNIS 90/DIE \nGRÜNEN)\nDass
-                  wir uns in solcher Öffnung zur Welt und Ein-\nordnung noch selbst erkennen, dass
-                  wir bleiben, was \nwir irgendwie fühlen, das wir sind – im Guten, wie \nzum Beispiel
-                  unserer parlamentarischen Ordnung, wie \nim Schlechten, das wir als nationale Schicksalsgemein-\nschaft
-                  nicht werden abstreifen können und aus dem wir \ndoch immer wieder neues Gutes zu
-                  entwickeln uns be-\nmühen –, dass wir all das bleiben, ohne uns abzuschotten \noder
-                  uns bequem rauszuhalten, darum, liebe Kolleginnen \nund Kollegen, geht es.\n(Beifall
-                  bei der CDU/CSU, der SPD, der FDP \nund dem BÜNDNIS 90/DIE GRÜNEN sowie \nbei Abgeordneten
-                  der LINKEN)\nIn der Präambel unseres Grundgesetzes von 1949, die \nwir 1990 im wiedervereinten
-                  Deutschland fortgeschrie-\nben haben, heißt es:\n… von dem Willen beseelt, als gleichberechtigtes
-                  \nGlied in einem vereinten Europa dem Frieden der \nWelt zu dienen, hat sich das
-                  Deutsche Volk kraft \nseiner verfassungsgebenden Gewalt dieses Grund-\ngesetz gegeben.\nDies
-                  hier, liebe Kolleginnen und Kollegen, ist der Ort, an \ndem wir diesem Willen Gestalt
-                  geben.\n(Beifall bei der CDU/CSU, der SPD, der FDP, \nder LINKEN und dem BÜNDNIS
-                  90/DIE \nGRÜNEN sowie bei Abgeordneten der AfD)\nDafür hat uns eine wieder gewachsene
-                  Zahl von Bür-\ngerinnen und Bürgern gewählt. Der Trend zur höheren \nWahlbeteiligung
-                  bei den letzten Landtagswahlen hat sich \nauch im Bund fortgesetzt. Ich denke, das
-                  zeigt, dass Er-\nwartungen gestiegen sind. Wenn wir diese Erwartungen \neinigermaßen
-                  erfüllen, können wir unserem Land einen \ngroßen Dienst erweisen. Steigende Erwartungen
-                  sind \nalso eine Chance, auch wenn es zur Wahrheit gehört, dass \nin dieser Welt
-                  immer neuer Akteure und immer dichte-\nrer Verflechtungen die Realität komplizierter
-                  wird und \nunsere Handlungsspielräume nicht immer nur wachsen. \nZwischen beidem
-                  müssen wir als Parlament unseren Weg \nfinden.\nIch freue mich auf unsere Arbeit
-                  hier in den kommen-\nden vier Jahren.\nHerzlichen Dank.\n(Beifall im ganzen Hause)\nIch
-                  rufe den Tagesordnungspunkt 5 auf:\nFestlegung der Zahl der Stellvertreterinnen
-                  und \nStellvertreter des Präsidenten\nDrucksache 19/3 \nEs liegt hierzu ein Antrag
-                  der Fraktionen CDU/CSU, \nSPD, AfD, FDP, Die Linke und Bündnis 90/Die Grünen \nvor.
-                  Wer stimmt für den Antrag auf Drucksache 19/3? – \nGegenstimmen? – Enthaltungen?
-                  – Bei zwei Enthaltun-\ngen ist der Antrag einstimmig angenommen. Damit ist \ndie
-                  Zahl der Stellvertreterinnen und Stellvertreter des \nPräsidenten auf sechs festgelegt.\nDamit
-                  rufe ich den Tagesordnungspunkt 6 auf:\nWahl der Stellvertreterinnen und Stellvertreter
-                  \ndes Präsidenten \nDie Wahl erfolgt nach unserer Geschäftsordnung ge-\nheim. Es
-                  ist interfraktionell vereinbart worden, die Wahl \nder sechs Stellvertreterinnen
-                  und Stellvertreter des Prä-\nsidenten mit Wahlausweis und einer Stimmkarte, auf
-                  der \ndie Namen aller vorgeschlagenen Kandidatinnen und \nKandidaten aufgeführt
-                  sind, durchzuführen. – Ich sehe \nkeinen Widerspruch. Damit sind Sie einverstanden.
-                  Dann \nverfahren wir so. \nMir liegen die folgenden Vorschläge der Fraktionen \nvor:
-                  von der Fraktion der CDU/CSU Dr. Hans-Peter \nFriedrich, von der Fraktion der SPD
-                  Thomas Oppermann, \nvon der Fraktion der AfD Albrecht Glaser, von der Frak-\ntion
-                  der FDP Wolfgang Kubicki, von der Fraktion Die \nLinke Petra Pau und von der Fraktion
-                  Bündnis 90/Die \nGrünen Claudia Roth.\nIch bitte nun um Ihre Aufmerksamkeit für
-                  einige wei-\ntere Hinweise zum Ablauf der Wahl. \nGewählt ist, wer die Stimmen der
-                  Mehrheit der Mit-\nglieder des Bundestags erhält; das sind 355 Stimmen. \nFür diesen
-                  Wahlgang sind Stimmkarte und Wahlausweis \ngrün. Ihren Wahlausweis können Sie, soweit
-                  noch nicht \ngeschehen, den Stimmkartenfächern in der Lobby ent-\nnehmen. Vor den
-                  Wahlkabinen an den Ausgabetischen \nerhalten Sie Ihre grüne Stimmkarte und den amtlichen
-                  \nWahlumschlag. Auf der Stimmkarte sind alle vorgeschla-\ngenen Kandidatinnen und
-                  Kandidaten aufgeführt. Sie \ndürfen Ihre Stimmkarte nur in der Wahlkabine ankreuzen
-                  \nund müssen die Stimmkarte noch in der Wahlkabine in \nden Umschlag legen. \nSie
-                  können zu jedem Vorschlag „Ja“, „Nein“ oder \n„Enthalte mich“ ankreuzen. Sie haben
-                  also insgesamt \nsechs Stimmen. Wenn Sie bei einem Namen mehr als ein \nKreuz oder
-                  gar kein Kreuz machen oder andere Namen \nals die der vorgeschlagenen Kandidaten
-                  oder Zusätze \neintragen, ist die Stimme ungültig. \nBevor Sie die Stimmkarte in
-                  die Wahlurne werfen, \nmüssen Sie einer der Schriftführerinnen oder einem der \nSchriftführer
-                  an der Wahlurne Ihren Wahlausweis über-\ngeben.\nIch bitte die Schriftführerinnen
-                  und Schriftführer, die \nvorgesehenen Plätze einzunehmen. Dieser Wahlgang er-\nfolgt
-                  ohne Namensaufruf. – Sind alle Urnen besetzt? – \nDas ist der Fall. Dann eröffne
-                  ich die Wahl. \nHaben alle anwesenden Abgeordneten die Gelegen-\nheit gehabt, ihre
-                  Stimme abzugeben? – Offensichtlich \nhaben alle Mitglieder des Hauses ihre Stimmkarten
-                  ab-\ngeben können. Damit schließe ich die Wahl und bitte die \nSchriftführerinnen
-                  und Schriftführer, mit der Auszählung \nzu beginnen. Bis zur Bekanntgabe des Ergebnisses
-                  der \nPräsident Dr. Wolfgang Schäuble\nDeutscher Bundestag – 19. Wahlperiode – 1.
-                  Sitzung. Berlin, Dienstag, den 24. Oktober 2017 17\n(A) (C)\n(B) (D)\nWahl unterbreche
-                  ich die Sitzung. Der Wiederbeginn \nwird durch Klingelzeichen rechtzeitig angekündigt.\n(Unterbrechung
-                  von 14.14 bis 15.24 Uhr) \nPräsident Dr. Wolfgang Schäuble: \nLiebe Kolleginnen
-                  und Kollegen, ich eröffne die un-\nterbrochene Sitzung wieder. \nIch gebe das Ergebnis
-                  der Wahl der Stellvertreterinnen \nund Stellvertreter des Präsidenten bekannt: abgegebene
-                  \nStimmen 703. – Die notwendige Mehrheit ist übrigens \nunverändert ab 355 Stimmen
-                  erreicht.\nAuf den vorgeschlagenen Kandidaten Dr. Hans-Peter \nFriedrich entfielen
-                  507 Jastimmen, 112 Neinstimmen \nund 82 Enthaltungen; 2 Stimmen waren ungültig.\n(Beifall
-                  im ganzen Hause) \nAuf den vorgeschlagenen Kandidaten Thomas \nOppermann entfielen
-                  396 Jastimmen, 220 Neinstimmen \nund 81 Enthaltungen; 6 Stimmen waren ungültig.
-                  \n(Beifall bei der CDU/CSU, der SPD, der FDP \nund der LINKEN)\nAuf den vorgeschlagenen
-                  Kandidaten Albrecht Glaser \nentfielen 115 Jastimmen, 550 Neinstimmen und 26 Ent-\nhaltungen;
-                  12 Stimmen waren ungültig. \n(Zurufe von der SPD und dem BÜNDNIS 90/\nDIE GRÜNEN:
-                  Bitte wiederholen!)\n– Alle? \n(Zurufe: Nein! – Dr. Eva Högl [SPD]: Es ist \nhier
-                  zu laut!)\nAuf den vorgeschlagenen Kandidaten Albrecht Glaser \nentfielen 115 Jastimmen,
-                  550 Neinstimmen und 26 Ent-\nhaltungen; 12 Stimmen waren ungültig. \nAuf den vorgeschlagenen
-                  Kandidaten Wolfgang \n Kubicki entfielen 489 Jastimmen, \n(Beifall bei der CDU/CSU,
-                  der SPD, der FDP \nund dem BÜNDNIS 90/DIE GRÜNEN sowie \nbei Abgeordneten der LINKEN)\n100
-                  Neinstimmen und 111 Enthaltungen; 3 Stimmen wa-\nren ungültig.\nAuf die vorgeschlagene
-                  Kandidatin Petra Pau entfie-\nlen 456 Jastimmen,\n(Beifall bei der CDU/CSU, der
-                  SPD, der FDP, \nder LINKEN und dem BÜNDNIS 90/DIE \nGRÜNEN)\n187 Neinstimmen und
-                  54 Enthaltungen; 6 Stimmen wa-\nren ungültig\nAuf die vorgeschlagene Kandidatin
-                  Claudia Roth ent-\nfielen 489 Jastimmen, \n(Beifall bei der CDU/CSU, der SPD, der
-                  FDP, \nder LINKEN und dem BÜNDNIS 90/DIE \nGRÜNEN)\n166 Neinstimmen und 45 Enthaltungen;
-                  3 Stimmen wa-\nren ungültig.\nDie Abgeordneten Dr. Hans-Peter Friedrich, Thomas
-                  \nOppermann, Wolfgang Kubicki, Petra Pau und Claudia \nRoth haben die erforderliche
-                  Mehrheit erhalten und sind \nzu Stellvertreterinnen und Stellvertretern des Präsidenten
-                  \ngewählt. Der Abgeordnete Albrecht Glaser hat die erfor-\nderliche Mehrheit nicht
-                  erhalten.1)\nIch frage Sie, die gewählten Stellvertreterinnen und \nStellvertreter,
-                  ob Sie die Wahl annehmen. \nHerr Dr. Friedrich, nehmen Sie die Wahl an? \nDr. Hans-Peter
-                  Friedrich (Hof) (CDU/CSU): \nHerr Präsident, ich nehme die Wahl an.\n(Beifall bei
-                  der CDU/CSU und der FDP so-\nwie bei Abgeordneten der SPD)\nPräsident Dr. Wolfgang
-                  Schäuble: \nDann beglückwünsche ich Sie, Herr Kollege Friedrich. \nHerr Kollege
-                  Thomas Oppermann, nehmen Sie Wahl \nan?\nThomas Oppermann (SPD): \nJawohl, Herr
-                  Präsident, ich nehme die Wahl an.\n(Beifall bei der SPD)\nPräsident Dr. Wolfgang
-                  Schäuble: \nIch beglückwünsche Sie und freue mich auf gute Zu-\nsammenarbeit. \nHerr
-                  Kollege Kubicki, nehmen Sie die Wahl an?\nWolfgang Kubicki (FDP): \nHerr Präsident,
-                  ich nehme die Wahl an.\n(Beifall bei der FDP sowie bei Abgeordneten \nder CDU/CSU)\nPräsident
-                  Dr. Wolfgang Schäuble: \nDann beglückwünsche ich auch Sie im Namen des \nHauses
-                  und freue mich auf gute Zusammenarbeit. \nFrau Kollegin Pau, nehmen Sie die Wahl
-                  an?\nPetra Pau (DIE LINKE): \nHerr Präsident, ich nehme die Wahl an und freue mich
-                  \nauf die Zusammenarbeit.\n(Beifall bei der LINKEN sowie bei Abgeord-\nneten der
-                  CDU/CSU, der SPD, der FDP und \ndes BÜNDNISSES 90/DIE GRÜNEN)\nPräsident Dr. Wolfgang
-                  Schäuble: \nHerzlichen Glückwunsch, Frau Pau. Auch ich freue \nmich auf die Zusammenarbeit.\nJetzt
-                  frage ich die Frau Kollegin Roth, ob sie die Wahl \nannimmt.\n1)  Namensverzeichnis
-                  der Teilnehmer an der Wahl siehe Anlage 3\nPräsident Dr. Wolfgang Schäuble\nDeutscher
-                  Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 201718\n(A)
-                  (C)\n(B) (D)\nClaudia Roth (Augsburg) (BÜNDNIS 90/DIE GRÜ-\nNEN): \nJa, ich nehme
-                  die Wahl mit großer Freude an und freue \nmich auch auf die Zusammenarbeit.\n(Beifall
-                  beim BÜNDNIS 90/DIE GRÜNEN \nsowie bei Abgeordneten der CDU/CSU)\nPräsident Dr.
-                  Wolfgang Schäuble: \nDie Freude ist unübersehbar. Ich beglückwünsche Sie \nim Namen
-                  des ganzen Hauses, Frau Kollegin Roth.\n(Beifall bei Abgeordneten des BÜNDNIS-\nSES
-                  90/DIE GRÜNEN)\nIch wünsche Ihnen allen im Namen des Hauses Glück \nund Erfolg für
-                  das verantwortungsvolle Amt.\nDa der Kollege Glaser nicht die erforderliche Mehr-\nheit
-                  der Mitglieder des Hauses erhalten hat, ist nach der \nGeschäftsordnung ein zweiter
-                  Wahlgang erforderlich. \nWir führen diesen zweiten Wahlgang jetzt unmittelbar \ndurch.
-                  \ \nFür diesen zweiten Wahlgang schlägt die Fraktion der \nAfD den Kollegen Glaser
-                  vor. Auch im zweiten Wahl-\ngang ist nach unserer Geschäftsordnung die Mehrheit
-                  der \nMitglieder des Bundestages, also 355 Stimmen, erforder-\nlich. Die Wahl ist
-                  wiederum geheim. Wahlausweise und \nStimmkarte für diesen Wahlgang sind blau. Die
-                  Stimm-\nkarte erhalten Sie wieder vor den Wahlkabinen. – Jetzt \nbitte ich Sie –
-                  genauso wie zuvor –, sich die Wahlun-\nterlagen zu besorgen und in den Kabinen Ihr
-                  Kreuz zu \nmachen. Wir beginnen mit der Wahl. Sind alle Urnen \nbesetzt? – Das ist
-                  der Fall. Dann ist die Wahl eröffnet. \nLiebe Kolleginnen und Kollegen, darf ich
-                  fragen, ob \njemand nicht die Möglichkeit hatte, seine Stimme ab-\nzugeben? – Das
-                  ist offensichtlich nicht der Fall. Dann \nschließe ich die Wahl. Ich bitte die Schriftführerinnen
-                  \nund Schriftführer, mit der Auszählung zu beginnen.\nIch unterbreche die Sitzung
-                  für etwa eine halbe Stun-\nde. Der Wiederbeginn wird rechtzeitig durch Klingelsi-\ngnal
-                  angekündigt.\n(Unterbrechung von 15.55 bis 16.15 Uhr) \nPräsident Dr. Wolfgang Schäuble:
-                  \nLiebe Kolleginnen und Kollegen, die unterbrochene \nSitzung ist wieder eröffnet.
-                  Ich darf Sie bitten, Platz zu \nnehmen. \nIch teile Ihnen das Ergebnis des zweiten
-                  Wahlgangs \nzur Wahl eines Stellvertreters des Präsidenten mit: abge-\ngebene Stimmen
-                  697, ungültige Stimmen 1, gültige Stim-\nmen 696. Mit Ja haben gestimmt 123, mit
-                  Nein haben \ngestimmt 549, Enthaltungen 24. Der Abgeordnete Glaser \nhat damit die
-                  erforderliche Mehrheit nicht erhalten.1)\nJetzt schaue ich den Kollegen Baumann
-                  an. – Die \nFraktion der AfD beantragt, einen dritten Wahlgang \ndurchzuführen.
-                  Es gibt keinen neuen Kandidaten.\n1)  Namensverzeichnis der Teilnehmer an der Wahl
-                  siehe Anlage 4\nIch würde Ihnen gerne noch erläutern, wie der dritte \nWahlgang
-                  abläuft. Nach unserer Geschäftsordnung ist \nim dritten Wahlgang der Kandidat Herr
-                  Glaser gewählt, \nwenn er die Mehrheit der abgegebenen Stimmen auf \nsich vereinigt,
-                  also die Zahl der Jastimmen größer ist als \ndie Zahl der Neinstimmen. Enthaltungen
-                  bleiben inso-\nfern unberücksichtigt. Die Wahl ist wiederum geheim. \nWahlausweis
-                  und Stimmkarte für diesen Wahlgang sind \nrot. Alles andere, Wahlkabine etc., läuft
-                  so ab wie bei den \nersten beiden Wahlgängen auch. \nIch bitte, die Wahlunterlagen
-                  in Empfang zu nehmen \nund die Urnen zu besetzen. Dazu brauchen wir Schrift-\nführer.
-                  – Die Urnen sind besetzt. Ich eröffne den dritten \nWahlgang. \nLiebe Kolleginnen
-                  und Kollegen, darf ich fragen, ob \nnoch ein Abgeordneter seine Stimmkarte abgeben
-                  möch-\nte, der sie nicht abgegeben hat? – Das ist nicht der Fall. \nDann schließe
-                  ich den Wahlgang und bitte die Schrift-\nführerinnen und Schriftführer, mit der
-                  Auszählung zu \nbeginnen. Ich unterbreche die Sitzung wieder für etwa \neine halbe
-                  Stunde. Auch diesmal wird durch Klingelzei-\nchen rechtzeitig angekündigt, wenn
-                  die Sitzung wieder \nbeginnt.\n(Unterbrechung von 16.39 bis 16.59 Uhr) \nPräsident
-                  Dr. Wolfgang Schäuble: \nDie unterbrochene Sitzung ist wieder eröffnet. \nLiebe
-                  Kolleginnen und Kollegen, ich darf Sie bitten, \nwieder Platz zu nehmen. Mir liegt
-                  das Ergebnis des drit-\nten Wahlgangs vor. Sobald Sie Platz genommen haben, \nwerde
-                  ich es Ihnen mitteilen.  \nIm dritten Wahlgang für die Wahl einer Stellver-\ntreterin/eines
-                  Stellvertreters des Präsidenten wurden \n685 Stimmen abgegeben. 685 Stimmen waren
-                  gültig. \nMit Ja haben gestimmt 114, mit Nein haben gestimmt \n545, Enthaltungen
-                  26. Der Abgeordnete Glaser hat damit \nnicht die erforderliche Mehrheit erhalten.2)\nGemäß
-                  § 2 Absatz 3 unserer Geschäftsordnung findet \nkein weiterer Wahlgang mit einem
-                  im dritten Wahlgang \nerfolglosen Kandidaten statt, es sei denn, ein weiterer \nWahlgang
-                  wird im Ältestenrat vereinbart. Wird ein neuer \nBewerber vorgeschlagen, so ist
-                  in ein neues Wahlverfah-\nren einzutreten. Es wäre also wieder ein erster Wahlgang
-                  \nmit den entsprechenden Mehrheitserfordernissen durch-\nzuführen. In beiden Fällen
-                  muss aber erst vereinbart wer-\nden, an welchem Tag die Wahl durchgeführt werden
-                  soll. \nDie Geschäftsführerinnen und Geschäftsführer der \nFraktionen haben mir
-                  signalisiert, dass es kein Einver-\nnehmen über die Durchführung weiterer Wahlgänge
-                  am \nheutigen Tag gibt. Damit ist dieser Tagesordnungspunkt \nabgeschlossen. \nDamit
-                  darf ich Sie bitten, sich zu unserer Natio-\nnalhymne von Ihren Sitzen zu erheben.
-                  \n(Nationalhymne – Beifall)\n2) Namensverzeichnis der Teilnehmer an der Wahl siehe
-                  Anlage 5\nDeutscher Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag,
-                  den 24. Oktober 2017 19\n(A) (C)\n(B) (D)\nLiebe Kolleginnen und Kollegen, wir sind
-                  damit am \nSchluss unserer heutigen Tagesordnung. Die nächste Sit-\nzung findet
-                  in der 47. Kalenderwoche, also in der Woche \nvom 20. November, statt. Der genaue
-                  Tag der Sitzung \nwird noch bestimmt und Ihnen bekannt gegeben.\nBevor ich die Sitzung
-                  schließe, darf ich Sie herzlich zu \neinem kleinen Empfang auf der Fraktionsebene
-                  einladen.\nDie Sitzung ist geschlossen. \n(Schluss: 17.03 Uhr) \nPräsident Dr. Wolfgang
-                  Schäuble\n\n(A) (C)\n(B) (D)\nDeutscher Bundestag – 19. Wahlperiode – 1. Sitzung.
-                  Berlin, Dienstag, den 24. Oktober 2017 21\nAnlagen zum Stenografischen Bericht\nAnlage
-                  1\nListe der entschuldigten Abgeordneten\nAbgeordnete(r)\nentschuldigt bis \neinschließlich\nLeidig,
-                  Sabine DIE LINKE 24.10.2017\nLutze, Thomas DIE LINKE 24.10.2017\nPoschmann, Sabine
-                  SPD 24.10.2017\nSchimke, Jana CDU/CSU 24.10.2017\nStrenz, Karin CDU/CSU 24.10.2017\nAnlage
-                  2\nNamensverzeichnis\nder Mitglieder des Deutschen Bundestages, die an der Wahl
-                  der des Präsidenten des Deutschen Bundestages \nteilgenommen haben\nCDU/CSU\nDr.
-                  Michael von Abercron\nStephan Albani\nNorbert Maria Altenkamp\nPeter Altmaier\nPhilipp
-                  Amthor\nArtur Auernhammer\nPeter Aumer\nDorothee Bär\nThomas Bareiß\nNorbert Barthle\nMaik
-                  Beermann\nManfred Behrens (Börde)\nVeronika Bellmann\nSybille Benning\nDr. André
-                  Berghegger\nMelanie Bernstein\nChristoph Bernstiel\nPeter Beyer\nMarc Biadacz\nSteffen
-                  Bilger\nPeter Bleser\nNorbert Brackmann\nMichael Brand\nDr. Reinhard Brandl\nDr.
-                  Ralf Brauksiepe\nDr. Helge Braun\nSilvia Breher\nSebastian Brehm\nHeike Brehmer\nRalph
-                  Brinkhaus\nDr. Carsten Brodesser\nGitta Connemann\nAstrid Damerow\nAlexander Dobrindt\nMarie-Luise
-                  Dött\nMichael Donth\nHansjörg Durz\nThomas Erndl\nHermann Färber\nUwe Feiler\nEnak
-                  Ferlemann\nAxel E. Fischer (Karlsruhe-\nLand)\nDr. Maria Flachsbarth\nThorsten Frei\nDr.
-                  Hans-Peter Friedrich \n(Hof)\nMichael Frieser\nHans-Joachim Fuchtel\nIngo Gädechens\nDr.
-                  Thomas Gebhart\nAlois Gerig\nEberhard Gienger\nEckhard Gnodtke\nUrsula Groden-Kranich\nHermann
-                  Gröhe\nKlaus-Dieter Gröhler\nMichael Grosse-Brömer\nAstrid Grotelüschen\nMarkus
-                  Grübel\nMonika Grütters\nManfred Grund\nOliver Grundmann\nFritz Güntzler\nOlav Gutting\nChristian
-                  Haase\nFlorian Hahn\nDr. Stephan Harbarth\nJürgen Hardt\nMatthias Hauer\nMark Hauptmann\nDr.
-                  Matthias Heider\nMechthild Heil\nThomas Heilmann\nFrank Heinrich (Chemnitz)\nMark
-                  Helfrich\nRudolf Henke\nMichael Hennrich\nMarc Henrichmann\nAnsgar Heveling\nChristian
-                  Hirte\nDr. Heribert Hirte\nAlexander Hoffmann\nKarl Holmeier\nDr. Hendrik Hoppenstedt\nErich
-                  Irlstorfer\nHans-Jürgen Irmer\nThomas Jarzombek\nAndreas Jung\nIngmar Jung\nAlois
-                  Karl\nAnja Karliczek\nTorbjörn Kartes\nVolker Kauder\nDr. Stefan Kaufmann\nRonja
-                  Kemmer\nRoderich Kiesewetter\nMichael Kießling\nDr. Georg Kippels\nVolkmar Klein\nAxel
-                  Knoerig\nJens Koeppen\nCarsten Körber\nMarkus Koob\nAlexander Krauß\nGunther Krichbaum\nDr.
-                  Günter Krings\nRüdiger Kruse\nDr. Roy Kühne\nMichael Kuffer\nAndreas G. Lämmel\nDr.
-                  Dr. h. c. Karl A. Lamers\nKatharina Landgraf\nUlrich Lange\nDr. Silke Launert\nJens
-                  Lehmann\nPaul Lehrieder\nDr. Katja Leikert\nDr. Andreas Lenz\nDr. Ursula von der
-                  Leyen\nDeutscher Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den
-                  24. Oktober 201722\n(A) (C)\n(B) (D)\nAntje Lezius\nAndrea Lindholz\nDr. Carsten
-                  Linnemann\nPatricia Lips\nNikolas Löbel\nBernhard Loos\nDr. Jan-Marco Luczak\nDaniela
-                  Ludwig\nKarin Maag\nYvonne Magwas\nDr. Thomas de Maizière\nDr. Astrid Mannes\nMatern
-                  von Marschall\nHans-Georg von der Marwitz\nAndreas Mattfeldt\nStephan Mayer (Altötting)\nDr.
-                  Michael Meister\nDr. Angela Merkel\nJan Metzler\nDr. h. c. Hans Michelbach\nDr.
-                  Mathias Middelberg\nKarsten Möring\nDietrich Monstadt\nMarlene Mortler\nElisabeth
-                  Motschmann\nAxel Müller\nDr. Gerd Müller\nSepp Müller\nCarsten Müller \n(Braunschweig)\nStefan
-                  Müller (Erlangen)\nDr. Andreas Nick\nPetra Nicolaisen\nMichaela Noll\nDr. Georg
-                  Nüßlein\nWilfried Oellers\nFlorian Oßner\nJosef Oster\nHenning Otte\nSylvia Pantel\nMartin
-                  Patzelt\nDr. Joachim Pfeiffer\nStephan Pilsinger\nDr. Christoph Ploß\nEckhard Pols\nThomas
-                  Rachel\nKerstin Radomski\nAlexander Radwan\nAlois Rainer\nDr. Peter Ramsauer\nEckhardt
-                  Rehberg\nLothar Riebsamen\nJosef Rief\nJohannes Röring\nDr. Norbert Röttgen\nStefan
-                  Rouenhoff\nErwin Rüddel\nAlbert Rupprecht\nStefan Sauer\nAnita Schäfer (Saalstadt)\nDr.
-                  Wolfgang Schäuble\nAndreas Scheuer\nJana Schimke\nTankred Schipanski\nChristian
-                  Schmidt (Fürth)\nDr. Claudia Schmidtke\nPatrick Schnieder\nNadine Schön\nFelix Schreiner\nDr.
-                  Klaus-Peter Schulze\nUwe Schummer\nArmin Schuster (Weil am \nRhein)\nTorsten Schweiger\nDetlef
-                  Seif\nJohannes Selle\nReinhold Sendker\nDr. Patrick Sensburg\nThomas Silberhorn\nBjörn
-                  Simon\nTino Sorge\nJens Spahn\nKatrin Staffler\nDr. Frank Steffel\nDr. Wolfgang
-                  Stefinger\nAlbert Stegemann\nAndreas Steier\nPeter Stein (Rostock)\nSebastian Steineke\nJohannes
-                  Steiniger\nChristian Frhr. von Stetten\nDieter Stier\nGero Storjohann\nStephan Stracke\nMax
-                  Straubinger\nMichael Stübgen\nDr. Peter Tauber\nDr. Hermann-Josef Tebroke\nHans-Jürgen
-                  Thies\nAlexander Throm\nDr. Dietlind Tiemann\nAntje Tillmann\nMarkus Uhl\nDr. Volker
-                  Ullrich\nArnold Vaatz\nOswin Veith\nKerstin Vieregge\nVolkmar Vogel (Kleinsaara)\nChristoph
-                  de Vries\nKees de Vries\nDr. Johann David Wadephul\nMarco Wanderwitz\nKai Wegner\nDr.
-                  h. c. Albert Weiler\nMarcus Weinberg (Hamburg)\nDr. Anja Weisgerber\nPeter Weiß
-                  (Emmendingen)\nSabine Weiss (Wesel I)\nIngo Wellenreuther\nMarian Wendt\nKai Whittaker\nAnnette
-                  Widmann-Mauz\nBettina Margarethe \nWiesmann\nKlaus-Peter Willsch\nElisabeth Winkelmeier-\nBecker\nOliver
-                  Wittke\nEmmi Zeulner\nPaul Ziemiak\nDr. Matthias Zimmer\nSPD\nNiels Annen\nIngrid
-                  Arndt-Brauer\nHeike Baehrens\nUlrike Bahr\nDr. Katarina Barley\nDoris Barnett\nDr.
-                  Matthias Bartke\nSören Bartol\nBärbel Bas\nLothar Binding (Heidelberg)\nLeni Breymaier\nDr.
-                  Karl-Heinz Brunner\nKatrin Budde\nMarco Bülow\nMartin Burkert\nDr. Lars Castellucci\nBernhard
-                  Daldrup\nDr. Daniela De Ridder\nDr. Karamba Diaby\nEsther Dilcher\nSabine Dittmar\nWiebke
-                  Esdar\nSaskia Esken\nYasmin Fahimi\nDr. Johannes Fechner\nDr. Fritz Felgentreu\nDr.
-                  Edgar Franke\nUlrich Freese\nDagmar Freitag\nSigmar Gabriel\nMichael Gerdes\nMartin
-                  Gerster\nAngelika Glöckner\nTimon Gremmels\nKerstin Griese\nUli Grötsch\nMichael
-                  Groß\nBettina Hagedorn\nRita Hagl-Kehl\nMetin Hakverdi\nSebastian Hartmann\nDirk
-                  Heidenblut\nHubertus Heil (Peine)\nGabriela Heinrich\nMarcus Held\nWolfgang Hellmich\nDr.
-                  Barbara Hendricks\nGustav Herzog\nGabriele Hiller-Ohm\nThomas Hitschler\nDr. Eva
-                  Högl\nFrank Junge\nJosip Juratovic\nThomas Jurk\nOliver Kaczmarek\nJohannes Kahrs\nElisabeth
-                  Kaiser\nRalf Kapschack\nGabriele Katzmarek\nUlrich Kelber\nCansel Kiziltepe\nArno
-                  Klare\nLars Klingbeil\nDr. Bärbel Kofler\nDaniela Kolbe\nElvan Korkmaz\nAnette Kramme\nChristine
-                  Lambrecht\nChristian Lange (Backnang)\nDr. Karl Lauterbach\nHelge Lindh\nBurkhard
-                  Lischka\nKirsten Lühmann\nHeiko Josef Maas\nCaren Marks\nKatja Mast\nChristoph Matschie\nHilde
-                  Mattheis\nDr. Matthias Miersch\nKlaus Mindrup\nSusanne Mittag\nSiemtje Möller\nFalko
-                  Mohrs\nClaudia Moll\nBettina Müller\nDetlef Müller (Chemnitz)\nMichelle Müntefering\nDr.
-                  Rolf Mützenich\nAndrea Nahles\nDietmar Nietan\nDeutscher Bundestag – 19. Wahlperiode
-                  – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 2017 Deutscher Bundestag – 19. Wahlperiode
-                  – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 2017 23\n(A) (C)\n(B) (D)\nUlli
-                  Nissen\nMahmut Özdemir (Duisburg)\nAydan Özoğuz\nThomas Oppermann\nJosephine Ortleb\nChristian
-                  Petry\nDetlev Pilger\nFlorian Post\nAchim Post (Minden)\nFlorian Pronold\nDr. Sascha
-                  Raabe\nMartin Rabanus\nDr. Carola Reimann\nAndreas Rimkus\nSönke Rix\nRené Röspel\nDennis
-                  Rohde\nDr. Martin Rosemann\nDr. Ernst Dieter Rossmann\nMichael Roth (Heringen)\nSusann
-                  Rüthrich\nBernd Rützel\nSarah Ryglewski\nJohann Saathoff\nAxel Schäfer (Bochum)\nDr.
-                  Nina Scheer\nMarianne Schieder\nUdo Schiefner\nDr. Nils Schmid\nUwe Schmidt\nUlla
-                  Schmidt (Aachen)\nDagmar Schmidt (Wetzlar)\nCarsten Schneider (Erfurt)\nJohannes
-                  Schraps\nMichael Schrodi\nDr. Manja Schüle\nUrsula Schulte\nMartin Schulz\nSwen
-                  Schulz (Spandau)\nEwald Schurer\nFrank Schwabe\nStefan Schwartze\nAndreas Schwarz\nRita
-                  Schwarzelühr-Sutter\nRainer Spiering\nSvenja Stadler\nMartina Stamm-Fibich\nSonja
-                  Amalie Steffen\nMathias Stein\nKerstin Tack\nClaudia Tausend\nMichael Thews\nMarkus
-                  Töns\nDirk Vöpel\nUte Vogt\nGabi Weber\nBernd Westphal\nDirk Wiese\nGülistan Yüksel\nDagmar
-                  Ziegler\nStefan Zierke\nDr. Jens Zimmermann\nAfD\nDr. Bernd Baumann\nMarc Bernhard\nAndreas
-                  Bleck\nPeter Boehringer\nStephan Brandner\nJürgen Braun\nMarcus Bühl\nMatthias Büttner\nPetr
-                  Bystron\nTino Chrupalla\nJoana Eleonora Cotar\nDr. Gottfried Curio\nSiegbert Droese\nThomas
-                  Ehrhorn\nBerengar Elsner von Gronow\nDr. Michael Espendiller\nPeter Felser\nDietmar
-                  Friedhoff\nDr. Anton Friesen\nDr. Götz Frömming\nMarkus Frohnmaier\nDr. Eberhardt
-                  Alexander \nGauland\nDr. Axel Gehrke\nAlbrecht Heinz Erhard \nGlaser\nFranziska
-                  Gminder\nWilhelm von Gottberg\nKay Gottschalk\nArmin-Paulus Hampel\nMariana Iris
-                  Harder-Kühnel\nVerena Hartmann\nDr. Roland Hartwig\nJochen Haug\nMartin Hebner\nUdo
-                  Theodor Hemmelgarn\nWaldemar Herdt\nLars Herrmann\nMartin Hess\nDr. Heiko Heßenkemper\nKarsten
-                  Hilse\nNicole Höchst\nMartin Hohmann\nDr. Bruno Hollnagel\nLeif-Erik Holm\nJohannes
-                  Huber\nFabian Jacobi\nDr. Marc Jongen\nUwe Kamann\nJens Kestner\nStefan Keuter\nNorbert
-                  Kleinwächter\nJörn König\nEnrico Komning\nSteffen Kotré\nDr. Rainer Kraft\nRüdiger
-                  Lucassen\nFrank Magnitz\nJens Maier\nDr. Lothar Maier\nDr. Birgit Malsack-\nWinkemann\nCorinna
-                  Miazga\nAndreas Mrosek\nHansjörg Gerhard Georg \nMüller\nVolker Münz\nSebastian
-                  Münzenmaier\nChristoph Neumann\nJan Ralf Nolte\nUlrich Oehme\nGerold Joachim Otten\nFrank
-                  Pasemann\nTobias Matthias Peterka\nPaul Viktor Podolay\nJürgen Pohl\nStephan Protschka\nMartin
-                  Reichardt\nMartin Erwin Renner\nRoman Johannes Reusch\nUlrike Schielke-Ziesing\nDr.
-                  Robby Schlund\nJörg Schneider\nUwe Schulz\nThomas Seitz\nMartin Sichert\nDetlev
-                  Spangenberg\nDr. Dirk Spaniel\nRené Springer\nBeatrix von Storch\nAlice Weidel\nDr.
-                  Harald Weyel\nWolfgang Wiehle\nDr. Heiko Wildberg\nDr. Christian Friedrich Wirth\nUwe
-                  Witt\nFDP\nGrigorios Aggelidis\nRenata Alt\nChristine Aschenberg-\nDugnus\nNicole
-                  Bauer\nJens Beeck\nNicola Beer\nDr. Jens Brandenburg\nMario Brandenburg\nDr. Marco
-                  Buschmann\nKarlheinz Busen\nCarl-Julius Cronenberg\nBritta Katharina Dassler\nBijan
-                  Djir-Sarai\nChristian Dürr\nHartmut Ebbing\nDr. Marcus Faber\nDaniel Föst\nOtto
-                  Fricke\nThomas Hacker\nKatrin Helling-Plahr\nMarkus Herbrand\nTorsten Herbst\nKatja
-                  Hessel\nDr. Gero Clemens Hocker\nManuel Höferlin\nDr. Christoph Hoffmann\nReinhard
-                  Houben\nUlla Ihnen\nOlaf In der Beek\nGyde Jensen\nDr. Christian Jung\nThomas L.
-                  Kemmerich\nKarsten Klein\nDr. Marcel Klinge\nKatharina Kloke\nDaniela Kluckert\nPascal
-                  Kober\nDr. Lukas Köhler\nCarina Konrad\nWolfgang Kubicki\nKonstantin Elias Kuhle\nAlexander
-                  Kulitz\nAlexander Graf Lambsdorff\nUlrich Lechte\nChristian Lindner\nMichael Link
-                  (Heilbronn)\nOliver Luksic\nTill Berthold Mansmann\nDr. Jürgen Andreas Michael \nMartens\nChristoph
-                  Meyer\nAlexander Müller\nRoman Müller-Böhm\nFrank Müller-Rosentritt\nDr. Martin
-                  Neumann \n(Lausitz)\nHagen Reinhold\nBernd Reuther\nDr. Stefan Ruppert\nThomas Sattelberger\nDeutscher
-                  Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 201724\n(A)
-                  (C)\n(B) (D)\nChristian Sauter\nFrank Schäffler\nDr. Wieland Schinnenburg\nJimmy
-                  Schulz\nMatthias Seestern-Pauly\nFrank Sitta\nJudith Skudelny\nDr. Hermann Otto
-                  Solms\nBettina Stark-Watzinger\nDr. Marie-Agnes Strack-\nZimmermann\nBenjamin Strasser\nKatja
-                  Suding\nLinda Teuteberg\nMichael Theurer\nStephan Thomae\nManfred Todtenhausen\nDr.
-                  Florian Toncar\nDr. Andrew Ullmann\nGerald Ullrich\nJohannes Vogel \n(Lüdenscheid)\nSandra
-                  Weeser\nNicole Westig\nDIE LINKE.\nDoris Achelwilm\nGökay Akbulut\nSimone Barrientos\nDr.
-                  Dietmar Bartsch\nLorenz Gösta Beutin\nMatthias W. Birkwald\nHeidrun Bluhm\nMichel
-                  Brandt\nChristine Buchholz\nBirke Bull-Bischoff\nJörg Cezanne\nSevim Dağdelen\nFabio
-                  De Masi\nDr. Diether Dehm\nAnke Domscheit-Berg\nKlaus Ernst\nSusanne Ferschl\nBrigitte
-                  Freihold\nSylvia Gabelmann\nNicole Gohlke\nDr. Gregor Gysi\nHeike Hänsel\nDr. André
-                  Hahn\nMatthias Höhn\nAndrej Hunko\nUlla Jelpke\nKerstin Kassner\nDr. Achim Kessler\nKatja
-                  Kipping\nJan Korte\nJutta Krellmann\nCaren Lay\nRalph Lenkert\nMichael Leutert\nStefan
-                  Liebich\nDr. Gesine Lötzsch\nPascal Meiser\nCornelia Möhring\nAmira Mohamed Ali\nNiema
-                  Movassat\nNorbert Müller (Potsdam)\nZaklin Nastic\nDr. Alexander S. Neu\nThomas
-                  Nord\nPetra Pau\nSören Pellmann\nVictor Perli\nTobias Pflüger\nIngrid Remmers\nMartina
-                  Renner\nBernd Riexinger\nEva-Maria Elisabeth \nSchreiber\nDr. Petra Sitte\nEvrim
-                  Sommer\nKersten Steinke\nFriedrich Straetmanns\nDr. Kirsten Tackmann\nJessica Tatti\nAlexander
-                  Ulrich\nKathrin Vogler\nDr. Sahra Wagenknecht\nAndreas Wagner\nHarald Weinberg\nKatrin
-                  Werner\nHubertus Zdebel\nPia Zimmermann\nSabine Zimmermann \n(Zwickau)\nBÜNDNIS
-                  90/ \nDIE GRÜNEN\nLuise Amtsberg\nKerstin Andreae\nLisa Hildegard Badum\nAnnalena
-                  Baerbock\nMargarete Bause\nDr. Danyal Bayaz\nCanan Bayram\nDr. Franziska Brantner\nAgnieszka
-                  Brugger\nDr. Anna Christmann\nEkin Deligöz\nKatja Dörner\nKatharina Dröge\nHarald
-                  Ebner\nMatthias Gastel\nKai Gehring\nStefan Gelbhaar\nKatrin Göring-Eckardt\nErhard
-                  Grundl\nAnja Hajduk\nBritta Haßelmann\nDr. Bettina Hoffmann\nDr. Anton Hofreiter\nOttmar
-                  von Holtz\nDieter Janecek\nDr. Kirsten Kappert-Gonther\nUwe Kekeritz\nKatja Keul\nSven-Christian
-                  Kindler\nMaria Klein-Schmeink\nSylvia Kotting-Uhl\nOliver Krischer\nStephan Kühn
-                  (Dresden)\nChristian Kühn (Tübingen)\nRenate Künast\nMarkus Kurth\nMonika Lazar\nSven
-                  Lehmann\nSteffi Lemke\nDr. Tobias Lindner\nIrene Mihalic\nClaudia Müller\nBeate
-                  Müller-Gemmeke\nIngrid Nestle\nDr. Konstantin von Notz\nOmid Nouripour\nCem Özdemir\nFriedrich
-                  Ostendorff\nLisa Paus\nFiliz Polat\nTabea Rößner\nClaudia Roth (Augsburg)\nDr. Manuela
-                  Rottmann\nCorinna Rüffer\nManuel Sarrazin\nUlle Schauws\nDr. Gerhard Schick\nDr.
-                  Frithjof Schmidt\nStefan Schmidt\nKordula Schulz-Asche\nDr. Wolfgang Strengmann-\nKuhn\nMargit
-                  Stumpp\nMarkus Tressel\nJürgen Trittin\nDr. Julia Verlinden\nDaniela Wagner\nBeate
-                  Walter-Rosenheimer\nFraktionslos\nMario Mieruch\nDr. Frauke Petry\nAnlage 3\nNamensverzeichnis\nder
-                  Mitglieder des Deutschen Bundestages, die an der Wahl der Stellvertreterinnen und
-                  Stellvertreter des \nPräsidenten des Deutschen Bundestages teilgenommen haben\nCDU/CSU\nDr.
-                  Michael von Abercron\nStephan Albani\nNorbert Maria Altenkamp\nPeter Altmaier\nPhilipp
-                  Amthor\nArtur Auernhammer\nPeter Aumer\nDorothee Bär\nThomas Bareiß\nNorbert Barthle\nMaik
-                  Beermann\nManfred Behrens (Börde)\nVeronika Bellmann\nSybille Benning\nDr. André
-                  Berghegger\nMelanie Bernstein\nChristoph Bernstiel\nPeter Beyer\nMarc Biadacz\nSteffen
-                  Bilger\nPeter Bleser\nNorbert Brackmann\nDeutscher Bundestag – 19. Wahlperiode –
-                  1. Sitzung. Berlin, Dienstag, den 24. Oktober 2017 Deutscher Bundestag – 19. Wahlperiode
-                  – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 2017 25\n(A) (C)\n(B) (D)\nMichael
-                  Brand\nDr. Reinhard Brandl\nDr. Ralf Brauksiepe\nDr. Helge Braun\nSilvia Breher\nSebastian
-                  Brehm\nHeike Brehmer\nRalph Brinkhaus\nDr. Carsten Brodesser\nGitta Connemann\nAstrid
-                  Damerow\nAlexander Dobrindt\nMarie-Luise Dött\nMichael Donth\nHansjörg Durz\nThomas
-                  Erndl\nHermann Färber\nUwe Feiler\nEnak Ferlemann\nAxel E. Fischer (Karlsruhe-\nLand)\nDr.
-                  Maria Flachsbarth\nThorsten Frei\nDr. Hans-Peter Friedrich \n(Hof)\nMichael Frieser\nHans-Joachim
-                  Fuchtel\nIngo Gädechens\nDr. Thomas Gebhart\nAlois Gerig\nEberhard Gienger\nEckhard
-                  Gnodtke\nUrsula Groden-Kranich\nHermann Gröhe\nKlaus-Dieter Gröhler\nMichael Grosse-Brömer\nAstrid
-                  Grotelüschen\nMarkus Grübel\nMonika Grütters\nManfred Grund\nOliver Grundmann\nFritz
-                  Güntzler\nOlav Gutting\nChristian Haase\nFlorian Hahn\nDr. Stephan Harbarth\nJürgen
-                  Hardt\nMatthias Hauer\nMark Hauptmann\nDr. Matthias Heider\nMechthild Heil\nThomas
-                  Heilmann\nFrank Heinrich (Chemnitz)\nMark Helfrich\nRudolf Henke\nMichael Hennrich\nMarc
-                  Henrichmann\nAnsgar Heveling\nChristian Hirte\nDr. Heribert Hirte\nAlexander Hoffmann\nKarl
-                  Holmeier\nDr. Hendrik Hoppenstedt\nErich Irlstorfer\nHans-Jürgen Irmer\nThomas Jarzombek\nAndreas
-                  Jung\nIngmar Jung\nAlois Karl\nAnja Karliczek\nTorbjörn Kartes\nVolker Kauder\nDr.
-                  Stefan Kaufmann\nRonja Kemmer\nRoderich Kiesewetter\nMichael Kießling\nDr. Georg
-                  Kippels\nVolkmar Klein\nAxel Knoerig\nJens Koeppen\nCarsten Körber\nMarkus Koob\nAlexander
-                  Krauß\nGunther Krichbaum\nDr. Günter Krings\nDr. Roy Kühne\nMichael Kuffer\nAndreas
-                  G. Lämmel\nDr. Dr. h. c. Karl A. Lamers\nKatharina Landgraf\nUlrich Lange\nDr. Silke
-                  Launert\nJens Lehmann\nPaul Lehrieder\nDr. Katja Leikert\nDr. Andreas Lenz\nDr.
-                  Ursula von der Leyen\nAntje Lezius\nAndrea Lindholz\nDr. Carsten Linnemann\nPatricia
-                  Lips\nNikolas Löbel\nBernhard Loos\nDr. Jan-Marco Luczak\nDaniela Ludwig\nKarin
-                  Maag\nYvonne Magwas\nDr. Thomas de Maizière\nDr. Astrid Mannes\nMatern von Marschall\nHans-Georg
-                  von der Marwitz\nAndreas Mattfeldt\nStephan Mayer (Altötting)\nDr. Michael Meister\nDr.
-                  Angela Merkel\nJan Metzler\nDr. h. c. Hans Michelbach\nDr. Mathias Middelberg\nKarsten
-                  Möring\nDietrich Monstadt\nMarlene Mortler\nElisabeth Motschmann\nAxel Müller\nDr.
-                  Gerd Müller\nSepp Müller\nCarsten Müller \n(Braunschweig)\nStefan Müller (Erlangen)\nDr.
-                  Andreas Nick\nPetra Nicolaisen\nMichaela Noll\nDr. Georg Nüßlein\nWilfried Oellers\nFlorian
-                  Oßner\nJosef Oster\nHenning Otte\nSylvia Pantel\nMartin Patzelt\nDr. Joachim Pfeiffer\nStephan
-                  Pilsinger\nDr. Christoph Ploß\nEckhard Pols\nThomas Rachel\nKerstin Radomski\nAlexander
-                  Radwan\nAlois Rainer\nDr. Peter Ramsauer\nEckhardt Rehberg\nLothar Riebsamen\nJosef
-                  Rief\nJohannes Röring\nDr. Norbert Röttgen\nStefan Rouenhoff\nErwin Rüddel\nAlbert
-                  Rupprecht\nStefan Sauer\nAnita Schäfer (Saalstadt)\nDr. Wolfgang Schäuble\nAndreas
-                  Scheuer\nJana Schimke\nTankred Schipanski\nChristian Schmidt (Fürth)\nDr. Claudia
-                  Schmidtke\nPatrick Schnieder\nNadine Schön\nFelix Schreiner\nDr. Klaus-Peter Schulze\nUwe
-                  Schummer\nArmin Schuster (Weil am \nRhein)\nTorsten Schweiger\nDetlef Seif\nJohannes
-                  Selle\nReinhold Sendker\nDr. Patrick Sensburg\nThomas Silberhorn\nBjörn Simon\nTino
-                  Sorge\nJens Spahn\nKatrin Staffler\nDr. Frank Steffel\nDr. Wolfgang Stefinger\nAlbert
-                  Stegemann\nAndreas Steier\nPeter Stein (Rostock)\nSebastian Steineke\nJohannes Steiniger\nChristian
-                  Frhr. von Stetten\nDieter Stier\nGero Storjohann\nStephan Stracke\nMax Straubinger\nMichael
-                  Stübgen\nDr. Peter Tauber\nDr. Hermann-Josef Tebroke\nHans-Jürgen Thies\nAlexander
-                  Throm\nDr. Dietlind Tiemann\nAntje Tillmann\nMarkus Uhl\nDr. Volker Ullrich\nArnold
-                  Vaatz\nOswin Veith\nKerstin Vieregge\nVolkmar Vogel (Kleinsaara)\nChristoph de Vries\nKees
-                  de Vries\nDr. Johann David Wadephul\nMarco Wanderwitz\nKai Wegner\nDr. h. c. Albert
-                  Weiler\nMarcus Weinberg (Hamburg)\nDr. Anja Weisgerber\nPeter Weiß (Emmendingen)\nSabine
-                  Weiss (Wesel I)\nIngo Wellenreuther\nMarian Wendt\nKai Whittaker\nAnnette Widmann-Mauz\nBettina
-                  Margarethe \nWiesmann\nKlaus-Peter Willsch\nElisabeth Winkelmeier-\nBecker\nDeutscher
-                  Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 201726\n(A)
-                  (C)\n(B) (D)\nOliver Wittke\nEmmi Zeulner\nPaul Ziemiak\nDr. Matthias Zimmer\nSPD\nNiels
-                  Annen\nIngrid Arndt-Brauer\nHeike Baehrens\nUlrike Bahr\nDr. Katarina Barley\nDoris
-                  Barnett\nDr. Matthias Bartke\nSören Bartol\nBärbel Bas\nLothar Binding (Heidelberg)\nLeni
-                  Breymaier\nDr. Karl-Heinz Brunner\nKatrin Budde\nMarco Bülow\nMartin Burkert\nDr.
-                  Lars Castellucci\nBernhard Daldrup\nDr. Daniela De Ridder\nDr. Karamba Diaby\nEsther
-                  Dilcher\nSabine Dittmar\nWiebke Esdar\nSaskia Esken\nYasmin Fahimi\nDr. Johannes
-                  Fechner\nDr. Fritz Felgentreu\nDr. Edgar Franke\nUlrich Freese\nDagmar Freitag\nSigmar
-                  Gabriel\nMichael Gerdes\nMartin Gerster\nAngelika Glöckner\nTimon Gremmels\nKerstin
-                  Griese\nUli Grötsch\nMichael Groß\nBettina Hagedorn\nRita Hagl-Kehl\nMetin Hakverdi\nSebastian
-                  Hartmann\nDirk Heidenblut\nHubertus Heil (Peine)\nGabriela Heinrich\nMarcus Held\nWolfgang
-                  Hellmich\nDr. Barbara Hendricks\nGustav Herzog\nGabriele Hiller-Ohm\nThomas Hitschler\nDr.
-                  Eva Högl\nFrank Junge\nJosip Juratovic\nThomas Jurk\nOliver Kaczmarek\nJohannes
-                  Kahrs\nElisabeth Kaiser\nRalf Kapschack\nGabriele Katzmarek\nUlrich Kelber\nCansel
-                  Kiziltepe\nArno Klare\nLars Klingbeil\nDr. Bärbel Kofler\nDaniela Kolbe\nElvan Korkmaz\nAnette
-                  Kramme\nChristine Lambrecht\nChristian Lange (Backnang)\nDr. Karl Lauterbach\nHelge
-                  Lindh\nBurkhard Lischka\nKirsten Lühmann\nHeiko Josef Maas\nCaren Marks\nKatja Mast\nChristoph
-                  Matschie\nHilde Mattheis\nDr. Matthias Miersch\nKlaus Mindrup\nSusanne Mittag\nSiemtje
-                  Möller\nFalko Mohrs\nClaudia Moll\nBettina Müller\nDetlef Müller (Chemnitz)\nMichelle
-                  Müntefering\nDr. Rolf Mützenich\nAndrea Nahles\nDietmar Nietan\nUlli Nissen\nMahmut
-                  Özdemir (Duisburg)\nAydan Özoğuz\nThomas Oppermann\nJosephine Ortleb\nChristian
-                  Petry\nDetlev Pilger\nFlorian Post\nAchim Post (Minden)\nFlorian Pronold\nDr. Sascha
-                  Raabe\nMartin Rabanus\nDr. Carola Reimann\nAndreas Rimkus\nSönke Rix\nRené Röspel\nDennis
-                  Rohde\nDr. Martin Rosemann\nDr. Ernst Dieter Rossmann\nMichael Roth (Heringen)\nSusann
-                  Rüthrich\nBernd Rützel\nSarah Ryglewski\nJohann Saathoff\nAxel Schäfer (Bochum)\nDr.
-                  Nina Scheer\nMarianne Schieder\nUdo Schiefner\nDr. Nils Schmid\nUwe Schmidt\nUlla
-                  Schmidt (Aachen)\nDagmar Schmidt (Wetzlar)\nCarsten Schneider (Erfurt)\nJohannes
-                  Schraps\nMichael Schrodi\nDr. Manja Schüle\nUrsula Schulte\nMartin Schulz\nSwen
-                  Schulz (Spandau)\nEwald Schurer\nFrank Schwabe\nStefan Schwartze\nAndreas Schwarz\nRita
-                  Schwarzelühr-Sutter\nRainer Spiering\nSvenja Stadler\nMartina Stamm-Fibich\nMathias
-                  Stein\nKerstin Tack\nClaudia Tausend\nMichael Thews\nMarkus Töns\nDirk Vöpel\nUte
-                  Vogt\nGabi Weber\nBernd Westphal\nDirk Wiese\nGülistan Yüksel\nDagmar Ziegler\nStefan
-                  Zierke\nDr. Jens Zimmermann\nAfD\nDr. Bernd Baumann\nMarc Bernhard\nAndreas Bleck\nPeter
-                  Boehringer\nStephan Brandner\nJürgen Braun\nMarcus Bühl\nMatthias Büttner\nPetr
-                  Bystron\nTino Chrupalla\nJoana Eleonora Cotar\nDr. Gottfried Curio\nSiegbert Droese\nThomas
-                  Ehrhorn\nBerengar Elsner von Gronow\nDr. Michael Espendiller\nPeter Felser\nDietmar
-                  Friedhoff\nDr. Anton Friesen\nDr. Götz Frömming\nMarkus Frohnmaier\nDr. Eberhardt
-                  Alexander \nGauland\nDr. Axel Gehrke\nAlbrecht Heinz Erhard \nGlaser\nFranziska
-                  Gminder\nWilhelm von Gottberg\nKay Gottschalk\nArmin-Paulus Hampel\nMariana Iris
-                  Harder-Kühnel\nVerena Hartmann\nDr. Roland Hartwig\nJochen Haug\nMartin Hebner\nUdo
-                  Theodor Hemmelgarn\nWaldemar Herdt\nLars Herrmann\nMartin Hess\nDr. Heiko Heßenkemper\nKarsten
-                  Hilse\nNicole Höchst\nMartin Hohmann\nDr. Bruno Hollnagel\nLeif-Erik Holm\nJohannes
-                  Huber\nFabian Jacobi\nDr. Marc Jongen\nUwe Kamann\nJens Kestner\nStefan Keuter\nNorbert
-                  Kleinwächter\nJörn König\nEnrico Komning\nSteffen Kotré\nDr. Rainer Kraft\nRüdiger
-                  Lucassen\nFrank Magnitz\nJens Maier\nDr. Lothar Maier\nDr. Birgit Malsack-\nWinkemann\nCorinna
-                  Miazga\nDeutscher Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den
-                  24. Oktober 2017 Deutscher Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag,
-                  den 24. Oktober 2017 27\n(A) (C)\n(B) (D)\nAndreas Mrosek\nHansjörg Gerhard Georg
-                  \nMüller\nVolker Münz\nSebastian Münzenmaier\nChristoph Neumann\nJan Ralf Nolte\nUlrich
-                  Oehme\nGerold Joachim Otten\nFrank Pasemann\nTobias Matthias Peterka\nPaul Viktor
-                  Podolay\nJürgen Pohl\nStephan Protschka\nMartin Reichardt\nMartin Erwin Renner\nRoman
-                  Johannes Reusch\nUlrike Schielke-Ziesing\nDr. Robby Schlund\nJörg Schneider\nUwe
-                  Schulz\nThomas Seitz\nMartin Sichert\nDetlev Spangenberg\nDr. Dirk Spaniel\nRené
-                  Springer\nBeatrix von Storch\nAlice Weidel\nDr. Harald Weyel\nWolfgang Wiehle\nDr.
-                  Heiko Wildberg\nDr. Christian Friedrich Wirth\nUwe Witt\nFDP\nGrigorios Aggelidis\nRenata
-                  Alt\nChristine Aschenberg-\nDugnus\nNicole Bauer\nJens Beeck\nNicola Beer\nDr. Jens
-                  Brandenburg\nMario Brandenburg\nDr. Marco Buschmann\nKarlheinz Busen\nCarl-Julius
-                  Cronenberg\nBritta Katharina Dassler\nBijan Djir-Sarai\nChristian Dürr\nHartmut
-                  Ebbing\nDr. Marcus Faber\nDaniel Föst\nOtto Fricke\nThomas Hacker\nKatrin Helling-Plahr\nMarkus
-                  Herbrand\nTorsten Herbst\nKatja Hessel\nDr. Gero Clemens Hocker\nManuel Höferlin\nDr.
-                  Christoph Hoffmann\nReinhard Houben\nUlla Ihnen\nOlaf In der Beek\nGyde Jensen\nDr.
-                  Christian Jung\nThomas L. Kemmerich\nKarsten Klein\nDr. Marcel Klinge\nKatharina
-                  Kloke\nDaniela Kluckert\nPascal Kober\nDr. Lukas Köhler\nCarina Konrad\nWolfgang
-                  Kubicki\nKonstantin Elias Kuhle\nAlexander Kulitz\nAlexander Graf Lambsdorff\nUlrich
-                  Lechte\nChristian Lindner\nMichael Link (Heilbronn)\nOliver Luksic\nTill Berthold
-                  Mansmann\nDr. Jürgen Andreas Michael \nMartens\nChristoph Meyer\nAlexander Müller\nRoman
-                  Müller-Böhm\nFrank Müller-Rosentritt\nDr. Martin Neumann \n(Lausitz)\nHagen Reinhold\nBernd
-                  Reuther\nDr. Stefan Ruppert\nThomas Sattelberger\nChristian Sauter\nFrank Schäffler\nDr.
-                  Wieland Schinnenburg\nJimmy Schulz\nMatthias Seestern-Pauly\nFrank Sitta\nJudith
-                  Skudelny\nDr. Hermann Otto Solms\nBettina Stark-Watzinger\nDr. Marie-Agnes Strack-\nZimmermann\nBenjamin
-                  Strasser\nKatja Suding\nLinda Teuteberg\nMichael Theurer\nStephan Thomae\nManfred
-                  Todtenhausen\nDr. Florian Toncar\nDr. Andrew Ullmann\nGerald Ullrich\nJohannes Vogel
-                  \n(Lüdenscheid)\nSandra Weeser\nNicole Westig\nDIE LINKE.\nDoris Achelwilm\nGökay
-                  Akbulut\nSimone Barrientos\nDr. Dietmar Bartsch\nLorenz Gösta Beutin\nMatthias W.
-                  Birkwald\nHeidrun Bluhm\nMichel Brandt\nChristine Buchholz\nBirke Bull-Bischoff\nJörg
-                  Cezanne\nSevim Dağdelen\nFabio De Masi\nDr. Diether Dehm\nAnke Domscheit-Berg\nKlaus
-                  Ernst\nSusanne Ferschl\nBrigitte Freihold\nSylvia Gabelmann\nNicole Gohlke\nDr.
-                  Gregor Gysi\nHeike Hänsel\nDr. André Hahn\nMatthias Höhn\nAndrej Hunko\nUlla Jelpke\nKerstin
-                  Kassner\nDr. Achim Kessler\nKatja Kipping\nJan Korte\nJutta Krellmann\nCaren Lay\nRalph
-                  Lenkert\nMichael Leutert\nStefan Liebich\nDr. Gesine Lötzsch\nPascal Meiser\nCornelia
-                  Möhring\nAmira Mohamed Ali\nNiema Movassat\nNorbert Müller (Potsdam)\nZaklin Nastic\nDr.
-                  Alexander S. Neu\nThomas Nord\nPetra Pau\nSören Pellmann\nVictor Perli\nTobias Pflüger\nIngrid
-                  Remmers\nMartina Renner\nBernd Riexinger\nEva-Maria Elisabeth \nSchreiber\nDr. Petra
-                  Sitte\nEvrim Sommer\nKersten Steinke\nFriedrich Straetmanns\nDr. Kirsten Tackmann\nJessica
-                  Tatti\nAlexander Ulrich\nKathrin Vogler\nDr. Sahra Wagenknecht\nAndreas Wagner\nHarald
-                  Weinberg\nKatrin Werner\nHubertus Zdebel\nPia Zimmermann\nSabine Zimmermann \n(Zwickau)\nBÜNDNIS
-                  90/ \nDIE GRÜNEN\nLuise Amtsberg\nKerstin Andreae\nLisa Hildegard Badum\nAnnalena
-                  Baerbock\nMargarete Bause\nDr. Danyal Bayaz\nCanan Bayram\nDr. Franziska Brantner\nAgnieszka
-                  Brugger\nDr. Anna Christmann\nEkin Deligöz\nKatja Dörner\nKatharina Dröge\nHarald
-                  Ebner\nMatthias Gastel\nKai Gehring\nStefan Gelbhaar\nKatrin Göring-Eckardt\nErhard
-                  Grundl\nAnja Hajduk\nBritta Haßelmann\nDr. Bettina Hoffmann\nDr. Anton Hofreiter\nOttmar
-                  von Holtz\nDieter Janecek\nDr. Kirsten Kappert-Gonther\nUwe Kekeritz\nKatja Keul\nDeutscher
-                  Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 201728\n(A)
-                  (C)\n(B) (D)\nSven-Christian Kindler\nMaria Klein-Schmeink\nSylvia Kotting-Uhl\nOliver
-                  Krischer\nStephan Kühn (Dresden)\nChristian Kühn (Tübingen)\nRenate Künast\nMarkus
-                  Kurth\nMonika Lazar\nSven Lehmann\nSteffi Lemke\nDr. Tobias Lindner\nIrene Mihalic\nClaudia
-                  Müller\nBeate Müller-Gemmeke\nIngrid Nestle\nDr. Konstantin von Notz\nOmid Nouripour\nCem
-                  Özdemir\nFriedrich Ostendorff\nLisa Paus\nFiliz Polat\nTabea Rößner\nClaudia Roth
-                  (Augsburg)\nDr. Manuela Rottmann\nCorinna Rüffer\nManuel Sarrazin\nUlle Schauws\nDr.
-                  Gerhard Schick\nDr. Frithjof Schmidt\nStefan Schmidt\nKordula Schulz-Asche\nDr.
-                  Wolfgang Strengmann-\nKuhn\nMargit Stumpp\nMarkus Tressel\nJürgen Trittin\nDr. Julia
-                  Verlinden\nDaniela Wagner\nBeate Walter-Rosenheimer\nFraktionslos\nMario Mieruch\nDr.
-                  Frauke Petry\nAnlage 4\nNamensverzeichnis\nder Mitglieder des Deutschen Bundestages,
-                  die an der Wahl eines Stellvertreters des Präsidenten des Deut-\nschen Bundestages
-                  teilgenommen haben (2. Wahlgang)\nCDU/CSU\nDr. Michael von Abercron\nStephan Albani\nNorbert
-                  Maria Altenkamp\nPhilipp Amthor\nArtur Auernhammer\nPeter Aumer\nDorothee Bär\nThomas
-                  Bareiß\nNorbert Barthle\nMaik Beermann\nManfred Behrens (Börde)\nVeronika Bellmann\nSybille
-                  Benning\nDr. André Berghegger\nMelanie Bernstein\nChristoph Bernstiel\nPeter Beyer\nMarc
-                  Biadacz\nSteffen Bilger\nPeter Bleser\nNorbert Brackmann\nMichael Brand\nDr. Reinhard
-                  Brandl\nDr. Ralf Brauksiepe\nDr. Helge Braun\nSilvia Breher\nSebastian Brehm\nHeike
-                  Brehmer\nRalph Brinkhaus\nDr. Carsten Brodesser\nGitta Connemann\nAstrid Damerow\nAlexander
-                  Dobrindt\nMarie-Luise Dött\nMichael Donth\nHansjörg Durz\nThomas Erndl\nHermann
-                  Färber\nUwe Feiler\nEnak Ferlemann\nAxel E. Fischer (Karlsruhe-\nLand)\nDr. Maria
-                  Flachsbarth\nThorsten Frei\nDr. Hans-Peter Friedrich \n(Hof)\nMichael Frieser\nHans-Joachim
-                  Fuchtel\nIngo Gädechens\nDr. Thomas Gebhart\nAlois Gerig\nEberhard Gienger\nEckhard
-                  Gnodtke\nUrsula Groden-Kranich\nHermann Gröhe\nKlaus-Dieter Gröhler\nMichael Grosse-Brömer\nAstrid
-                  Grotelüschen\nMarkus Grübel\nMonika Grütters\nManfred Grund\nOliver Grundmann\nFritz
-                  Güntzler\nOlav Gutting\nChristian Haase\nFlorian Hahn\nDr. Stephan Harbarth\nJürgen
-                  Hardt\nMatthias Hauer\nMark Hauptmann\nDr. Matthias Heider\nMechthild Heil\nThomas
-                  Heilmann\nFrank Heinrich (Chemnitz)\nMark Helfrich\nRudolf Henke\nMichael Hennrich\nMarc
-                  Henrichmann\nAnsgar Heveling\nChristian Hirte\nDr. Heribert Hirte\nAlexander Hoffmann\nKarl
-                  Holmeier\nDr. Hendrik Hoppenstedt\nErich Irlstorfer\nHans-Jürgen Irmer\nThomas Jarzombek\nAndreas
-                  Jung\nIngmar Jung\nAlois Karl\nAnja Karliczek\nTorbjörn Kartes\nVolker Kauder\nDr.
-                  Stefan Kaufmann\nRonja Kemmer\nRoderich Kiesewetter\nMichael Kießling\nDr. Georg
-                  Kippels\nVolkmar Klein\nAxel Knoerig\nJens Koeppen\nCarsten Körber\nMarkus Koob\nAlexander
-                  Krauß\nGunther Krichbaum\nDr. Günter Krings\nRüdiger Kruse\nDr. Roy Kühne\nMichael
-                  Kuffer\nAndreas G. Lämmel\nDr. Dr. h. c. Karl A. Lamers\nKatharina Landgraf\nUlrich
-                  Lange\nDr. Silke Launert\nJens Lehmann\nPaul Lehrieder\nDr. Katja Leikert\nDr. Andreas
-                  Lenz\nDr. Ursula von der Leyen\nAntje Lezius\nAndrea Lindholz\nDr. Carsten Linnemann\nPatricia
-                  Lips\nNikolas Löbel\nBernhard Loos\nDr. Jan-Marco Luczak\nDaniela Ludwig\nKarin
-                  Maag\nYvonne Magwas\nDr. Thomas de Maizière\nDr. Astrid Mannes\nMatern von Marschall\nHans-Georg
-                  von der Marwitz\nAndreas Mattfeldt\nStephan Mayer (Altötting)\nDr. Michael Meister\nDr.
-                  Angela Merkel\nJan Metzler\nDr. h. c. Hans Michelbach\nDr. Mathias Middelberg\nKarsten
-                  Möring\nDietrich Monstadt\nMarlene Mortler\nElisabeth Motschmann\nAxel Müller\nDr.
-                  Gerd Müller\nSepp Müller\nDeutscher Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin,
-                  Dienstag, den 24. Oktober 2017 Deutscher Bundestag – 19. Wahlperiode – 1. Sitzung.
-                  Berlin, Dienstag, den 24. Oktober 2017 29\n(A) (C)\n(B) (D)\nCarsten Müller \n(Braunschweig)\nStefan
-                  Müller (Erlangen)\nDr. Andreas Nick\nPetra Nicolaisen\nMichaela Noll\nDr. Georg
-                  Nüßlein\nWilfried Oellers\nFlorian Oßner\nJosef Oster\nHenning Otte\nSylvia Pantel\nMartin
-                  Patzelt\nDr. Joachim Pfeiffer\nStephan Pilsinger\nDr. Christoph Ploß\nEckhard Pols\nThomas
-                  Rachel\nKerstin Radomski\nAlexander Radwan\nAlois Rainer\nDr. Peter Ramsauer\nEckhardt
-                  Rehberg\nLothar Riebsamen\nJosef Rief\nJohannes Röring\nDr. Norbert Röttgen\nStefan
-                  Rouenhoff\nErwin Rüddel\nAlbert Rupprecht\nStefan Sauer\nAnita Schäfer (Saalstadt)\nDr.
-                  Wolfgang Schäuble\nAndreas Scheuer\nJana Schimke\nTankred Schipanski\nChristian
-                  Schmidt (Fürth)\nDr. Claudia Schmidtke\nPatrick Schnieder\nNadine Schön\nFelix Schreiner\nDr.
-                  Klaus-Peter Schulze\nUwe Schummer\nArmin Schuster (Weil am \nRhein)\nTorsten Schweiger\nDetlef
-                  Seif\nJohannes Selle\nReinhold Sendker\nDr. Patrick Sensburg\nThomas Silberhorn\nBjörn
-                  Simon\nTino Sorge\nJens Spahn\nKatrin Staffler\nDr. Frank Steffel\nDr. Wolfgang
-                  Stefinger\nAlbert Stegemann\nAndreas Steier\nPeter Stein (Rostock)\nSebastian Steineke\nJohannes
-                  Steiniger\nChristian Frhr. von Stetten\nDieter Stier\nGero Storjohann\nStephan Stracke\nMax
-                  Straubinger\nMichael Stübgen\nDr. Peter Tauber\nDr. Hermann-Josef Tebroke\nHans-Jürgen
-                  Thies\nAlexander Throm\nDr. Dietlind Tiemann\nAntje Tillmann\nMarkus Uhl\nDr. Volker
-                  Ullrich\nArnold Vaatz\nOswin Veith\nKerstin Vieregge\nVolkmar Vogel (Kleinsaara)\nChristoph
-                  de Vries\nKees de Vries\nDr. Johann David Wadephul\nMarco Wanderwitz\nKai Wegner\nDr.
-                  h. c. Albert Weiler\nMarcus Weinberg (Hamburg)\nDr. Anja Weisgerber\nPeter Weiß
-                  (Emmendingen)\nSabine Weiss (Wesel I)\nIngo Wellenreuther\nMarian Wendt\nKai Whittaker\nAnnette
-                  Widmann-Mauz\nBettina Margarethe \nWiesmann\nKlaus-Peter Willsch\nElisabeth Winkelmeier-\nBecker\nOliver
-                  Wittke\nEmmi Zeulner\nPaul Ziemiak\nDr. Matthias Zimmer\nSPD\nNiels Annen\nIngrid
-                  Arndt-Brauer\nHeike Baehrens\nUlrike Bahr\nDr. Katarina Barley\nDoris Barnett\nDr.
-                  Matthias Bartke\nSören Bartol\nBärbel Bas\nLothar Binding (Heidelberg)\nLeni Breymaier\nDr.
-                  Karl-Heinz Brunner\nKatrin Budde\nMarco Bülow\nMartin Burkert\nDr. Lars Castellucci\nBernhard
-                  Daldrup\nDr. Daniela De Ridder\nDr. Karamba Diaby\nEsther Dilcher\nSabine Dittmar\nWiebke
-                  Esdar\nSaskia Esken\nYasmin Fahimi\nDr. Johannes Fechner\nDr. Fritz Felgentreu\nDr.
-                  Edgar Franke\nUlrich Freese\nDagmar Freitag\nSigmar Gabriel\nMichael Gerdes\nMartin
-                  Gerster\nAngelika Glöckner\nTimon Gremmels\nKerstin Griese\nUli Grötsch\nMichael
-                  Groß\nBettina Hagedorn\nRita Hagl-Kehl\nMetin Hakverdi\nSebastian Hartmann\nDirk
-                  Heidenblut\nGabriela Heinrich\nMarcus Held\nWolfgang Hellmich\nDr. Barbara Hendricks\nGustav
-                  Herzog\nGabriele Hiller-Ohm\nThomas Hitschler\nDr. Eva Högl\nFrank Junge\nJosip
-                  Juratovic\nThomas Jurk\nOliver Kaczmarek\nJohannes Kahrs\nElisabeth Kaiser\nRalf
-                  Kapschack\nGabriele Katzmarek\nUlrich Kelber\nCansel Kiziltepe\nArno Klare\nLars
-                  Klingbeil\nDr. Bärbel Kofler\nDaniela Kolbe\nElvan Korkmaz\nAnette Kramme\nChristine
-                  Lambrecht\nChristian Lange (Backnang)\nDr. Karl Lauterbach\nHelge Lindh\nBurkhard
-                  Lischka\nKirsten Lühmann\nHeiko Josef Maas\nCaren Marks\nKatja Mast\nChristoph Matschie\nHilde
-                  Mattheis\nDr. Matthias Miersch\nKlaus Mindrup\nSusanne Mittag\nSiemtje Möller\nFalko
-                  Mohrs\nClaudia Moll\nBettina Müller\nDetlef Müller (Chemnitz)\nMichelle Müntefering\nDr.
-                  Rolf Mützenich\nAndrea Nahles\nDietmar Nietan\nUlli Nissen\nMahmut Özdemir (Duisburg)\nAydan
-                  Özoğuz\nJosephine Ortleb\nChristian Petry\nDetlev Pilger\nFlorian Post\nAchim Post
-                  (Minden)\nFlorian Pronold\nDr. Sascha Raabe\nMartin Rabanus\nDr. Carola Reimann\nAndreas
-                  Rimkus\nSönke Rix\nRené Röspel\nDennis Rohde\nDr. Martin Rosemann\nDr. Ernst Dieter
-                  Rossmann\nMichael Roth (Heringen)\nSusann Rüthrich\nBernd Rützel\nSarah Ryglewski\nJohann
-                  Saathoff\nAxel Schäfer (Bochum)\nDr. Nina Scheer\nMarianne Schieder\nUdo Schiefner\nDr.
-                  Nils Schmid\nUwe Schmidt\nDeutscher Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin,
-                  Dienstag, den 24. Oktober 201730\n(A) (C)\n(B) (D)\nUlla Schmidt (Aachen)\nDagmar
-                  Schmidt (Wetzlar)\nCarsten Schneider (Erfurt)\nJohannes Schraps\nMichael Schrodi\nDr.
-                  Manja Schüle\nUrsula Schulte\nMartin Schulz\nSwen Schulz (Spandau)\nEwald Schurer\nFrank
-                  Schwabe\nStefan Schwartze\nAndreas Schwarz\nRita Schwarzelühr-Sutter\nRainer Spiering\nSvenja
-                  Stadler\nMartina Stamm-Fibich\nMathias Stein\nKerstin Tack\nClaudia Tausend\nMichael
-                  Thews\nMarkus Töns\nDirk Vöpel\nUte Vogt\nGabi Weber\nBernd Westphal\nDirk Wiese\nGülistan
-                  Yüksel\nDagmar Ziegler\nStefan Zierke\nDr. Jens Zimmermann\nAfD\nDr. Bernd Baumann\nMarc
-                  Bernhard\nAndreas Bleck\nPeter Boehringer\nStephan Brandner\nJürgen Braun\nMarcus
-                  Bühl\nMatthias Büttner\nPetr Bystron\nTino Chrupalla\nJoana Eleonora Cotar\nDr.
-                  Gottfried Curio\nSiegbert Droese\nThomas Ehrhorn\nBerengar Elsner von Gronow\nDr.
-                  Michael Espendiller\nPeter Felser\nDietmar Friedhoff\nDr. Anton Friesen\nDr. Götz
-                  Frömming\nMarkus Frohnmaier\nDr. Eberhardt Alexander \nGauland\nDr. Axel Gehrke\nAlbrecht
-                  Heinz Erhard \nGlaser\nFranziska Gminder\nWilhelm von Gottberg\nKay Gottschalk\nMariana
-                  Iris Harder-Kühnel\nVerena Hartmann\nDr. Roland Hartwig\nJochen Haug\nMartin Hebner\nUdo
-                  Theodor Hemmelgarn\nWaldemar Herdt\nLars Herrmann\nMartin Hess\nDr. Heiko Heßenkemper\nKarsten
-                  Hilse\nNicole Höchst\nMartin Hohmann\nDr. Bruno Hollnagel\nLeif-Erik Holm\nJohannes
-                  Huber\nFabian Jacobi\nDr. Marc Jongen\nUwe Kamann\nJens Kestner\nStefan Keuter\nNorbert
-                  Kleinwächter\nJörn König\nEnrico Komning\nSteffen Kotré\nDr. Rainer Kraft\nRüdiger
-                  Lucassen\nFrank Magnitz\nJens Maier\nDr. Lothar Maier\nDr. Birgit Malsack-\nWinkemann\nCorinna
-                  Miazga\nAndreas Mrosek\nHansjörg Gerhard Georg \nMüller\nVolker Münz\nSebastian
-                  Münzenmaier\nChristoph Neumann\nJan Ralf Nolte\nUlrich Oehme\nGerold Joachim Otten\nFrank
-                  Pasemann\nTobias Matthias Peterka\nPaul Viktor Podolay\nJürgen Pohl\nStephan Protschka\nMartin
-                  Reichardt\nMartin Erwin Renner\nRoman Johannes Reusch\nUlrike Schielke-Ziesing\nDr.
-                  Robby Schlund\nJörg Schneider\nUwe Schulz\nThomas Seitz\nMartin Sichert\nDetlev
-                  Spangenberg\nDr. Dirk Spaniel\nRené Springer\nBeatrix von Storch\nAlice Weidel\nDr.
-                  Harald Weyel\nWolfgang Wiehle\nDr. Heiko Wildberg\nDr. Christian Friedrich Wirth\nUwe
-                  Witt\nFDP\nGrigorios Aggelidis\nRenata Alt\nChristine Aschenberg-\nDugnus\nNicole
-                  Bauer\nJens Beeck\nNicola Beer\nDr. Jens Brandenburg\nMario Brandenburg\nDr. Marco
-                  Buschmann\nKarlheinz Busen\nCarl-Julius Cronenberg\nBritta Katharina Dassler\nBijan
-                  Djir-Sarai\nChristian Dürr\nHartmut Ebbing\nDr. Marcus Faber\nDaniel Föst\nOtto
-                  Fricke\nThomas Hacker\nKatrin Helling-Plahr\nMarkus Herbrand\nTorsten Herbst\nKatja
-                  Hessel\nDr. Gero Clemens Hocker\nManuel Höferlin\nDr. Christoph Hoffmann\nReinhard
-                  Houben\nUlla Ihnen\nOlaf In der Beek\nGyde Jensen\nDr. Christian Jung\nThomas L.
-                  Kemmerich\nKarsten Klein\nDr. Marcel Klinge\nKatharina Kloke\nDaniela Kluckert\nPascal
-                  Kober\nDr. Lukas Köhler\nCarina Konrad\nWolfgang Kubicki\nKonstantin Elias Kuhle\nAlexander
-                  Kulitz\nAlexander Graf Lambsdorff\nUlrich Lechte\nChristian Lindner\nMichael Link
-                  (Heilbronn)\nOliver Luksic\nTill Berthold Mansmann\nDr. Jürgen Andreas Michael \nMartens\nChristoph
-                  Meyer\nAlexander Müller\nRoman Müller-Böhm\nFrank Müller-Rosentritt\nDr. Martin
-                  Neumann \n(Lausitz)\nHagen Reinhold\nBernd Reuther\nDr. Stefan Ruppert\nThomas Sattelberger\nChristian
-                  Sauter\nFrank Schäffler\nDr. Wieland Schinnenburg\nJimmy Schulz\nMatthias Seestern-Pauly\nFrank
-                  Sitta\nJudith Skudelny\nDr. Hermann Otto Solms\nBettina Stark-Watzinger\nDr. Marie-Agnes
-                  Strack-\nZimmermann\nBenjamin Strasser\nKatja Suding\nMichael Theurer\nStephan Thomae\nManfred
-                  Todtenhausen\nDr. Florian Toncar\nDr. Andrew Ullmann\nGerald Ullrich\nJohannes Vogel
-                  \n(Lüdenscheid)\nSandra Weeser\nNicole Westig\nDIE LINKE.\nDoris Achelwilm\nGökay
-                  Akbulut\nSimone Barrientos\nDr. Dietmar Bartsch\nLorenz Gösta Beutin\nDeutscher
-                  Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 2017
-                  Deutscher Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 24. Oktober
-                  2017 31\n(A) (C)\n(B) (D)\nMatthias W. Birkwald\nHeidrun Bluhm\nMichel Brandt\nChristine
-                  Buchholz\nBirke Bull-Bischoff\nJörg Cezanne\nSevim Dağdelen\nFabio De Masi\nDr.
-                  Diether Dehm\nAnke Domscheit-Berg\nKlaus Ernst\nSusanne Ferschl\nBrigitte Freihold\nSylvia
-                  Gabelmann\nNicole Gohlke\nDr. Gregor Gysi\nHeike Hänsel\nDr. André Hahn\nMatthias
-                  Höhn\nUlla Jelpke\nKerstin Kassner\nDr. Achim Kessler\nKatja Kipping\nJan Korte\nJutta
-                  Krellmann\nCaren Lay\nRalph Lenkert\nMichael Leutert\nStefan Liebich\nDr. Gesine
-                  Lötzsch\nPascal Meiser\nCornelia Möhring\nAmira Mohamed Ali\nNiema Movassat\nNorbert
-                  Müller (Potsdam)\nZaklin Nastic\nDr. Alexander S. Neu\nThomas Nord\nPetra Pau\nSören
-                  Pellmann\nVictor Perli\nTobias Pflüger\nIngrid Remmers\nMartina Renner\nBernd Riexinger\nEva-Maria
-                  Elisabeth \nSchreiber\nDr. Petra Sitte\nEvrim Sommer\nKersten Steinke\nFriedrich
-                  Straetmanns\nDr. Kirsten Tackmann\nJessica Tatti\nAlexander Ulrich\nKathrin Vogler\nDr.
-                  Sahra Wagenknecht\nAndreas Wagner\nHarald Weinberg\nKatrin Werner\nHubertus Zdebel\nPia
-                  Zimmermann\nSabine Zimmermann \n(Zwickau)\nBÜNDNIS 90/ \nDIE GRÜNEN\nLuise Amtsberg\nKerstin
-                  Andreae\nLisa Hildegard Badum\nAnnalena Baerbock\nMargarete Bause\nDr. Danyal Bayaz\nCanan
-                  Bayram\nDr. Franziska Brantner\nAgnieszka Brugger\nDr. Anna Christmann\nEkin Deligöz\nKatja
-                  Dörner\nKatharina Dröge\nHarald Ebner\nMatthias Gastel\nKai Gehring\nStefan Gelbhaar\nKatrin
-                  Göring-Eckardt\nErhard Grundl\nAnja Hajduk\nBritta Haßelmann\nDr. Bettina Hoffmann\nDr.
-                  Anton Hofreiter\nOttmar von Holtz\nDieter Janecek\nDr. Kirsten Kappert-Gonther\nUwe
-                  Kekeritz\nKatja Keul\nMaria Klein-Schmeink\nSylvia Kotting-Uhl\nOliver Krischer\nStephan
-                  Kühn (Dresden)\nChristian Kühn (Tübingen)\nRenate Künast\nMarkus Kurth\nMonika Lazar\nSven
-                  Lehmann\nSteffi Lemke\nDr. Tobias Lindner\nIrene Mihalic\nClaudia Müller\nBeate
-                  Müller-Gemmeke\nIngrid Nestle\nDr. Konstantin von Notz\nOmid Nouripour\nCem Özdemir\nFriedrich
-                  Ostendorff\nLisa Paus\nFiliz Polat\nTabea Rößner\nClaudia Roth (Augsburg)\nDr. Manuela
-                  Rottmann\nCorinna Rüffer\nManuel Sarrazin\nUlle Schauws\nDr. Gerhard Schick\nDr.
-                  Frithjof Schmidt\nStefan Schmidt\nKordula Schulz-Asche\nDr. Wolfgang Strengmann-\nKuhn\nMargit
-                  Stumpp\nMarkus Tressel\nJürgen Trittin\nDr. Julia Verlinden\nDaniela Wagner\nBeate
-                  Walter-Rosenheimer\nFraktionslos\nMario Mieruch\nDr. Frauke Petry\nAnlage 5\nNamensverzeichnis\nder
-                  Mitglieder des Deutschen Bundestages, die an der Wahl eines Stellvertreters des
-                  Präsidenten des Deut-\nschen Bundestages teilgenommen haben (3. Wahlgang)\nCDU/CSU\nDr.
-                  Michael von Abercron\nStephan Albani\nNorbert Maria Altenkamp\nPhilipp Amthor\nArtur
-                  Auernhammer\nPeter Aumer\nDorothee Bär\nThomas Bareiß\nNorbert Barthle\nMaik Beermann\nManfred
-                  Behrens (Börde)\nVeronika Bellmann\nSybille Benning\nDr. André Berghegger\nMelanie
-                  Bernstein\nChristoph Bernstiel\nPeter Beyer\nMarc Biadacz\nSteffen Bilger\nPeter
-                  Bleser\nNorbert Brackmann\nMichael Brand\nDr. Reinhard Brandl\nDr. Ralf Brauksiepe\nDr.
-                  Helge Braun\nSilvia Breher\nSebastian Brehm\nHeike Brehmer\nRalph Brinkhaus\nDr.
-                  Carsten Brodesser\nGitta Connemann\nAstrid Damerow\nAlexander Dobrindt\nMarie-Luise
-                  Dött\nMichael Donth\nHansjörg Durz\nThomas Erndl\nHermann Färber\nUwe Feiler\nEnak
-                  Ferlemann\nAxel E. Fischer (Karlsruhe-\nLand)\nDr. Maria Flachsbarth\nThorsten Frei\nDr.
-                  Hans-Peter Friedrich \n(Hof)\nMichael Frieser\nHans-Joachim Fuchtel\nIngo Gädechens\nDr.
-                  Thomas Gebhart\nAlois Gerig\nEberhard Gienger\nEckhard Gnodtke\nUrsula Groden-Kranich\nDeutscher
-                  Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 201732\n(A)
-                  (C)\n(B) (D)\nHermann Gröhe\nKlaus-Dieter Gröhler\nMichael Grosse-Brömer\nAstrid
-                  Grotelüschen\nMarkus Grübel\nMonika Grütters\nManfred Grund\nOliver Grundmann\nFritz
-                  Güntzler\nOlav Gutting\nChristian Haase\nFlorian Hahn\nDr. Stephan Harbarth\nJürgen
-                  Hardt\nMatthias Hauer\nMark Hauptmann\nDr. Matthias Heider\nThomas Heilmann\nFrank
-                  Heinrich (Chemnitz)\nMark Helfrich\nRudolf Henke\nMichael Hennrich\nMarc Henrichmann\nAnsgar
-                  Heveling\nChristian Hirte\nDr. Heribert Hirte\nAlexander Hoffmann\nKarl Holmeier\nDr.
-                  Hendrik Hoppenstedt\nErich Irlstorfer\nHans-Jürgen Irmer\nThomas Jarzombek\nAndreas
-                  Jung\nIngmar Jung\nAlois Karl\nAnja Karliczek\nTorbjörn Kartes\nVolker Kauder\nDr.
-                  Stefan Kaufmann\nRonja Kemmer\nRoderich Kiesewetter\nMichael Kießling\nDr. Georg
-                  Kippels\nVolkmar Klein\nAxel Knoerig\nJens Koeppen\nCarsten Körber\nMarkus Koob\nAlexander
-                  Krauß\nGunther Krichbaum\nDr. Günter Krings\nRüdiger Kruse\nDr. Roy Kühne\nMichael
-                  Kuffer\nAndreas G. Lämmel\nDr. Dr. h. c. Karl A. Lamers\nKatharina Landgraf\nUlrich
-                  Lange\nDr. Silke Launert\nJens Lehmann\nPaul Lehrieder\nDr. Katja Leikert\nDr. Andreas
-                  Lenz\nDr. Ursula von der Leyen\nAntje Lezius\nAndrea Lindholz\nDr. Carsten Linnemann\nPatricia
-                  Lips\nBernhard Loos\nDr. Jan-Marco Luczak\nDaniela Ludwig\nKarin Maag\nYvonne Magwas\nDr.
-                  Thomas de Maizière\nDr. Astrid Mannes\nMatern von Marschall\nHans-Georg von der
-                  Marwitz\nAndreas Mattfeldt\nStephan Mayer (Altötting)\nDr. Angela Merkel\nJan Metzler\nDr.
-                  h. c. Hans Michelbach\nDr. Mathias Middelberg\nKarsten Möring\nDietrich Monstadt\nMarlene
-                  Mortler\nElisabeth Motschmann\nAxel Müller\nDr. Gerd Müller\nSepp Müller\nCarsten
-                  Müller \n(Braunschweig)\nStefan Müller (Erlangen)\nDr. Andreas Nick\nPetra Nicolaisen\nMichaela
-                  Noll\nDr. Georg Nüßlein\nWilfried Oellers\nFlorian Oßner\nJosef Oster\nHenning Otte\nSylvia
-                  Pantel\nMartin Patzelt\nDr. Joachim Pfeiffer\nStephan Pilsinger\nDr. Christoph Ploß\nEckhard
-                  Pols\nThomas Rachel\nKerstin Radomski\nAlexander Radwan\nAlois Rainer\nDr. Peter
-                  Ramsauer\nEckhardt Rehberg\nLothar Riebsamen\nJosef Rief\nJohannes Röring\nDr. Norbert
-                  Röttgen\nStefan Rouenhoff\nErwin Rüddel\nAlbert Rupprecht\nStefan Sauer\nAnita Schäfer
-                  (Saalstadt)\nDr. Wolfgang Schäuble\nAndreas Scheuer\nJana Schimke\nTankred Schipanski\nChristian
-                  Schmidt (Fürth)\nDr. Claudia Schmidtke\nPatrick Schnieder\nNadine Schön\nFelix Schreiner\nUwe
-                  Schummer\nArmin Schuster (Weil am \nRhein)\nTorsten Schweiger\nDetlef Seif\nJohannes
-                  Selle\nReinhold Sendker\nDr. Patrick Sensburg\nThomas Silberhorn\nBjörn Simon\nTino
-                  Sorge\nKatrin Staffler\nDr. Frank Steffel\nDr. Wolfgang Stefinger\nAlbert Stegemann\nAndreas
-                  Steier\nPeter Stein (Rostock)\nSebastian Steineke\nJohannes Steiniger\nChristian
-                  Frhr. von Stetten\nDieter Stier\nGero Storjohann\nStephan Stracke\nMichael Stübgen\nDr.
-                  Peter Tauber\nDr. Hermann-Josef Tebroke\nHans-Jürgen Thies\nAlexander Throm\nDr.
-                  Dietlind Tiemann\nAntje Tillmann\nMarkus Uhl\nDr. Volker Ullrich\nArnold Vaatz\nOswin
-                  Veith\nKerstin Vieregge\nVolkmar Vogel (Kleinsaara)\nChristoph de Vries\nKees de
-                  Vries\nDr. Johann David Wadephul\nMarco Wanderwitz\nKai Wegner\nDr. h. c. Albert
-                  Weiler\nMarcus Weinberg (Hamburg)\nDr. Anja Weisgerber\nPeter Weiß (Emmendingen)\nSabine
-                  Weiss (Wesel I)\nIngo Wellenreuther\nMarian Wendt\nKai Whittaker\nAnnette Widmann-Mauz\nBettina
-                  Margarethe \nWiesmann\nKlaus-Peter Willsch\nElisabeth Winkelmeier-\nBecker\nOliver
-                  Wittke\nEmmi Zeulner\nPaul Ziemiak\nDr. Matthias Zimmer\nSPD\nNiels Annen\nIngrid
-                  Arndt-Brauer\nHeike Baehrens\nUlrike Bahr\nDr. Katarina Barley\nDoris Barnett\nDr.
-                  Matthias Bartke\nSören Bartol\nBärbel Bas\nLothar Binding (Heidelberg)\nLeni Breymaier\nDr.
-                  Karl-Heinz Brunner\nKatrin Budde\nMarco Bülow\nMartin Burkert\nDr. Lars Castellucci\nBernhard
-                  Daldrup\nDr. Daniela De Ridder\nDr. Karamba Diaby\nEsther Dilcher\nSabine Dittmar\nWiebke
-                  Esdar\nSaskia Esken\nYasmin Fahimi\nDr. Johannes Fechner\nDr. Fritz Felgentreu\nDr.
-                  Edgar Franke\nUlrich Freese\nDagmar Freitag\nSigmar Gabriel\nMichael Gerdes\nDeutscher
-                  Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 2017
-                  Deutscher Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 24. Oktober
-                  2017 33\n(A) (C)\n(B) (D)\nMartin Gerster\nAngelika Glöckner\nTimon Gremmels\nKerstin
-                  Griese\nUli Grötsch\nMichael Groß\nBettina Hagedorn\nRita Hagl-Kehl\nMetin Hakverdi\nSebastian
-                  Hartmann\nDirk Heidenblut\nGabriela Heinrich\nMarcus Held\nWolfgang Hellmich\nDr.
-                  Barbara Hendricks\nGustav Herzog\nGabriele Hiller-Ohm\nThomas Hitschler\nDr. Eva
-                  Högl\nFrank Junge\nThomas Jurk\nOliver Kaczmarek\nJohannes Kahrs\nElisabeth Kaiser\nRalf
-                  Kapschack\nGabriele Katzmarek\nUlrich Kelber\nCansel Kiziltepe\nArno Klare\nLars
-                  Klingbeil\nDr. Bärbel Kofler\nDaniela Kolbe\nElvan Korkmaz\nAnette Kramme\nChristine
-                  Lambrecht\nChristian Lange (Backnang)\nDr. Karl Lauterbach\nHelge Lindh\nBurkhard
-                  Lischka\nKirsten Lühmann\nHeiko Josef Maas\nCaren Marks\nKatja Mast\nChristoph Matschie\nHilde
-                  Mattheis\nDr. Matthias Miersch\nKlaus Mindrup\nSusanne Mittag\nSiemtje Möller\nFalko
-                  Mohrs\nClaudia Moll\nBettina Müller\nDetlef Müller (Chemnitz)\nMichelle Müntefering\nDr.
-                  Rolf Mützenich\nAndrea Nahles\nDietmar Nietan\nUlli Nissen\nMahmut Özdemir (Duisburg)\nAydan
-                  Özoğuz\nJosephine Ortleb\nChristian Petry\nDetlev Pilger\nFlorian Post\nAchim Post
-                  (Minden)\nFlorian Pronold\nDr. Sascha Raabe\nMartin Rabanus\nDr. Carola Reimann\nAndreas
-                  Rimkus\nSönke Rix\nRené Röspel\nDennis Rohde\nDr. Martin Rosemann\nDr. Ernst Dieter
-                  Rossmann\nMichael Roth (Heringen)\nSusann Rüthrich\nBernd Rützel\nSarah Ryglewski\nJohann
-                  Saathoff\nAxel Schäfer (Bochum)\nDr. Nina Scheer\nMarianne Schieder\nUdo Schiefner\nDr.
-                  Nils Schmid\nUwe Schmidt\nUlla Schmidt (Aachen)\nDagmar Schmidt (Wetzlar)\nCarsten
-                  Schneider (Erfurt)\nJohannes Schraps\nMichael Schrodi\nDr. Manja Schüle\nUrsula
-                  Schulte\nMartin Schulz\nSwen Schulz (Spandau)\nEwald Schurer\nFrank Schwabe\nStefan
-                  Schwartze\nAndreas Schwarz\nRita Schwarzelühr-Sutter\nRainer Spiering\nSvenja Stadler\nMartina
-                  Stamm-Fibich\nMathias Stein\nKerstin Tack\nClaudia Tausend\nMichael Thews\nMarkus
-                  Töns\nDirk Vöpel\nUte Vogt\nGabi Weber\nBernd Westphal\nDirk Wiese\nGülistan Yüksel\nDagmar
-                  Ziegler\nStefan Zierke\nDr. Jens Zimmermann\nAfD\nDr. Bernd Baumann\nMarc Bernhard\nAndreas
-                  Bleck\nStephan Brandner\nJürgen Braun\nMarcus Bühl\nMatthias Büttner\nPetr Bystron\nTino
-                  Chrupalla\nJoana Eleonora Cotar\nDr. Gottfried Curio\nSiegbert Droese\nThomas Ehrhorn\nBerengar
-                  Elsner von Gronow\nDr. Michael Espendiller\nPeter Felser\nDietmar Friedhoff\nDr.
-                  Anton Friesen\nDr. Götz Frömming\nMarkus Frohnmaier\nDr. Eberhardt Alexander \nGauland\nDr.
-                  Axel Gehrke\nAlbrecht Heinz Erhard \nGlaser\nFranziska Gminder\nKay Gottschalk\nArmin-Paulus
-                  Hampel\nMariana Iris Harder-Kühnel\nVerena Hartmann\nDr. Roland Hartwig\nJochen
-                  Haug\nMartin Hebner\nUdo Theodor Hemmelgarn\nWaldemar Herdt\nLars Herrmann\nMartin
-                  Hess\nDr. Heiko Heßenkemper\nKarsten Hilse\nNicole Höchst\nMartin Hohmann\nDr. Bruno
-                  Hollnagel\nLeif-Erik Holm\nJohannes Huber\nFabian Jacobi\nDr. Marc Jongen\nUwe Kamann\nJens
-                  Kestner\nStefan Keuter\nNorbert Kleinwächter\nJörn König\nSteffen Kotré\nDr. Rainer
-                  Kraft\nRüdiger Lucassen\nFrank Magnitz\nJens Maier\nDr. Lothar Maier\nDr. Birgit
-                  Malsack-\nWinkemann\nCorinna Miazga\nAndreas Mrosek\nHansjörg Gerhard Georg \nMüller\nVolker
-                  Münz\nSebastian Münzenmaier\nChristoph Neumann\nJan Ralf Nolte\nUlrich Oehme\nGerold
-                  Joachim Otten\nFrank Pasemann\nTobias Matthias Peterka\nPaul Viktor Podolay\nJürgen
-                  Pohl\nStephan Protschka\nMartin Reichardt\nMartin Erwin Renner\nRoman Johannes Reusch\nUlrike
-                  Schielke-Ziesing\nDr. Robby Schlund\nJörg Schneider\nUwe Schulz\nThomas Seitz\nMartin
-                  Sichert\nDetlev Spangenberg\nDr. Dirk Spaniel\nRené Springer\nBeatrix von Storch\nAlice
-                  Weidel\nDr. Harald Weyel\nWolfgang Wiehle\nDr. Heiko Wildberg\nDr. Christian Friedrich
-                  Wirth\nUwe Witt\nFDP\nGrigorios Aggelidis\nRenata Alt\nChristine Aschenberg-\nDugnus\nNicole
-                  Bauer\nJens Beeck\nNicola Beer\nDr. Jens Brandenburg\nMario Brandenburg\nDeutscher
-                  Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin, Dienstag, den 24. Oktober 201734\n(A)
-                  (C)\n(B) (D)\nDr. Marco Buschmann\nKarlheinz Busen\nCarl-Julius Cronenberg\nBritta
-                  Katharina Dassler\nBijan Djir-Sarai\nChristian Dürr\nHartmut Ebbing\nDr. Marcus
-                  Faber\nDaniel Föst\nOtto Fricke\nThomas Hacker\nKatrin Helling-Plahr\nMarkus Herbrand\nTorsten
-                  Herbst\nKatja Hessel\nDr. Gero Clemens Hocker\nManuel Höferlin\nDr. Christoph Hoffmann\nReinhard
-                  Houben\nUlla Ihnen\nOlaf In der Beek\nGyde Jensen\nDr. Christian Jung\nThomas L.
-                  Kemmerich\nKarsten Klein\nDr. Marcel Klinge\nKatharina Kloke\nDaniela Kluckert\nPascal
-                  Kober\nDr. Lukas Köhler\nCarina Konrad\nWolfgang Kubicki\nKonstantin Elias Kuhle\nAlexander
-                  Kulitz\nAlexander Graf Lambsdorff\nUlrich Lechte\nChristian Lindner\nMichael Link
-                  (Heilbronn)\nOliver Luksic\nTill Berthold Mansmann\nDr. Jürgen Andreas Michael \nMartens\nChristoph
-                  Meyer\nAlexander Müller\nRoman Müller-Böhm\nFrank Müller-Rosentritt\nDr. Martin
-                  Neumann \n(Lausitz)\nHagen Reinhold\nBernd Reuther\nDr. Stefan Ruppert\nThomas Sattelberger\nChristian
-                  Sauter\nFrank Schäffler\nDr. Wieland Schinnenburg\nJimmy Schulz\nMatthias Seestern-Pauly\nFrank
-                  Sitta\nJudith Skudelny\nDr. Hermann Otto Solms\nBettina Stark-Watzinger\nDr. Marie-Agnes
-                  Strack-\nZimmermann\nBenjamin Strasser\nKatja Suding\nLinda Teuteberg\nMichael Theurer\nStephan
-                  Thomae\nManfred Todtenhausen\nDr. Florian Toncar\nDr. Andrew Ullmann\nGerald Ullrich\nJohannes
-                  Vogel \n(Lüdenscheid)\nSandra Weeser\nNicole Westig\nDIE LINKE.\nDoris Achelwilm\nGökay
-                  Akbulut\nSimone Barrientos\nDr. Dietmar Bartsch\nLorenz Gösta Beutin\nMatthias W.
-                  Birkwald\nHeidrun Bluhm\nMichel Brandt\nChristine Buchholz\nBirke Bull-Bischoff\nJörg
-                  Cezanne\nSevim Dağdelen\nFabio De Masi\nDr. Diether Dehm\nAnke Domscheit-Berg\nKlaus
-                  Ernst\nSusanne Ferschl\nBrigitte Freihold\nSylvia Gabelmann\nNicole Gohlke\nDr.
-                  Gregor Gysi\nHeike Hänsel\nDr. André Hahn\nMatthias Höhn\nAndrej Hunko\nUlla Jelpke\nKerstin
-                  Kassner\nDr. Achim Kessler\nJan Korte\nJutta Krellmann\nRalph Lenkert\nStefan Liebich\nDr.
-                  Gesine Lötzsch\nPascal Meiser\nCornelia Möhring\nAmira Mohamed Ali\nNiema Movassat\nNorbert
-                  Müller (Potsdam)\nZaklin Nastic\nDr. Alexander S. Neu\nThomas Nord\nPetra Pau\nSören
-                  Pellmann\nVictor Perli\nTobias Pflüger\nIngrid Remmers\nMartina Renner\nBernd Riexinger\nEva-Maria
-                  Elisabeth \nSchreiber\nDr. Petra Sitte\nEvrim Sommer\nKersten Steinke\nFriedrich
-                  Straetmanns\nDr. Kirsten Tackmann\nJessica Tatti\nAlexander Ulrich\nKathrin Vogler\nAndreas
-                  Wagner\nHarald Weinberg\nKatrin Werner\nHubertus Zdebel\nPia Zimmermann\nSabine
-                  Zimmermann \n(Zwickau)\nBÜNDNIS 90/ \nDIE GRÜNEN\nLuise Amtsberg\nKerstin Andreae\nLisa
-                  Hildegard Badum\nAnnalena Baerbock\nMargarete Bause\nDr. Danyal Bayaz\nCanan Bayram\nDr.
-                  Franziska Brantner\nAgnieszka Brugger\nDr. Anna Christmann\nEkin Deligöz\nKatja
-                  Dörner\nKatharina Dröge\nHarald Ebner\nMatthias Gastel\nKai Gehring\nStefan Gelbhaar\nKatrin
-                  Göring-Eckardt\nErhard Grundl\nAnja Hajduk\nBritta Haßelmann\nDr. Bettina Hoffmann\nDr.
-                  Anton Hofreiter\nOttmar von Holtz\nDieter Janecek\nDr. Kirsten Kappert-Gonther\nUwe
-                  Kekeritz\nKatja Keul\nMaria Klein-Schmeink\nSylvia Kotting-Uhl\nOliver Krischer\nStephan
-                  Kühn (Dresden)\nChristian Kühn (Tübingen)\nRenate Künast\nMarkus Kurth\nMonika Lazar\nSven
-                  Lehmann\nSteffi Lemke\nDr. Tobias Lindner\nIrene Mihalic\nClaudia Müller\nBeate
-                  Müller-Gemmeke\nIngrid Nestle\nOmid Nouripour\nCem Özdemir\nFriedrich Ostendorff\nLisa
-                  Paus\nFiliz Polat\nTabea Rößner\nClaudia Roth (Augsburg)\nDr. Manuela Rottmann\nCorinna
-                  Rüffer\nManuel Sarrazin\nUlle Schauws\nDr. Gerhard Schick\nDr. Frithjof Schmidt\nStefan
-                  Schmidt\nKordula Schulz-Asche\nDr. Wolfgang Strengmann-\nKuhn\nMargit Stumpp\nMarkus
-                  Tressel\nJürgen Trittin\nDr. Julia Verlinden\nDaniela Wagner\nBeate Walter-Rosenheimer\nFraktionslos\nMario
-                  Mieruch\nDr. Frauke Petry\nDeutscher Bundestag – 19. Wahlperiode – 1. Sitzung. Berlin,
-                  Dienstag, den 24. Oktober 2017 Deutscher Bundestag – 19. Wahlperiode – 1. Sitzung.
-                  Berlin, Dienstag, den 24. Oktober 2017 35\n(A) (C)\n(B) (D)\nAnlage 6\nAmtliche
-                  Mitteilungen ohne Verlesung\nDer Bundesrat hat in seiner 960. Sitzung am 22. Sep-\ntember
-                  2017 beschlossen, zu den nachstehenden – vom \n18. Deutschen Bundestag verabschiedeten
-                  – Gesetzen \neinen Antrag gemäß Artikel 77 Absatz 2 des Grundgeset-\nzes nicht zu
-                  stellen:\n-\t Gesetz\t zur\t Erweiterung\t der\t Medienöffent-\nlichkeit in Gerichtsverfahren
-                  und zur Verbes-\nserung der Kommunikationshilfen für Men-\nschen mit Sprach- und
-                  Hörbehinderungen  \n(Gesetz\t über\t die\t Erweiterung\t der\t Medienöffent-\nlichkeit
-                  in Gerichtsverfahren – EMöGG)\n- Strafrechtsänderungsgesetz – Strafbarkeit nicht
-                  \ngenehmigter Kraftfahrzeugrennen im Straßenver-\nkehr\n- Gesetz zur Neuregelung
-                  des Schutzes von Geheim-\nnissen bei der Mitwirkung Dritter an der Berufs-\nausübung\tschweigepflichtiger\tPersonen\n-
-                  Drittes Gesetz zur Änderung des Telemediengeset-\nzes\n- Gesetz zur Einführung einer
-                  Berufszulassungs-\nregelung für gewerbliche Immobilienmakler und \nWohnimmobilienverwalter
-                  \n\n\nSatz: Satzweiss.com Print, Web, Software GmbH, Mainzer Straße 116, 66121 Saarbrücken,
-                  www.satzweiss.com\nDruck: Printsystem GmbH, Schafwäsche 1-3, 71296 Heimsheim, www.printsystem.de\nVertrieb:
-                  Bundesanzeiger Verlag GmbH, Postfach 10 05 34, 50445 Köln, Telefon (02 21) 97 66
-                  83 40, Fax (02 21) 97 66 83 44, www.betrifft-gesetze.de\nISSN 0722-8333"
-                fundstelle:
-                  pdf_url: https://dserver.bundestag.de/btp/19/19001.pdf
-                  id: '908'
-                  dokumentnummer: 19/1
-                  datum: '2017-10-24'
-                  verteildatum: '2017-10-25'
-                  dokumentart: Plenarprotokoll
-                  herausgeber: BT
-                  urheber: [ ]
-
-        '401':
-          $ref: "#/components/responses/UnauthorizedError"
-        '404':
-          $ref: "#/components/responses/NotFoundError"
-
   /vorgang:
     get:
-      summary: Liste aller Vorgänge
-      description: Liste aller Vorgänge
-      operationId: vorgang
       tags:
-        - vorgang            
+      - "Vorgänge"
+      operationId: "getVorgangList"
+      summary: "Liefert eine Liste von Metadaten zu Vorgängen"
       parameters:
-        - in: query
-          name: format
-          schema:
-            type: string
-            enum:
-              - json
-              - xml
-          description: Format
-          example: "json"
-          required: false
-        - in: query
-          name: cursor
-          schema: 
-            type: string
-          description: "Position des Cursors zur Anfrage weiterer Entitäten (s. Folgeanfragen nach weiteren Entitäten)."
-          example: AoJwwOKPs1MCNFBsZW5hcnByb3Rva29sbC00NzM5
-          required: false
-        - in: query
-          name: f.id
-          schema:
-            type: integer
-          description: "ID der Entität. Kann wiederholt werden, um mehrere Entitäten zu selektieren (z.B. f.id=84393&f.id=84394)."
-          example: 84394
-          required: false
-        - in: query
-          name: f.datum.start
-          schema:
-            type: string
-          description: "Frühestes Datum der Entität im Format JJJJ-MM-TT. Selektiert Entitäten in einem Datumsbereich basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich aller zugehörigen Dokumente herangezogen."
-          example: 2020-01-01
-        - in: query
-          name: f.datum.end
-          schema:
-            type: string
-          description: "Spätestes Datum der Entität im Format JJJJ-MM-TT. Selektiert Entitäten in einem Datumsbereich basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich aller zugehörigen Dokumente herangezogen."
-          example: 2020-02-28
-        - in: query
-          name: f.plenarprotokoll
-          schema:
-            type: integer
-          description: "ID eines verknüpften Plenarprotokolls. Selektiert alle Entitäten, die mit dem angegebenen Plenarprotokoll verknüpft sind. Nur für die Ressourcentypen: aktivitaet, vorgang, vorgangsposition." 
-          example: 908
+      - $ref: "#/components/parameters/DatumStartFilter"
+      - $ref: "#/components/parameters/DatumEndFilter"
+      - $ref: "#/components/parameters/AktualisiertStartFilter"
+      - $ref: "#/components/parameters/AktualisiertEndFilter"
+      - $ref: "#/components/parameters/WahlperiodeFilter"
+      - $ref: "#/components/parameters/DrucksacheFilter"
+      - $ref: "#/components/parameters/IdFilter"
+      - $ref: "#/components/parameters/PlenarprotokollFilter"
+      - $ref: "#/components/parameters/DokumentartFilter"
+      - $ref: "#/components/parameters/DokumentnummerFilter"
+      - $ref: "#/components/parameters/DrucksachtypFilter"
+      - $ref: "#/components/parameters/FrageNummerFilter"
+      - $ref: "#/components/parameters/GestaFilter"
+      - $ref: "#/components/parameters/Format"
+      - $ref: "#/components/parameters/Cursor"
       responses:
-        '200':
-          description: OK
+        "200":
+          description: "Liste von Metadaten zu Vorgängen"
           content:
             application/json:
               schema:
-                type: object
-              example:
-                numFound: 280760
-                documents:
-                  - id: '282601'
-                    beratungsstand: Noch nicht beantwortet
-                    vorgangstyp: Kleine Anfrage
-                    sachgebiet:
-                      - Innere Sicherheit
-                    typ: Vorgang
-                    wahlperiode: 20
-                    initiative:
-                      - Fraktion DIE LINKE
-                    datum: '2021-11-02'
-                    titel: Politisch motivierte Kriminalität rechts im September 2021
-                    deskriptor:
-                      - fundstelle: false
-                        name: Antisemitismus
-                        typ: Sachbegriffe
-                      - fundstelle: false
-                        name: Fremdenfeindlichkeit
-                        typ: Sachbegriffe
-                      - fundstelle: false
-                        name: Gewaltkriminalität
-                        typ: Sachbegriffe
-                      - fundstelle: false
-                        name: Haftbefehl
-                        typ: Sachbegriffe
-                      - fundstelle: false
-                        name: Hasskriminalität
-                        typ: Sachbegriffe
-                      - fundstelle: false
-                        name: Körperverletzung
-                        typ: Sachbegriffe
-                      - fundstelle: true
-                        name: Politische Straftat
-                        typ: Sachbegriffe
-                      - fundstelle: true
-                        name: Rechtsextremismus
-                        typ: Sachbegriffe
-                      - fundstelle: false
-                        name: Tötungsdelikt
-                        typ: Sachbegriffe
-                      - fundstelle: false
-                        name: Verbrechensopfer
-                        typ: Sachbegriffe
-                  - id: '282600'
-                    beratungsstand: Noch nicht beantwortet
-                    vorgangstyp: Kleine Anfrage
-                    sachgebiet:
-                      - Innere Sicherheit
-                    typ: Vorgang
-                    wahlperiode: 20
-                    initiative:
-                      - Fraktion DIE LINKE
-                    datum: '2021-11-02'
-                    titel: Antisemitische Straftaten im dritten Quartal 2021
-                    deskriptor:
-                      - fundstelle: true
-                        name: Antisemitismus
-                        typ: Sachbegriffe
-                      - fundstelle: false
-                        name: Ermittlungsverfahren
-                        typ: Sachbegriffe
-                      - fundstelle: false
-                        name: Extremismus
-                        typ: Sachbegriffe
-                      - fundstelle: false
-                        name: Festnahme
-                        typ: Sachbegriffe
-                      - fundstelle: false
-                        name: Hasskriminalität
-                        typ: Sachbegriffe
-                      - fundstelle: false
-                        name: Körperverletzung
-                        typ: Sachbegriffe
-                      - fundstelle: true
-                        name: Politische Straftat
-                        typ: Sachbegriffe
-                      - fundstelle: false
-                        name: Polizeieinsatz
-                        typ: Sachbegriffe
-                      - fundstelle: false
-                        name: Sachbeschädigung
-                        typ: Sachbegriffe
-                      - fundstelle: false
-                        name: Sachschaden
-                        typ: Sachbegriffe
-                      - fundstelle: false
-                        name: Tötungsdelikt
-                        typ: Sachbegriffe
-
-                cursor: AoJwgKeGvvwCLlZvcmdhbmctMjgxNjg1
-        '401':
-          $ref: "#/components/responses/UnauthorizedError"
-        '404':
-          $ref: "#/components/responses/NotFoundError"
-
+                $ref: "#/components/schemas/VorgangListResponse"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/VorgangListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
   /vorgang/{id}:
     get:
-      summary: Metadaten zu Vorgang
-      description: Metadaten zu Vorgang
-      operationId: vorgangId
       tags:
-        - vorgang            
+      - "Vorgänge"
+      operationId: "getVorgang"
+      summary: "Liefert Metadaten zu einem Vorgang"
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-            example: 908
-          required: true
-          description: ID des Vorgangs
-        - in: query
-          name: format
-          schema:
-            type: string
-            enum:
-              - json
-              - xml
-          description: Format
-          example: "json"
-          required: false
+      - $ref: "#/components/parameters/Id"
+      - $ref: "#/components/parameters/Format"
       responses:
-        '200':
-          description: OK
+        "200":
+          description: "Metadaten eines Vorgangs"
           content:
             application/json:
               schema:
-                type: object
-              example:
-                id: '908'
-                abstract: Eckpunkte der Aufgabenplanung, Schwerpunkte der Entwicklung bis 2006, Anpassung
-                  an Markterfordernisse und finanzielle Zwänge, Leitgedanken für die Verbreitung von
-                  DE-TV, DW-RADIO und DW-WORLD, Zielsetzungen, Strategien und Maßnahmen bis 2010,
-                  Kommunikation und Marketing, Finanz- und Investitionsplanung, Projektförderung,
-                  Evaluation
-                beratungsstand: Abgeschlossen
-                vorgangstyp: Bericht, Gutachten, Programm
-                sachgebiet:
-                  - Außenpolitik und internationale Beziehungen
-                  - Kultur
-                  - Medien, Kommunikation und Informationstechnik
-                typ: Vorgang
-                wahlperiode: 16
-                initiative:
-                  - Deutsche Welle
-                datum: '2006-06-30'
-                titel: 'Aufgabenplanung der Deutschen Welle 2007 bis 2010 (G-SIG: 16000418)'
-                deskriptor:
-                  - fundstelle: false
-                    name: Auswärtige Kultur- und Bildungspolitik
-                    typ: Sachbegriffe
-                  - fundstelle: false
-                    name: Deutsch
-                    typ: Sachbegriffe
-                  - fundstelle: true
-                    name: Deutsche Welle
-                    typ: Institutionen
-                  - fundstelle: false
-                    name: Fernsehsender
-                    typ: Sachbegriffe
-                  - fundstelle: false
-                    name: Tourismus
-                    typ: Sachbegriffe
-                  - fundstelle: false
-                    name: Öffentlich-rechtlicher Rundfunk
-                    typ: Sachbegriffe
-
-        '401':
-          $ref: "#/components/responses/UnauthorizedError"
-        '404':
-          $ref: "#/components/responses/NotFoundError"
-
+                $ref: "#/components/schemas/Vorgang"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Vorgang"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
   /vorgangsposition:
     get:
-      summary: Liste aller Vorgangspositionen
-      description: Liste aller Vorgangspositionen
-      operationId: vorgangsposition
       tags:
-        - vorgangsposition            
+      - "Vorgangspositionen"
+      operationId: "getVorgangspositionList"
+      summary: "Liefert eine Liste von Metadaten zu Vorgangspositionen"
       parameters:
-        - in: query
-          name: format
-          schema:
-            type: string
-            enum:
-              - json
-              - xml
-          description: Format
-          example: "json"
-          required: false
-        - in: query
-          name: cursor
-          schema: 
-            type: string
-          description: "Position des Cursors zur Anfrage weiterer Entitäten (s. Folgeanfragen nach weiteren Entitäten)."
-          example: AoJwwOKPs1MCNFBsZW5hcnByb3Rva29sbC00NzM5
-          required: false
-        - in: query
-          name: f.id
-          schema:
-            type: integer
-          description: "ID der Entität. Kann wiederholt werden, um mehrere Entitäten zu selektieren (z.B. f.id=84393&f.id=84394)."
-          example: 84394
-          required: false
-        - in: query
-          name: f.datum.start
-          schema:
-            type: string
-          description: "Frühestes Datum der Entität im Format JJJJ-MM-TT. Selektiert Entitäten in einem Datumsbereich basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich aller zugehörigen Dokumente herangezogen."
-          example: 2020-01-01
-        - in: query
-          name: f.datum.end
-          schema:
-            type: string
-          description: "Spätestes Datum der Entität im Format JJJJ-MM-TT. Selektiert Entitäten in einem Datumsbereich basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich aller zugehörigen Dokumente herangezogen."
-          example: 2020-02-28
-        - in: query
-          name: f.drucksache
-          schema:
-            type: integer
-          description: "ID einer verknüpften Drucksache. Selektiert alle Entitäten, die mit der angegebenen Drucksache verknüpft sind. Nur für die Ressourcentypen: aktivitaet, vorgangvorgangsposition."
-          example: 68852
-        - in: query
-          name: f.plenarprotokoll
-          schema:
-            type: integer
-          description: "ID eines verknüpften Plenarprotokolls. Selektiert alle Entitäten, die mit dem angegebenen Plenarprotokoll verknüpft sind. Nur für die Ressourcentypen: aktivitaet, vorgang, vorgangsposition." 
-          example: 908
-        - in: query
-          name: f.vorgang
-          schema:
-            type: integer
-          description: "ID eines verknüpften Vorgangs. Selektiert alle Entitäten, die mit dem angegebenen Vorgang verknüpft sind. Nur für die Ressourcentypen: vorgangsposition."
-          example: 84394
-        - in: query
-          name: f.aktivitaet
-          schema:
-            type: integer
-          description: "ID einer verknüpften Aktivität. Selektiert alle Entitäten, die mit der angegebenen Aktivität verknüpft sind. Nur für die Ressourcentypen: vorgangsposition."
-          example: 1493545 
+      - $ref: "#/components/parameters/AktualisiertStartFilter"
+      - $ref: "#/components/parameters/AktualisiertEndFilter"
+      - $ref: "#/components/parameters/AktivitaetFilter"
+      - $ref: "#/components/parameters/DatumStartFilter"
+      - $ref: "#/components/parameters/DatumEndFilter"
+      - $ref: "#/components/parameters/WahlperiodeFilter"
+      - $ref: "#/components/parameters/DrucksacheFilter"
+      - $ref: "#/components/parameters/IdFilter"
+      - $ref: "#/components/parameters/PlenarprotokollFilter"
+      - $ref: "#/components/parameters/VorgangFilter"
+      - $ref: "#/components/parameters/DokumentartFilter"
+      - $ref: "#/components/parameters/DokumentnummerFilter"
+      - $ref: "#/components/parameters/DrucksachtypFilter"
+      - $ref: "#/components/parameters/FrageNummerFilter"
+      - $ref: "#/components/parameters/ZuordnungFilter"
+      - $ref: "#/components/parameters/Format"
+      - $ref: "#/components/parameters/Cursor"
       responses:
-        '200':
-          description: OK
+        "200":
+          description: "Metadaten zu Vorgangspositionen"
           content:
             application/json:
               schema:
-                type: object
-              example:
-                numFound: 5293
-                documents:
-                  - id: '1'
-                    vorgangsposition: Antrag zur Weitergeltung der Geschäftsordnung
-                    zuordnung: BT
-                    gang: true
-                    fortsetzung: false
-                    nachtrag: false
-                    vorgangstyp: Geschäftsordnung
-                    typ: Vorgangsposition
-                    titel: 'Weitergeltung von Geschäftsordnungsrecht (G-SIG: 16000001)'
-                    aktivitaet_anzahl: 0
-                    dokumentart: Drucksache
-                    vorgang_id: '3'
-                    datum: '2005-10-18'
-                    fundstelle:
-                      pdf_url: https://dserver.bundestag.de/btd/16/000/1600001.pdf
-                      id: '1'
-                      dokumentnummer: 16/1
-                      datum: '2005-10-18'
-                      dokumentart: Drucksache
-                      drucksachetyp: Antrag
-                      herausgeber: BT
-                      urheber:
-                        - Fraktion BÜNDNIS 90/DIE GRÜNEN
-                        - Fraktion der CDU/CSU
-                        - Fraktion der FDP
-                        - Fraktion der SPD
-                        - Fraktion DIE LINKE
-                    urheber:
-                      - einbringer: false
-                        bezeichnung: B90/GR
-                        titel: Fraktion BÜNDNIS 90/DIE GRÜNEN
-                      - einbringer: false
-                        bezeichnung: CDU/CSU
-                        titel: Fraktion der CDU/CSU
-                      - einbringer: false
-                        bezeichnung: FDP
-                        titel: Fraktion der FDP
-                      - einbringer: false
-                        bezeichnung: SPD
-                        titel: Fraktion der SPD
-                      - einbringer: false
-                        bezeichnung: LINKE
-                        titel: Fraktion DIE LINKE
-                  - id: '10'
-                    vorgangsposition: Unterrichtung
-                    zuordnung: BR
-                    gang: true
-                    fortsetzung: false
-                    nachtrag: false
-                    vorgangstyp: Bericht, Gutachten, Programm
-                    typ: Vorgangsposition
-                    titel: 'Bericht der Bundesregierung über die Tätigkeit des Europarats für die Zeit
-                      vom 1. Januar bis 30. Juni 2004 (G-SIG: 16000012)'
-                    aktivitaet_anzahl: 0
-                    dokumentart: Drucksache
-                    vorgang_id: '4'
-                    datum: '2005-10-19'
-                    fundstelle:
-                      pdf_url: https://dserver.bundestag.de/brd/2005/0766-05.pdf
-                      id: '6'
-                      dokumentnummer: 766/05
-                      datum: '2005-10-19'
-                      anlagen: 'Statistische Angaben '
-                      dokumentart: Drucksache
-                      drucksachetyp: Unterrichtung
-                      herausgeber: BR
-                      urheber:
-                        - Bundesregierung
-                    ueberweisung:
-                      - ausschuss: Ausschuss für Fragen der Europäischen Union
-                        ausschuss_kuerzel: EU
-                        federfuehrung: true
-                    urheber:
-                      - einbringer: false
-                        bezeichnung: BRg
-                        titel: Bundesregierung
-                cursor: AoIGAAAAADZWb3JnYW5nc3Bvc2l0aW9uLTEwMTc5
-        '401':
-          $ref: "#/components/responses/UnauthorizedError"
-        '404':
-          $ref: "#/components/responses/NotFoundError"
-
+                $ref: "#/components/schemas/VorgangspositionListResponse"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/VorgangspositionListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
   /vorgangsposition/{id}:
     get:
-      summary: Metadaten zu Vorgangsposition
-      description: Metadaten zu Vorgangsposition
-      operationId: vorgangspositionId
       tags:
-        - vorgangsposition            
+      - "Vorgangspositionen"
+      operationId: "getVorgangsposition"
+      summary: "Liefert Metadaten zu einer Vorgangsposition"
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-            example: 908
-          required: true
-          description: ID der Vorgangsposition
-        - in: query
-          name: format
-          schema:
-            type: string
-            enum:
-              - json
-              - xml
-          description: Format
-          example: "json"
-          required: false
+      - $ref: "#/components/parameters/Id"
+      - $ref: "#/components/parameters/Format"
       responses:
-        '200':
-          description: OK
+        "200":
+          description: "Metadaten einer Vorgangsposition"
           content:
             application/json:
               schema:
-                type: object
-              example:
-                id: '908'
-                vorgangsposition: Antrag
-                zuordnung: BT
-                gang: true
-                fortsetzung: false
-                nachtrag: false
-                vorgangstyp: Antrag
-                typ: Vorgangsposition
-                titel: 'Voraussetzungen für Entwicklung, Bau und Betrieb einer Europäischen Spallations-Neutronenquelle
-                  in Deutschland schaffen - Deutsche Bewerbung vorantreiben (G-SIG: 16010126)'
-                aktivitaet_anzahl: 38
-                dokumentart: Drucksache
-                vorgang_id: '3004'
-                datum: '2006-01-18'
-                aktivitaet_anzeige:
-                  - aktivitaetsart: Antrag
-                    titel: Jens Ackermann, MdB, FDP
-                    pdf_url: https://dserver.bundestag.de/btd/16/003/1600386.pdf
-                  - aktivitaetsart: Antrag
-                    titel: Dr. Karl Addicks, MdB, FDP
-                    pdf_url: https://dserver.bundestag.de/btd/16/003/1600386.pdf
-                  - aktivitaetsart: Antrag
-                    titel: Christian Ahrendt, MdB, FDP
-                    pdf_url: https://dserver.bundestag.de/btd/16/003/1600386.pdf
-                  - aktivitaetsart: Antrag
-                    titel: Daniel Bahr (Münster), MdB, FDP
-                    pdf_url: https://dserver.bundestag.de/btd/16/003/1600386.pdf
-                fundstelle:
-                  pdf_url: https://dserver.bundestag.de/btd/16/003/1600386.pdf
-                  id: '468'
-                  dokumentnummer: 16/386
-                  datum: '2006-01-18'
-                  dokumentart: Drucksache
-                  drucksachetyp: Antrag
-                  herausgeber: BT
-                  urheber:
-                    - Fraktion der FDP
-                urheber:
-                  - einbringer: false
-                    bezeichnung: FDP
-                    titel: Fraktion der FDP
-
-        '401':
-          $ref: "#/components/responses/UnauthorizedError"
-        '404':
-          $ref: "#/components/responses/NotFoundError"
-
+                $ref: "#/components/schemas/Vorgangsposition"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Vorgangsposition"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+  /drucksache:
+    get:
+      tags:
+      - "Drucksachen"
+      operationId: "getDrucksacheList"
+      summary: "Liefert eine Liste von Metadaten zu Drucksachen"
+      parameters:
+      - $ref: "#/components/parameters/AktualisiertStartFilter"
+      - $ref: "#/components/parameters/AktualisiertEndFilter"
+      - $ref: "#/components/parameters/DatumStartFilter"
+      - $ref: "#/components/parameters/DatumEndFilter"
+      - $ref: "#/components/parameters/WahlperiodeFilter"
+      - $ref: "#/components/parameters/IdFilter"
+      - $ref: "#/components/parameters/DokumentnummerFilter"
+      - $ref: "#/components/parameters/DrucksachtypFilter"
+      - $ref: "#/components/parameters/ZuordnungFilter"
+      - $ref: "#/components/parameters/Format"
+      - $ref: "#/components/parameters/Cursor"
+      responses:
+        "200":
+          description: "Metadaten zu Drucksachen"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DrucksacheListResponse"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/DrucksacheListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+  /drucksache/{id}:
+    get:
+      tags:
+      - "Drucksachen"
+      operationId: "getDrucksache"
+      summary: "Liefert Metadaten zu einer Drucksache"
+      parameters:
+      - $ref: "#/components/parameters/Id"
+      - $ref: "#/components/parameters/Format"
+      responses:
+        "200":
+          description: "Metadaten einer Drucksache"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Drucksache"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Drucksache"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+  /drucksache-text:
+    get:
+      tags:
+      - "Drucksachen"
+      operationId: "getDrucksacheTextList"
+      summary: "Liefert eine Liste von Volltexten und Metadaten zu Drucksachen"
+      parameters:
+      - $ref: "#/components/parameters/AktualisiertStartFilter"
+      - $ref: "#/components/parameters/AktualisiertEndFilter"
+      - $ref: "#/components/parameters/DatumStartFilter"
+      - $ref: "#/components/parameters/DatumEndFilter"
+      - $ref: "#/components/parameters/WahlperiodeFilter"
+      - $ref: "#/components/parameters/IdFilter"
+      - $ref: "#/components/parameters/DokumentnummerFilter"
+      - $ref: "#/components/parameters/DrucksachtypFilter"
+      - $ref: "#/components/parameters/ZuordnungFilter"
+      - $ref: "#/components/parameters/Format"
+      - $ref: "#/components/parameters/Cursor"
+      responses:
+        "200":
+          description: "Volltext und Metadaten zu Drucksachen"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DrucksacheTextListResponse"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/DrucksacheTextListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+  /drucksache-text/{id}:
+    get:
+      tags:
+      - "Drucksachen"
+      operationId: "getDrucksacheText"
+      summary: "Liefert Volltext und Metadaten zu einer Drucksache"
+      parameters:
+      - $ref: "#/components/parameters/Id"
+      - $ref: "#/components/parameters/Format"
+      responses:
+        "200":
+          description: "Volltext und Metadaten einer Drucksache"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DrucksacheText"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/DrucksacheText"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+  /plenarprotokoll:
+    get:
+      tags:
+      - "Plenarprotokolle"
+      operationId: "getPlenarprotokollList"
+      summary: "Liefert eine Liste von Metadaten zu Plenarprotokollen"
+      parameters:
+      - $ref: "#/components/parameters/AktualisiertStartFilter"
+      - $ref: "#/components/parameters/AktualisiertEndFilter"
+      - $ref: "#/components/parameters/DatumStartFilter"
+      - $ref: "#/components/parameters/DatumEndFilter"
+      - $ref: "#/components/parameters/WahlperiodeFilter"
+      - $ref: "#/components/parameters/IdFilter"
+      - $ref: "#/components/parameters/DokumentnummerFilter"
+      - $ref: "#/components/parameters/ZuordnungFilter"
+      - $ref: "#/components/parameters/Format"
+      - $ref: "#/components/parameters/Cursor"
+      responses:
+        "200":
+          description: "Metadaten zu Plenarprotokollen"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlenarprotokollListResponse"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/PlenarprotokollListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+  /plenarprotokoll/{id}:
+    get:
+      tags:
+      - "Plenarprotokolle"
+      operationId: "getPlenarprotokoll"
+      summary: "Liefert Metadaten zu einem Plenarprotokoll"
+      parameters:
+      - $ref: "#/components/parameters/Id"
+      - $ref: "#/components/parameters/Format"
+      responses:
+        "200":
+          description: "Metadaten eines Plenarprotokolls"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Plenarprotokoll"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Plenarprotokoll"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+  /plenarprotokoll-text:
+    get:
+      tags:
+      - "Plenarprotokolle"
+      operationId: "getPlenarprotokollTextList"
+      summary: "Liefert eine Liste von Volltexten und Metadaten zu Plenarprotokollen"
+      parameters:
+      - $ref: "#/components/parameters/AktualisiertStartFilter"
+      - $ref: "#/components/parameters/AktualisiertEndFilter"
+      - $ref: "#/components/parameters/DatumStartFilter"
+      - $ref: "#/components/parameters/DatumEndFilter"
+      - $ref: "#/components/parameters/WahlperiodeFilter"
+      - $ref: "#/components/parameters/IdFilter"
+      - $ref: "#/components/parameters/DokumentnummerFilter"
+      - $ref: "#/components/parameters/ZuordnungFilter"
+      - $ref: "#/components/parameters/Format"
+      - $ref: "#/components/parameters/Cursor"
+      responses:
+        "200":
+          description: "Volltext und Metadaten zu Plenarprotokollen"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlenarprotokollTextListResponse"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/PlenarprotokollTextListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+  /plenarprotokoll-text/{id}:
+    get:
+      tags:
+      - "Plenarprotokolle"
+      operationId: "getPlenarprotokollText"
+      summary: "Liefert Volltext und Metadaten zu einem Plenarprotokoll"
+      parameters:
+      - $ref: "#/components/parameters/Id"
+      - $ref: "#/components/parameters/Format"
+      responses:
+        "200":
+          description: "Volltext und Metadaten eines Plenarprotokolls"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlenarprotokollText"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/PlenarprotokollText"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+  /aktivitaet:
+    get:
+      tags:
+      - "Aktivitäten"
+      operationId: "getAktivitaetList"
+      summary: "Liefert eine Liste von Metadaten zu Aktivitäten"
+      parameters:
+      - $ref: "#/components/parameters/AktualisiertStartFilter"
+      - $ref: "#/components/parameters/AktualisiertEndFilter"
+      - $ref: "#/components/parameters/DatumStartFilter"
+      - $ref: "#/components/parameters/DatumEndFilter"
+      - $ref: "#/components/parameters/WahlperiodeFilter"
+      - $ref: "#/components/parameters/DrucksacheFilter"
+      - $ref: "#/components/parameters/IdFilter"
+      - $ref: "#/components/parameters/PlenarprotokollFilter"
+      - $ref: "#/components/parameters/DokumentartFilter"
+      - $ref: "#/components/parameters/DokumentnummerFilter"
+      - $ref: "#/components/parameters/DrucksachtypFilter"
+      - $ref: "#/components/parameters/FrageNummerFilter"
+      - $ref: "#/components/parameters/ZuordnungFilter"
+      - $ref: "#/components/parameters/Format"
+      - $ref: "#/components/parameters/Cursor"
+      responses:
+        "200":
+          description: "Metadaten zu Aktivitäten"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AktivitaetListResponse"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/AktivitaetListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+  /aktivitaet/{id}:
+    get:
+      tags:
+      - "Aktivitäten"
+      operationId: "getAktivitaet"
+      summary: "Liefert Metadaten zu einer Aktivität"
+      parameters:
+      - $ref: "#/components/parameters/Id"
+      - $ref: "#/components/parameters/Format"
+      responses:
+        "200":
+          description: "Metadaten einer Aktivität"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Aktivitaet"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Aktivitaet"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+  /person:
+    get:
+      tags:
+      - "Personenstammdaten"
+      operationId: "getPersonList"
+      summary: "Liefert eine Liste von Personenstammdaten"
+      parameters:
+      - $ref: "#/components/parameters/AktualisiertStartFilter"
+      - $ref: "#/components/parameters/AktualisiertEndFilter"
+      - $ref: "#/components/parameters/DatumStartFilter"
+      - $ref: "#/components/parameters/DatumEndFilter"
+      - $ref: "#/components/parameters/WahlperiodeFilter"
+      - $ref: "#/components/parameters/IdFilter"
+      - $ref: "#/components/parameters/Format"
+      - $ref: "#/components/parameters/Cursor"
+      responses:
+        "200":
+          description: "Personenstammdaten"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PersonListResponse"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/PersonListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+  /person/{id}:
+    get:
+      tags:
+      - "Personenstammdaten"
+      operationId: "getPerson"
+      summary: "Liefert Personenstammdaten zu einer Person"
+      parameters:
+      - $ref: "#/components/parameters/Id"
+      - $ref: "#/components/parameters/Format"
+      responses:
+        "200":
+          description: "Personenstammdaten"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Person"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Person"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
 components:
-  responses:
-    UnauthorizedError:
-      description: An API key is required to access this service. Please refer to https://dip.bundestag.de/über-dip/hilfe/api how to apply for a key. Misuse of this service may lead to blocking your requests.
-    NotFoundError:
-      description: ID not found
-
   securitySchemes:
-    ApiKeyAuth:
-      type: apiKey
-      in: header
-      name: Authorization
-      description: Aktuell wird ein API Key benötigt, der per Mail an infoline.id3@bundestag.de beantragt werden kann. Alternativ gibt es offenbar temporäre wechselnde öffentliche Keys. (siehe https://dip.bundestag.de/%C3%BCber-dip/hilfe/api#content)
-
-security:
-  - ApiKeyAuth: ["N64VhW8.yChkBUIJeosGojQ7CSR2xwLf3Qy7Apw464"]
+    ApiKeyHeader:
+      type: "apiKey"
+      in: "header"
+      name: "Authorization"
+      description: "Beispiel: *ApiKey rgsaY4U.oZRQKUHdJhF9qguHMkwCGIoLaqEcaHjYLF*\n"
+    ApiKeyQuery:
+      type: "apiKey"
+      in: "query"
+      name: "apikey"
+      description: "Beispiel: *rgsaY4U.oZRQKUHdJhF9qguHMkwCGIoLaqEcaHjYLF*\n"
+  parameters:
+    Id:
+      name: "id"
+      in: "path"
+      required: true
+      schema:
+        type: "integer"
+      example: 1
+    AktivitaetFilter:
+      name: "f.aktivitaet"
+      in: "query"
+      schema:
+        type: "integer"
+      description: "ID einer verknüpften Aktivität\n\nSelektiert alle Entitäten, die\
+        \ mit der angegebenen Aktivität verknüpft sind.\n"
+    DatumStartFilter:
+      name: "f.datum.start"
+      in: "query"
+      schema:
+        $ref: "#/components/schemas/Datum"
+      description: "Frühestes Datum der Entität\n\nSelektiert Entitäten in einem Datumsbereich\
+        \ basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich\
+        \ aller zugehörigen Dokumente herangezogen.\n"
+      example: "2021-01-11"
+    DatumEndFilter:
+      name: "f.datum.end"
+      in: "query"
+      schema:
+        $ref: "#/components/schemas/Datum"
+      description: "Spätestes Datum der Entität\n\nSelektiert Entitäten in einem Datumsbereich\
+        \ basierend auf dem Dokumentdatum. Für Vorgänge und Personen wird der Datumsbereich\
+        \ aller zugehörigen Dokumente herangezogen.\n"
+      example: "2021-01-15"
+    AktualisiertStartFilter:
+      name: "f.aktualisiert.start"
+      in: "query"
+      schema:
+        type: "string"
+        format: "date-time"
+      description: "Frühestes Aktualisierungsdatum der Entität\n\nSelektiert Entitä\
+        ten in einem Datumsbereich basierend auf dem letzten Aktualisierungsdatum.\n"
+      example: "2022-06-01T15:00:00+02:00"
+    AktualisiertEndFilter:
+      name: "f.aktualisiert.end"
+      in: "query"
+      schema:
+        type: "string"
+        format: "date-time"
+      description: "Spätestes Aktualisierungsdatum der Entität\n\nSelektiert Entitä\
+        ten in einem Datumsbereich basierend auf dem letzten Aktualisierungsdatum.\n"
+    WahlperiodeFilter:
+      name: "f.wahlperiode"
+      in: "query"
+      schema:
+        type: "integer"
+      description: "Nummer der Wahlperiode\n\nSelektiert alle Entitäten, die der angegebenen\
+        \ Wahlperiode zugeordnet sind.\nKann wiederholt werden, um mehrere Wahlperioden\
+        \ zu selektieren.\n"
+    DrucksacheFilter:
+      name: "f.drucksache"
+      in: "query"
+      schema:
+        type: "integer"
+      description: "ID einer verknüpften Drucksache\n\nSelektiert alle Entitäten,\
+        \ die mit der angegebenen Drucksache verknüpft sind.\n"
+    IdFilter:
+      name: "f.id"
+      in: "query"
+      schema:
+        type: "integer"
+      description: "ID der Entität\n\nKann wiederholt werden, um mehrere Entitäten\
+        \ zu selektieren.\n"
+    PlenarprotokollFilter:
+      name: "f.plenarprotokoll"
+      in: "query"
+      schema:
+        type: "integer"
+      description: "ID eines verknüpften Plenarprotokolls\n\nSelektiert alle Entitä\
+        ten, die mit dem angegebenen Plenarprotokoll verknüpft sind.\n"
+    VorgangFilter:
+      name: "f.vorgang"
+      in: "query"
+      schema:
+        type: "integer"
+      description: "ID eines verknüpften Vorgangs\n\nSelektiert alle Entitäten, die\
+        \ mit dem angegebenen Vorgang verknüpft sind.\n"
+    DokumentnummerFilter:
+      name: "f.dokumentnummer"
+      in: "query"
+      schema:
+        type: "string"
+      description: "Dokumentnummer einer Drucksache oder eines Plenarprotokolls\n\n\
+        Selektiert alle Entitäten, die mit der angegebenen Dokumentnummer verknüpft\
+        \ sind.\nKann wiederholt werden, um mehrere Dokumentnummern zu selektieren.\n"
+    DokumentartFilter:
+      name: "f.dokumentart"
+      in: "query"
+      schema:
+        type: "string"
+        enum:
+        - "Drucksache"
+        - "Plenarprotokoll"
+      description: "Drucksache oder Plenarprotokoll\n\nSelektiert alle Entitäten,\
+        \ die mit der angegebenen Dokumentart verknüpft sind.\n"
+    DrucksachtypFilter:
+      name: "f.drucksachetyp"
+      in: "query"
+      schema:
+        type: "string"
+      description: "Typ der Drucksache\n\nSelektiert alle Entitäten, die mit dem angegebenen\
+        \ Drucksachetyp verknüpft sind.\n"
+    FrageNummerFilter:
+      name: "f.frage_nummer"
+      in: "query"
+      schema:
+        type: "string"
+      description: "Fragenummer/Listenziffer\n\nSelektiert alle Entitäten, die mit\
+        \ der angegebenen Fragenummer in einer Drucksache verknüpft sind.\nKann wiederholt\
+        \ werden, um mehrere Fragenummern zu selektieren.\n"
+    GestaFilter:
+      name: "f.gesta"
+      in: "query"
+      schema:
+        type: "string"
+      description: "GESTA-Ordnungsnummer\n\nSelektiert alle Entitäten, die der angegebenen\
+        \ GESTA-Ordnungsnummer zugeordnet sind.\nKann wiederholt werden, um mehrere\
+        \ Ordnungsnummern zu selektieren.\n"
+    ZuordnungFilter:
+      name: "f.zuordnung"
+      in: "query"
+      schema:
+        $ref: "#/components/schemas/Zuordnung"
+      description: "Zuordnung der Entität zum Bundestag, Bundesrat, Bundesversammlung\
+        \ oder Europakammer"
+    Format:
+      name: "format"
+      in: "query"
+      schema:
+        type: "string"
+        enum:
+        - "json"
+        - "xml"
+        default: "json"
+      description: "Steuert das Datenformat der Antwort, möglich sind JSON (voreingestellt)\
+        \ oder XML."
+    Cursor:
+      name: "cursor"
+      in: "query"
+      schema:
+        type: "string"
+      description: "Position des Cursors zur Anfrage weiterer Entitäten\n\nÜbersteigt\
+        \ die Anzahl der gefundenen Entitäten das jeweilige Limit, muss eine Folgeanfrage\
+        \ gestellt werden, um weitere Entitäten zu laden.\nEine Folgeanfrage wird\
+        \ gebildet, indem alle Parameter der ursprünglichen Anfrage wiederholt werden\
+        \ und zusätzlich der cursor Parameter der letzten Antwort eingesetzt wird.\n\
+        Es können solange Folgeanfragen gestellt werden, bis sich der cursor nicht\
+        \ mehr ändert. Dies signalisiert, dass alle Entitäten geladen wurden.\n"
+  responses:
+    BadRequestResponse:
+      description: "Syntaxfehler in einem der Anfrageparameter"
+      content:
+        application/json:
+          schema:
+            type: "object"
+            properties:
+              code:
+                type: "integer"
+                enum:
+                - 400
+              message:
+                type: "string"
+                example: "Invalid cursor"
+            required:
+            - "code"
+            - "message"
+    UnauthorizedResponse:
+      description: "Ein gültiger API-Key ist für alle Anfragen erforderlich. Dieser\
+        \ kann entweder im HTTP Authorization Header oder als Anfrageparameter apikey\
+        \ gesendet werden."
+      content:
+        application/json:
+          schema:
+            type: "object"
+            properties:
+              code:
+                type: "integer"
+                enum:
+                - 401
+              message:
+                type: "string"
+                enum:
+                - "An API key is required to access this service. Please refer to\
+                  \ https://dip.bundestag.de/über-dip/hilfe/api how to apply for a\
+                  \ key. Misuse of this service may lead to blocking your requests."
+            required:
+            - "code"
+            - "message"
+    NotFoundResponse:
+      description: "Die angefragte Entität wurde nicht gefunden"
+      content:
+        application/json:
+          schema:
+            type: "object"
+            properties:
+              code:
+                type: "integer"
+                enum:
+                - 404
+              message:
+                type: "string"
+                example: "ID not found: 0"
+            required:
+            - "code"
+            - "message"
+  schemas:
+    ListResponseBase:
+      type: "object"
+      xml:
+        name: "response"
+      properties:
+        numFound:
+          type: "integer"
+          format: "int32"
+          example: 176
+        cursor:
+          type: "string"
+          example: "AoJwgNjC_PYCMURydWNrc2FjaGUtMjQ5MjYw"
+      required:
+      - "numFound"
+      - "cursor"
+    VorgangListResponse:
+      allOf:
+      - $ref: "#/components/schemas/ListResponseBase"
+      - type: "object"
+        properties:
+          documents:
+            type: "array"
+            items:
+              $ref: "#/components/schemas/Vorgang"
+            minItems: 0
+            maxItems: 100
+        required:
+        - "documents"
+    VorgangspositionListResponse:
+      allOf:
+      - $ref: "#/components/schemas/ListResponseBase"
+      - type: "object"
+        properties:
+          documents:
+            type: "array"
+            items:
+              $ref: "#/components/schemas/Vorgangsposition"
+            minItems: 0
+            maxItems: 100
+        required:
+        - "documents"
+    PlenarprotokollListResponse:
+      allOf:
+      - $ref: "#/components/schemas/ListResponseBase"
+      - type: "object"
+        properties:
+          documents:
+            type: "array"
+            items:
+              $ref: "#/components/schemas/Plenarprotokoll"
+            minItems: 0
+            maxItems: 100
+        required:
+        - "documents"
+    DrucksacheListResponse:
+      allOf:
+      - $ref: "#/components/schemas/ListResponseBase"
+      - type: "object"
+        properties:
+          documents:
+            type: "array"
+            items:
+              $ref: "#/components/schemas/Drucksache"
+            minItems: 0
+            maxItems: 100
+        required:
+        - "documents"
+    PlenarprotokollTextListResponse:
+      allOf:
+      - $ref: "#/components/schemas/ListResponseBase"
+      - type: "object"
+        properties:
+          documents:
+            type: "array"
+            items:
+              $ref: "#/components/schemas/PlenarprotokollText"
+            minItems: 0
+            maxItems: 10
+        required:
+        - "documents"
+    DrucksacheTextListResponse:
+      allOf:
+      - $ref: "#/components/schemas/ListResponseBase"
+      - type: "object"
+        properties:
+          documents:
+            type: "array"
+            items:
+              $ref: "#/components/schemas/DrucksacheText"
+            minItems: 0
+            maxItems: 10
+        required:
+        - "documents"
+    AktivitaetListResponse:
+      allOf:
+      - $ref: "#/components/schemas/ListResponseBase"
+      - type: "object"
+        properties:
+          documents:
+            type: "array"
+            items:
+              $ref: "#/components/schemas/Aktivitaet"
+            minItems: 0
+            maxItems: 100
+        required:
+        - "documents"
+    PersonListResponse:
+      allOf:
+      - $ref: "#/components/schemas/ListResponseBase"
+      - type: "object"
+        properties:
+          documents:
+            type: "array"
+            items:
+              $ref: "#/components/schemas/Person"
+            minItems: 0
+            maxItems: 100
+        required:
+        - "documents"
+    Vorgang:
+      description: "Liefert Metadaten zu einem Vorgang."
+      type: "object"
+      xml:
+        name: "document"
+      properties:
+        id:
+          type: "string"
+          pattern: "^\\d+$"
+          example: 84343
+        typ:
+          type: "string"
+          enum:
+          - "Vorgang"
+          example: "Vorgang"
+        beratungsstand:
+          type: "string"
+          example: "Abgeschlossen"
+        vorgangstyp:
+          type: "string"
+          example: "Geschäftsordnung"
+        wahlperiode:
+          type: "integer"
+          format: "int32"
+          example: 19
+        initiative:
+          type: "array"
+          items:
+            type: "string"
+            example: "Fraktion der CDU/CSU"
+        datum:
+          type: "string"
+          format: "date"
+          example: "2019-03-27"
+          description: "Datierung des letzten zugehörigen Dokuments"
+        aktualisiert:
+          type: "string"
+          format: "date-time"
+          example: "2022-08-01T15:30:16+02:00"
+          description: "Letzte Aktualisierung der Entität"
+        titel:
+          type: "string"
+          example: "Weitergeltung von Geschäftsordnungsrecht"
+        abstract:
+          type: "string"
+          example: "Übernahme von Geschäftsordnungen durch den 19. Deutschen Bundestag:\
+            \ Geschäftsordnung des Deutschen Bundestages, Gemeinsame Geschäftsordnung\
+            \ für den Vermittlungsausschuss, Geschäftsordnung für den Gemeinsamen\
+            \ Ausschuss, Geschäftsordnung für das Verfahren nach Art. 115d GG, Richtlinien\
+            \ zur Überprüfung auf eine Stasi-Tätigkeit"
+        sachgebiet:
+          type: "array"
+          items:
+            type: "string"
+            example: "Bundestag"
+        deskriptor:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/VorgangDeskriptor"
+        gesta:
+          type: "string"
+          example: "B101"
+          description: "GESTA-Ordnungsnummer"
+        zustimmungsbeduerftigkeit:
+          type: "array"
+          items:
+            type: "string"
+            example: "Nein, laut Verkündung (BGBl I)"
+        kom:
+          type: "string"
+          example: "(2017) 600 endg."
+          description: "KOM-Nr."
+        ratsdok:
+          type: "string"
+          example: "11018/17"
+          description: "Ratsdok-Nr."
+        verkuendung:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Verkuendung"
+        inkrafttreten:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Inkrafttreten"
+        archiv:
+          type: "string"
+          example: "XIX/288"
+          description: "Archivsignatur"
+        mitteilung:
+          type: "string"
+          example: "Tag des Inkrafttretens bestimmter Teile des Gesetzes wird durch\
+            \ das BMI im BGBl bekanntgemacht, weiteres siehe im BGBl"
+        vorgang_verlinkung:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/VorgangVerlinkung"
+        sek:
+          type: "string"
+          example: "(2010) 305 endg."
+          description: "SEK-Nr."
+      required:
+      - "id"
+      - "typ"
+      - "vorgangstyp"
+      - "wahlperiode"
+      - "aktualisiert"
+      - "titel"
+    Vorgangsposition:
+      description: "Liefert Metadaten zu einer Vorgangsposition (Vorgangsschritt)."
+      type: "object"
+      xml:
+        name: "document"
+      properties:
+        id:
+          type: "string"
+          pattern: "^\\d+$"
+          example: 173376
+        vorgangsposition:
+          type: "string"
+          example: "Antrag zur Weitergeltung der Geschäftsordnung"
+        zuordnung:
+          $ref: "#/components/schemas/Zuordnung"
+        gang:
+          type: "boolean"
+          description: "Alle Vorgangsschritte, die von besonderer Bedeutung für den\
+            \ Fortgang der Beratung sind, werden durch das Attribut `gang: true` gekennzeichnet.\n\
+            \nIst ein solcher Vorgangsschritt mit einer Drucksache verknüpft, werden\
+            \ im Frontend unter der Benennung \"Wichtige Drucksachen\" Herausgeber,\
+            \ Nummer und Typ sowie das Datum der entsprechenden Drucksachen ausgegeben\
+            \ (z.B. BT-Drs 18/13014 (Beschlussempfehlung), 28.06.2017). \nIst er mit\
+            \ einem Plenarprotokoll verknüpft, werden im Frontend unter der Benennung\
+            \ \"Plenum\" der Klartext der Vorgangsposition, Datum, Herausgeber und\
+            \ Nummer des Plenarprotokolls mit Anfangsseite/Quadrant und Endseite/Quadrant\
+            \ dargestellt (z.B. 2. Beratung: 29.06.2017, BT-PlPr 18/243, S. 24964C\
+            \ - 24973C).\n"
+        fortsetzung:
+          type: "boolean"
+          description: "Erstreckt sich eine Beratung über mehrere Plenarprotokolle,\
+            \ so müssen entsprechend viele Vorgangsschritte mit je gleicher Vorgangsposition\
+            \ im Vorgangsablauf angelegt werden. Der zweite und jeder weitere dieser\
+            \ Schritte wird dann als \"Fortsetzung\" gekennzeichnet (Attribut `fortsetzung:\
+            \ true`). \nFür die Beratung des Gesetzentwurfs für die Feststellung des\
+            \ Haushaltsplanes (Haushaltsberatungen) gelten abweichende Regelungen.\n"
+        nachtrag:
+          type: "boolean"
+          description: "Eine Auswertungseinheit eines Plenarprotokolls kann nur an\
+            \ genau einen Vorgangsschritt angebunden werden. \nMüssen aber mehrere\
+            \ Auswertungseinheiten für einen Vorgangsschritt gebildet werden (weil\
+            \ die Ergänzung einer Rede erst in einem späteren Protokoll erscheint\
+            \ oder weil sich z.B. bei einer Verbundenen Beratung (§ 24 GO-BT) nicht\
+            \ alle Schriftlichen Erklärungen nach § 31 GO-BT auf sämtliche Vorlagen\
+            \ beziehen), \ndann müssen im Vorgangsablauf mehrere Vorgangsschritte\
+            \ mit der gleichen Vorgangsposition angelegt werden. Der zweite und jeder\
+            \ weitere dieser Schritte wird dann als \"Nachtrag\" gekennzeichnet (Attribut\
+            \ `nachtrag: true`)\n"
+        vorgangstyp:
+          type: "string"
+          example: "Geschäftsordnung"
+          description: "Vorgangstyp des zugehörigen Vorgangs"
+        typ:
+          type: "string"
+          enum:
+          - "Vorgangsposition"
+          example: "Vorgangsposition"
+        titel:
+          type: "string"
+          example: "Weitergeltung von Geschäftsordnungsrecht"
+          description: "Titel des zugehörigen Vorgangs"
+        dokumentart:
+          type: "string"
+          enum:
+          - "Drucksache"
+          - "Plenarprotokoll"
+          example: "Drucksache"
+        vorgang_id:
+          type: "string"
+          pattern: "^\\d+$"
+          example: 84343
+          description: "ID des zugehörigen Vorgangs"
+        datum:
+          type: "string"
+          format: "date"
+          example: "2017-10-24"
+          description: "Datum des zugehörigen Dokuments"
+        aktualisiert:
+          type: "string"
+          format: "date-time"
+          example: "2022-08-01T15:30:16+02:00"
+          description: "Letzte Aktualisierung der Entität oder des zugehörigen Dokuments"
+        fundstelle:
+          $ref: "#/components/schemas/Fundstelle"
+        urheber:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Urheber"
+        ueberweisung:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Ueberweisung"
+        aktivitaet_anzeige:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/AktivitaetAnzeige"
+          minItems: 0
+          maxItems: 4
+          description: "Zusammenfassung der ersten 4 zur Anzeige vorgesehenen Aktivitä\
+            ten"
+        aktivitaet_anzahl:
+          type: "integer"
+          format: "int32"
+          example: 2
+          description: "Gesamtzahl der zugehörigen Aktivitäten"
+        ressort:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Ressort"
+        beschlussfassung:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Beschlussfassung"
+        ratsdok:
+          type: "string"
+          example: "11018/17"
+          description: "Ratsdok-Nr."
+        kom:
+          type: "string"
+          example: "(2017) 600 endg."
+          description: "KOM-Nr."
+        sek:
+          type: "string"
+          example: "(2010) 305 endg."
+          description: "SEK-Nr."
+        mitberaten:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Vorgangspositionbezug"
+          description: "Es ist eine häufig geübte Praxis, mehrere thematisch verwandte\
+            \ Vorlagen (z.B. konkurrierende Anträge der verschiedenen Fraktionen zum\
+            \ Thema Diesel-Fahrverbote) in einer Debatte gemeinsam zu beraten (\"\
+            Zusammenberatung\").\n\n`mitberaten` liefert, von einem Vorgang ausgehend,\
+            \ alle anderen Vorgänge, die Gegenstand der Zusammenberatung sind.\n"
+        abstract:
+          type: "string"
+          example: "Stellungnahme der BRg zu den Tätigkeitsberichten 2016/2017 der\
+            \ Bundesnetzagentur  - Telekommunikation und Post - mit den Sondergutachten\
+            \ der Monopolkommission"
+      required:
+      - "id"
+      - "vorgangsposition"
+      - "zuordnung"
+      - "gang"
+      - "fortsetzung"
+      - "nachtrag"
+      - "vorgangstyp"
+      - "typ"
+      - "titel"
+      - "dokumentart"
+      - "vorgang_id"
+      - "datum"
+      - "aktualisiert"
+      - "fundstelle"
+      - "aktivitaet_anzahl"
+    Drucksache:
+      description: "Liefert Metadaten zu einer Drucksache."
+      type: "object"
+      xml:
+        name: "document"
+      properties:
+        id:
+          type: "string"
+          pattern: "^\\d+$"
+          example: 68852
+        typ:
+          type: "string"
+          enum:
+          - "Dokument"
+          example: "Dokument"
+        dokumentart:
+          type: "string"
+          enum:
+          - "Drucksache"
+          example: "Drucksache"
+        drucksachetyp:
+          type: "string"
+          example: "Antrag"
+        dokumentnummer:
+          type: "string"
+          example: "19/1"
+        wahlperiode:
+          type: "integer"
+          format: "int32"
+          example: 19
+        herausgeber:
+          type: "string"
+          enum:
+          - "BT"
+          - "BR"
+          example: "BT"
+        datum:
+          type: "string"
+          format: "date"
+          example: "2017-10-24"
+        aktualisiert:
+          type: "string"
+          format: "date-time"
+          example: "2022-08-01T15:30:16+02:00"
+          description: "Letzte Aktualisierung der Entität"
+        titel:
+          type: "string"
+          example: "Weitergeltung von Geschäftsordnungsrecht"
+        autoren_anzeige:
+          type: "array"
+          items:
+            type: "object"
+            properties:
+              id:
+                type: "string"
+                pattern: "^\\d+$"
+                example: 546
+                description: "ID von Personenstammdaten"
+              title:
+                type: "string"
+                example: "Kai Gehring, MdB, BÜNDNIS 90/DIE GRÜNEN"
+              autor_titel:
+                type: "string"
+                example: "Kai Gehring"
+            required:
+            - "id"
+            - "title"
+            - "autor_titel"
+          minItems: 0
+          maxItems: 4
+          description: "Zusammenfassung der ersten 4 zur Anzeige markierten Autor:innen"
+        autoren_anzahl:
+          type: "integer"
+          format: "int32"
+          example: 4
+          description: "Gesamtzahl der Autor:innen"
+        fundstelle:
+          $ref: "#/components/schemas/Fundstelle"
+        pdf_hash:
+          type: "string"
+          example: "a33af31e7c4524db8db172ef8f9e0f6d"
+          description: "MD5-Prüfsumme der PDF-Datei"
+        urheber:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Urheber"
+        vorgangsbezug:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Vorgangsbezug"
+          minItems: 0
+          maxItems: 4
+          description: "Zusammenfassung der ersten 4 zugehörigen Vorgänge"
+        vorgangsbezug_anzahl:
+          type: "integer"
+          format: "int32"
+          example: 6
+          description: "Gesamtzahl der zugehörigen Vorgänge"
+        ressort:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Ressort"
+        anlagen:
+          type: "string"
+          example: "Verzeichnis der Gutachten des Sachverständigenrates"
+      required:
+      - "id"
+      - "drucksachetyp"
+      - "dokumentart"
+      - "autoren_anzahl"
+      - "typ"
+      - "vorgangsbezug_anzahl"
+      - "dokumentnummer"
+      - "herausgeber"
+      - "datum"
+      - "aktualisiert"
+      - "titel"
+      - "fundstelle"
+    Plenarprotokoll:
+      description: "Liefert Metadaten zu einem Plenarprotokoll."
+      type: "object"
+      xml:
+        name: "document"
+      properties:
+        id:
+          type: "string"
+          pattern: "^\\d+$"
+          example: 908
+        dokumentart:
+          type: "string"
+          enum:
+          - "Plenarprotokoll"
+          example: "Plenarprotokoll"
+        typ:
+          type: "string"
+          enum:
+          - "Dokument"
+          example: "Dokument"
+        dokumentnummer:
+          type: "string"
+          example: "19/1"
+        wahlperiode:
+          type: "integer"
+          format: "int32"
+          example: 19
+        herausgeber:
+          $ref: "#/components/schemas/Zuordnung"
+        datum:
+          type: "string"
+          format: "date"
+          example: "2017-10-24"
+        aktualisiert:
+          type: "string"
+          format: "date-time"
+          example: "2022-08-01T15:30:16+02:00"
+          description: "Letzte Aktualisierung der Entität"
+        titel:
+          type: "string"
+          example: "Protokoll der 1. Sitzung des 19. Deutschen Bundestages"
+        fundstelle:
+          $ref: "#/components/schemas/Fundstelle"
+        pdf_hash:
+          type: "string"
+          example: "a33af31e7c4524db8db172ef8f9e0f6d"
+          description: "MD5-Prüfsumme der PDF-Datei"
+        vorgangsbezug:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Vorgangsbezug"
+          minItems: 0
+          maxItems: 4
+          description: "Zusammenfassung der ersten 4 zugehörigen Vorgänge"
+        vorgangsbezug_anzahl:
+          type: "integer"
+          format: "int32"
+          example: 6
+          description: "Gesamtzahl der zugehörigen Vorgänge"
+        sitzungsbemerkung:
+          type: "string"
+          example: "Sondersitzung"
+      required:
+      - "id"
+      - "dokumentart"
+      - "typ"
+      - "vorgangsbezug_anzahl"
+      - "dokumentnummer"
+      - "herausgeber"
+      - "datum"
+      - "aktualisiert"
+      - "titel"
+      - "fundstelle"
+    DokumentTextBase:
+      description: "Liefert zusätzlich zu den Metadaten den Volltext eines Dokuments."
+      type: "object"
+      properties:
+        text:
+          type: "string"
+          description: "Volltext des Dokuments\n\nDas Beispiel enthält einen gekü\
+            rzten Auszug einer Drucksache.\n"
+          example: "Deutscher Bundestag Drucksache 19/1\n19. Wahlperiode 24.10.2017\n\
+            \nAntrag\nder Fraktion der CDU/CSU\nWeitergeltung von Geschäftsordnungsrecht\n\
+            Der Bundestag wolle beschließen:\nFür die 19. Wahlperiode werden übernommen\n\
+            – die Geschäftsordnung des Deutschen Bundestages einschließlich ihrer\
+            \ Anla-\ngen, soweit sie vom Deutschen Bundestag zu beschließen sind,\
+            \ in der Fassung\nder Bekanntmachung vom 2. Juli 1980 (BGBl. I S. 1237),\
+            \ zuletzt geändert\nlaut Bekanntmachung vom 12. Juni 2017 (BGBl. I S.\
+            \ 1877), wobei § 126a der\nGeschäftsordnung mit Ablauf der 18. Wahlperiode\
+            \ entfallen ist;\n– die Gemeinsame Geschäftsordnung des Bundestages und\
+            \ des Bundesrates für\nden Ausschuss nach Artikel 77 des Grundgesetzes\
+            \ (Vermittlungsausschuss)\nvom 5. Mai 1951 (BGBl. II S. 103), zuletzt\
+            \ geändert laut Bekanntmachung vom\n30. April 2003 (BGBl. I S. 677);\n\
+            – die Geschäftsordnung für den Gemeinsamen Ausschuss vom 23. Juli 1969\n\
+            (BGBl. I S. 1102), zuletzt geändert laut Bekanntmachung vom 20. Juli 1993\n\
+            (BGBl. I S. 1500);\n– die Geschäftsordnung für das Verfahren nach Artikel\
+            \ 115d des Grundgesetzes\nvom 23. Juli 1969 (BGBl. I S. 1100);\n– die\
+            \ Richtlinien zur Überprüfung auf eine Tätigkeit oder politische Verantwor-\n\
+            tung für das Ministerium für Staatssicherheit/Amt für Nationale Sicherheit\
+            \ der\nehemaligen Deutschen Demokratischen Republik vom 13. Dezember 1991\n\
+            (BGBl. 1992 I S. 76), zuletzt geändert laut Bekanntmachung vom 21. Oktober\n\
+            2005 (BGBl. I S. 3094).\nBerlin, den 23. Oktober 2017\nVolker Kauder,\
+            \ Alexander Dobrindt und Fraktion\nSatz: Satzweiss.com Print, Web, Software\
+            \ GmbH, Mainzer Straße 116, 66121 Saarbrücken, www.satzweiss.com\nDruck:\
+            \ Printsystem GmbH, Schafwäsche 1-3, 71296 Heimsheim, www.printsystem.de\n\
+            Vertrieb: Bundesanzeiger Verlag GmbH, Postfach 10 05 34, 50445 Köln, Telefon\
+            \ (02 21) 97 66 83 40, Fax (02 21) 97 66 83 44, www.betrifft-gesetze.de\n\
+            ISSN 0722-8333\n"
+    DrucksacheText:
+      allOf:
+      - $ref: "#/components/schemas/Drucksache"
+      - $ref: "#/components/schemas/DokumentTextBase"
+    PlenarprotokollText:
+      allOf:
+      - $ref: "#/components/schemas/Plenarprotokoll"
+      - $ref: "#/components/schemas/DokumentTextBase"
+    Aktivitaet:
+      description: "Liefert Metadaten zu einer Aktivität."
+      type: "object"
+      xml:
+        name: "document"
+      properties:
+        id:
+          type: "string"
+          pattern: "^\\d+$"
+          example: 1493545
+        aktivitaetsart:
+          type: "string"
+          example: "Rede"
+        typ:
+          type: "string"
+          enum:
+          - "Aktivität"
+          example: "Aktivität"
+        dokumentart:
+          type: "string"
+          enum:
+          - "Drucksache"
+          - "Plenarprotokoll"
+          example: "Plenarprotokoll"
+        wahlperiode:
+          type: "integer"
+          format: "int32"
+          example: 19
+        datum:
+          type: "string"
+          format: "date"
+          example: "2020-12-11"
+        aktualisiert:
+          type: "string"
+          format: "date-time"
+          example: "2022-08-01T15:30:16+02:00"
+          description: "Letzte Aktualisierung der Entität oder des zugehörigen Dokuments"
+        titel:
+          type: "string"
+          example: "Olaf Scholz, Bundesmin., Bundesministerium der Finanzen"
+        fundstelle:
+          $ref: "#/components/schemas/Fundstelle"
+        vorgangsbezug:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Vorgangspositionbezug"
+          minItems: 0
+          maxItems: 4
+          description: "Zusammenfassung der ersten 4 zugehörigen Vorgänge"
+        vorgangsbezug_anzahl:
+          type: "integer"
+          format: "int32"
+          example: 18
+          description: "Gesamtzahl der zugehörigen Vorgänge"
+        deskriptor:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Deskriptor"
+        abstract:
+          type: "string"
+          example: "Zusammenberaten mit Finanzplan"
+      required:
+      - "id"
+      - "aktivitaetsart"
+      - "typ"
+      - "vorgangsbezug_anzahl"
+      - "dokumentart"
+      - "wahlperiode"
+      - "datum"
+      - "aktualisiert"
+      - "titel"
+      - "fundstelle"
+    Person:
+      description: "Liefert Personenstammdaten zu einer Person"
+      type: "object"
+      xml:
+        name: "document"
+      properties:
+        id:
+          type: "string"
+          pattern: "^\\d+$"
+          example: 1728
+        nachname:
+          type: "string"
+          example: "Leyen"
+        vorname:
+          type: "string"
+          example: "Ursula"
+        namenszusatz:
+          type: "string"
+          example: "von der"
+        typ:
+          type: "string"
+          example: "Person"
+        wahlperiode:
+          type: "integer"
+          format: "int32"
+          example: 15
+          description: "Wahlperiode des ersten zugehörigen Dokuments"
+        basisdatum:
+          type: "string"
+          format: "date"
+          example: "2003-09-09"
+          description: "Datum des ersten zugehörigen Dokuments"
+        datum:
+          type: "string"
+          format: "date"
+          example: "2019-06-25"
+          description: "Datum des letzten zugehörigen Dokuments"
+        aktualisiert:
+          type: "string"
+          format: "date-time"
+          example: "2022-08-01T15:30:16+02:00"
+          description: "Letzte Aktualisierung der Entität"
+        titel:
+          type: "string"
+          example: "Dr.  Ursula von der Leyen, Bundesmin., Bundesministerium der Verteidigung"
+        person_roles:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/PersonRole"
+          description: "Nebeneinträge mit bspw. abweichenden Funktionen oder Namensä\
+            nderungen"
+      required:
+      - "id"
+      - "nachname"
+      - "vorname"
+      - "typ"
+      - "aktualisiert"
+      - "titel"
+    AktivitaetAnzeige:
+      description: "Liefert im Vorgangsablauf die beim Vorgangsschritt zur Anzeige\
+        \ vorgesehenen Aktivitäten, z. B. eine Rede eines MdB beim Vorgangsschritt\
+        \ 1. Beratung in einem Gesetzgebungsvorgang."
+      type: "object"
+      properties:
+        aktivitaetsart:
+          type: "string"
+          example: "Rede"
+        titel:
+          type: "string"
+          example: "Prof. Dr. Patrick Sensburg, MdB, CDU/CSU"
+        pdf_url:
+          type: "string"
+          example: "https://dserver.bundestag.de/btp/19/19083.pdf#P.9800"
+        seite:
+          type: "string"
+          example: "9800D"
+      required:
+      - "aktivitaetsart"
+      - "titel"
+    Beschlussfassung:
+      description: "Liefert die Beschlussfassung (z. B. Annahme, Ablehnung, Kenntnisnahme)\
+        \ zu einer Drucksache mit Fundstelle im Plenarprotokoll sowie Angaben zu ggf.\
+        \ erforderlichen qualifizierten Mehrheiten (`mehrheit`) bzw. der besonderen\
+        \ Abstimmungsverfahren (`abstimmungsart`)."
+      type: "object"
+      properties:
+        beschlusstenor:
+          type: "string"
+          example: "Annahme der Vorlage"
+        seite:
+          type: "string"
+          example: "11B"
+        abstimmungsart:
+          type: "string"
+          enum:
+          - "Abstimmung durch Aufruf der Länder"
+          - "Geheime Wahl"
+          - "Hammelsprung"
+          - "Namentliche Abstimmung"
+          - "Verhältniswahl"
+        abstimm_ergebnis_bemerkung:
+          type: "string"
+          example: "einstimmig"
+        grundlage:
+          type: "string"
+          example: "Art. 80 Abs. 2 GG"
+        dokumentnummer:
+          type: "string"
+          example: "19/8"
+        mehrheit:
+          type: "string"
+          enum:
+          - "Absolute Mehrheit"
+          - "Zweidrittelmehrheit"
+      required:
+      - "beschlusstenor"
+    Deskriptor:
+      description: "Liefert die mit einer Aktivität zu deren inhaltlichen Beschreibung\
+        \ verknüpften Schlagwörter. Die Schlagwörter (Deskriptoren) entstammen dem\
+        \ kontrollierten Vokabular des Parlamentsthesaurus ANTHES/PARTHES und stehen\
+        \ in thematischer Beziehung zueinander.\n\nSiehe auch: VorgangDeskriptor\n"
+      type: "object"
+      properties:
+        name:
+          type: "string"
+          example: "Parlamentarische Geschäftsordnung"
+        typ:
+          type: "string"
+          enum:
+          - "Freier Deskriptor"
+          - "Geograph. Begriffe"
+          - "Institutionen"
+          - "Personen"
+          - "Rechtsmaterialien"
+          - "Sachbegriffe"
+          example: "Sachbegriffe"
+      required:
+      - "name"
+      - "typ"
+    Fundstelle:
+      description: "Liefert im Vorgangsablauf das zu einem Vorgangsschritt gehörende\
+        \ Dokument (Drucksache oder Protokoll). \n\nBeispiel: „BT-Drucksache 19/1\
+        \ (Antrag Fraktion der CDU/CSU)“ oder beim Vorgangsschritt Beratung „BT-Plenarprotokoll\
+        \ 19/1, S. 4C-12A“.\n"
+      type: "object"
+      properties:
+        id:
+          type: "string"
+          pattern: "^\\d+$"
+          example: 68852
+          description: "ID einer Drucksache oder eines Plenarprotokolls"
+        dokumentart:
+          type: "string"
+          enum:
+          - "Drucksache"
+          - "Plenarprotokoll"
+          example: "Drucksache"
+        pdf_url:
+          type: "string"
+          example: "https://dserver.bundestag.de/btd/19/000/1900001.pdf"
+        dokumentnummer:
+          type: "string"
+          example: "19/1"
+        datum:
+          type: "string"
+          format: "date"
+          example: "2017-10-24"
+        drucksachetyp:
+          type: "string"
+          example: "Antrag"
+        herausgeber:
+          $ref: "#/components/schemas/Zuordnung"
+        urheber:
+          type: "array"
+          items:
+            type: "string"
+            example: "Fraktion der CDU/CSU"
+            description: "Körperschaftliche Urheber der zugehörigen Drucksache"
+        verteildatum:
+          type: "string"
+          format: "date"
+          example: "2017-10-25"
+        seite:
+          type: "string"
+          example: "4292B"
+        anfangsseite:
+          type: "integer"
+          example: 4251
+        endseite:
+          type: "integer"
+          example: 4298
+        anfangsquadrant:
+          $ref: "#/components/schemas/Quadrant"
+        endquadrant:
+          $ref: "#/components/schemas/Quadrant"
+        frage_nummer:
+          type: "string"
+          example: "C.4"
+        anlagen:
+          type: "string"
+          example: "Verzeichnis der Gutachten des Sachverständigenrates"
+        top:
+          type: "integer"
+          format: "int32"
+          example: 2
+        top_zusatz:
+          type: "string"
+          example: "b"
+      required:
+      - "id"
+      - "dokumentnummer"
+      - "datum"
+      - "dokumentart"
+      - "herausgeber"
+      - "urheber"
+    Inkrafttreten:
+      description: "Liefert im Gesetzgebungsvorgang zu einem verkündeten Gesetz das\
+        \ Datum des Tages, an dem das Gesetz in Kraft tritt bzw. an dem Teile eines\
+        \ Gesetzes in Kraft treten."
+      type: "object"
+      properties:
+        datum:
+          type: "string"
+          format: "date"
+          example: "2020-06-06"
+        erlaeuterung:
+          type: "string"
+          example: "Artikel 1 Nr. 14, Artikel 3 Nr. 4, Artikel 4 Nr. 4"
+      required:
+      - "datum"
+    PersonRole:
+      description: "Liefert den Eintrag einer Person in einer bestimmten Rolle oder\
+        \ Funktion."
+      type: "object"
+      properties:
+        funktion:
+          type: "string"
+          example: "LMin Soz u. Frauen"
+        funktionszusatz:
+          type: "string"
+          example: "Stellv. MdBR"
+        fraktion:
+          type: "string"
+          example: "CDU/CSU"
+        nachname:
+          type: "string"
+          example: "Leyen"
+        vorname:
+          type: "string"
+          example: "Ursula"
+        namenszusatz:
+          type: "string"
+          example: "von der"
+        wahlperiode_nummer:
+          type: "array"
+          items:
+            type: "integer"
+            format: "int32"
+          example:
+          - 17
+          - 18
+          - 19
+          description: "Wahlperioden, für die der Personeneintrag zutrifft"
+        wahlkreiszusatz:
+          type: "string"
+          example: "Hannover"
+        ressort_titel:
+          type: "string"
+          example: "Bundesministerium für Familie, Senioren, Frauen und Jugend"
+        bundesland:
+          $ref: "#/components/schemas/Bundesland"
+      required:
+      - "funktion"
+      - "nachname"
+      - "vorname"
+    Ressort:
+      description: "Liefert das Ressort (Bundesministerium), das innerhalb der Bundesregierung\
+        \ federführend für die Ausarbeitung z. B. eines Gesetzentwurfs oder eines\
+        \ Antrags oder die Beantwortung von Anfragen ist. Wird nur verwendet, wenn\
+        \ Urheber einer Drucksache die Bundesregierung ist.\n\nDas Ressort wird auch\
+        \ bei persönlichen Urhebern verwendet, um die Funktion von Angehörigen der\
+        \ Bundesregierung zu präzisieren, z. B. „Dr. Robert Habeck, Bundesmin., Bundesministerium\
+        \ für Wirtschaft und Klimaschutz“ oder „Dr. Florian Toncar, Parl. Staatssekr.,\
+        \ Bundesministerium der Finanzen“.\n"
+      type: "object"
+      properties:
+        federfuehrend:
+          type: "boolean"
+          example: true
+        titel:
+          type: "string"
+          example: "Bundesministerium für Wirtschaft und Energie"
+      required:
+      - "federfuehrend"
+      - "titel"
+    Ueberweisung:
+      description: "Liefert den Ausschuss bzw. die Ausschüsse, an die eine Drucksache\
+        \ überwiesen wurde, unter Angabe der Federführung und ggf. der Überweisungsart\
+        \ (z. B. „gemäß § 96 Geschäftsordnung BT“)."
+      type: "object"
+      properties:
+        ausschuss:
+          type: "string"
+          example: "Ausschuss für Wahlprüfung, Immunität und Geschäftsordnung"
+        ausschuss_kuerzel:
+          type: "string"
+          example: "AfWIuG"
+        federfuehrung:
+          type: "boolean"
+          example: true
+        ueberweisungsart:
+          type: "string"
+          example: "gemäß § 96 Geschäftsordnung BT"
+      required:
+      - "ausschuss"
+      - "ausschuss_kuerzel"
+      - "federfuehrung"
+    Urheber:
+      description: "Liefert den körperschaftlichen Urheber einer Bundestags- oder\
+        \ Bundesratsdrucksache, z. B. einen Ausschuss, eine Fraktion, die Bundesregierung,\
+        \ ein Bundesland oder dergleichen."
+      type: "object"
+      properties:
+        einbringer:
+          type: "boolean"
+        bezeichnung:
+          type: "string"
+          example: "B90/GR"
+        titel:
+          type: "string"
+          example: "Fraktion BÜNDNIS 90/DIE GRÜNEN"
+        rolle:
+          type: "string"
+          enum:
+          - "B"
+          - "U"
+      required:
+      - "bezeichnung"
+      - "titel"
+    Verkuendung:
+      description: "Liefert die Angaben zur Verkündung eines Gesetzes: Ausfertigungs-\
+        \ und Verkündungsdatum sowie die Fundstelle im jeweiligen Verkündungsblatt.\
+        \ Bei Bundesgesetzblatt I und II ist die Fundstelle verlinkt.\n"
+      type: "object"
+      properties:
+        jahrgang:
+          type: "string"
+          example: 2018
+        heftnummer:
+          type: "string"
+          example: 11
+        seite:
+          type: "string"
+          example: 409
+        ausfertigungsdatum:
+          type: "string"
+          format: "date"
+          example: "2018-03-19"
+        verkuendungsdatum:
+          type: "string"
+          format: "date"
+          example: "2018-03-29"
+        rubrik_nr:
+          type: "string"
+          example: "V1"
+        einleitungstext:
+          type: "string"
+          example: "Bekanntmachung"
+        verkuendungsblatt_bezeichnung:
+          type: "string"
+          example: "Bundesgesetzblatt Teil I"
+        verkuendungsblatt_kuerzel:
+          type: "string"
+          example: "BGBl I"
+        fundstelle:
+          type: "string"
+          example: "BGBl I 2018, 409"
+        pdf_url:
+          type: "string"
+          example: "https://www.bgbl.de/xaver/bgbl/start.xav?startbk=Bundesanzeiger_BGBl&start=//*%5b@attr_id=%27bgbl118s0409.pdf%27%5d"
+        titel:
+          type: "string"
+          example: "Bekanntmachung über die Übernahme des Beschlusses des Deutschen\
+            \ Bundestages betr. Aufhebung der Immunität von Mitgliedern des Bundestages\
+            \ und der Grundsätze in Immunitätsangelegenheiten"
+      required:
+      - "jahrgang"
+      - "seite"
+      - "ausfertigungsdatum"
+      - "verkuendungsdatum"
+      - "einleitungstext"
+      - "fundstelle"
+    VorgangDeskriptor:
+      allOf:
+      - $ref: "#/components/schemas/Deskriptor"
+      - type: "object"
+        description: "Liefert diejenigen mit einem Vorgang zu dessen inhaltlicher\
+          \ Beschreibung verknüpften Schlagwörter, denen zur Kennzeichnung ihrer zentralen\
+          \ Bedeutung für den Vorgang das Attribut „Fundstelle“ zugewiesen wurde.\
+          \ Die Schlagwörter (Deskriptoren) entstammen dem kontrollierten Vokabular\
+          \ des Parlamentsthesaurus ANTHES/PARTHES und stehen in thematischer Beziehung\
+          \ zueinander.\n\nSiehe auch: Deskriptor\n"
+        properties:
+          fundstelle:
+            type: "boolean"
+            example: true
+            description: "Kennzeichnet Deskriptoren mit zentraler Bedeutung"
+        required:
+        - "fundstelle"
+    Vorgangsbezug:
+      description: "Liefert ID, Titel und Vorgangstyp eines Vorgangs, der mit der\
+        \ Drucksache oder dem Plenarprotokoll verbunden ist."
+      type: "object"
+      properties:
+        id:
+          type: "string"
+          pattern: "^\\d+$"
+          example: 84393
+          description: "ID eines verknüpften Vorgangs"
+        titel:
+          type: "string"
+          example: "Eröffnung der 1. Sitzung des 19. Deutschen Bundestages"
+        vorgangstyp:
+          type: "string"
+          example: "Ansprache/Erklärung/Mitteilung"
+      required:
+      - "id"
+      - "titel"
+      - "vorgangstyp"
+    Vorgangspositionbezug:
+      allOf:
+      - $ref: "#/components/schemas/Vorgangsbezug"
+      - type: "object"
+        description: "Liefert ID, Titel und Vorgangstyp eines Vorgangs sowie die Bezeichnung\
+          \ der Vorgangsposition, z. B. Ansprache, Antrag, Gesetzentwurf, auf die\
+          \ in einer Aktivität oder im Vorgangsablauf Bezug genommen wird."
+        properties:
+          vorgangsposition:
+            type: "string"
+            example: "Ansprache"
+        required:
+        - "vorgangsposition"
+    VorgangVerlinkung:
+      description: "Verlinkte Verweisung von einem Vorgang auf einen anderen Vorgang,\
+        \ zu dem eine besondere inhaltliche Verbindung besteht."
+      type: "object"
+      properties:
+        id:
+          type: "string"
+          pattern: "^\\d+$"
+          example: 282237
+          description: "ID eines verknüpften Vorgangs"
+        verweisung:
+          type: "string"
+          example: "Bericht"
+        titel:
+          type: "string"
+          example: "Zwischenbericht zur Reform des Bundeswahlrechts und zur Modernisierung\
+            \ der Parlamentsarbeit"
+        wahlperiode:
+          type: "integer"
+          format: "int32"
+          example: 19
+        gesta:
+          type: "string"
+      required:
+      - "verweisung"
+      - "titel"
+      - "id"
+      - "wahlperiode"
+    Bundesland:
+      description: "Das Bundesland wird bei persönlichen Urhebern verwendet, die Mitglieder\
+        \ des Bundesrates sind, z. B. „Reinhold Hilbers, MdBR (Finanzminister), Niedersachsen“"
+      type: "string"
+      enum:
+      - "Baden-Württemberg"
+      - "Bayern"
+      - "Berlin"
+      - "Brandenburg"
+      - "Bremen"
+      - "Hamburg"
+      - "Hessen"
+      - "Mecklenburg-Vorpommern"
+      - "Niedersachsen"
+      - "Nordrhein-Westfalen"
+      - "Rheinland-Pfalz"
+      - "Saarland"
+      - "Sachsen"
+      - "Sachsen-Anhalt"
+      - "Schleswig-Holstein"
+      - "Thüringen"
+      example: "Niedersachsen"
+    Datum:
+      description: "Liefert das Datum eines Dokuments (Drucksache oder Protokoll)."
+      type: "string"
+      format: "date"
+    Quadrant:
+      description: "Teil der Fundstelle eines Plenarprotokolls. Jede Seite im Plenarprotokoll\
+        \ ist in vier gleich große Viertel unterteilt (Quadranten) mit den Bezeichnungen\
+        \ A, B, C, D."
+      type: "string"
+      enum:
+      - "A"
+      - "B"
+      - "C"
+      - "D"
+    Zuordnung:
+      description: "Jeder Vorgangsschritt ist entweder dem Bundestag (BT), dem Bundesrat\
+        \ (BR), der Bundesversammlung (BV) oder der Europakammer (EK) zugeordnet.\
+        \ Über die Zuordnung lassen sich bspw. Rechtsverordnungen herausfiltern, an\
+        \ denen der Bundestag beteiligt / nicht beteiligt war."
+      type: "string"
+      enum:
+      - "BT"
+      - "BR"
+      - "BV"
+      - "EK"


### PR DESCRIPTION
Reflect API's current version: https://search.dip.bundestag.de/api/v1/openapi.yaml

This will introduce several new features, for example:
- additional query parameters such as `f.wahlperiode`
- document hashes
- improved API documentation (hence better client docs)

PS: I think it should be feasible to pull the API's current version on each client generation, instead of having to manually copy/paste it like I did now. Is this something the team is interested in?