### PR TITLE
add workflow for auto sync.

### DIFF
--- a/.github/workflows/auto_sync.yaml
+++ b/.github/workflows/auto_sync.yaml
@@ -20,12 +20,6 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - name: print # If action not triggered manually, set Url
-        id: print
-        run: |
-          echo ${{steps.seturl.outputs.OPENAPI_URL}}
-
-
       - uses: maximiliancw/openapi-sync-action@latest
         with:
           openapi-url: ${{ steps.seturl.outputs.OPENAPI_URL}}

--- a/.github/workflows/auto_sync.yaml
+++ b/.github/workflows/auto_sync.yaml
@@ -1,0 +1,32 @@
+on:
+  schedule:
+    - cron: '0 4 * * 0' # At 04:00 on Sunday.
+  workflow_dispatch:
+    inputs:
+      openapi-url:
+        description: "Url for the openapi.yaml to sync."
+        default: "https://search.dip.bundestag.de/api/v1/openapi.yaml"
+        required: true
+jobs:
+  my_job:
+    runs-on: ubuntu-latest
+    name: OpenAPI Sync
+    steps:
+      - name: Set url step # If action not triggered manually, set Url
+        id: seturl
+        run: |
+          USER_INPUT=${{ github.event.inputs.openapi-url }}
+          echo "::set-output openapi-url=value::${USER_INPUT:-"https://search.dip.bundestag.de/api/v1/openapi.yaml"}"
+
+      - uses: actions/checkout@v3
+
+      - uses: maximiliancw/openapi-sync-action@latest
+        with:
+          openapi-url: ${{ steps.seturl.outputs.value}}
+
+      - uses: devops-infra/action-pull-request@v0.5.5
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          target_branch: main
+          title: New version of openapi.yaml
+          body: "**Automated pull request** New version of openapi found on https://search.dip.bundestag.de/api/v1/openapi.yaml"

--- a/.github/workflows/auto_sync.yaml
+++ b/.github/workflows/auto_sync.yaml
@@ -1,6 +1,6 @@
 on:
-  #schedule:
-  #  - cron: '0 4 * * 0' # At 04:00 on Sunday.
+  schedule:
+    - cron: '0 4 * * 0' # At 04:00 on Sunday.
   workflow_dispatch:
     inputs:
       openapi-url:

--- a/.github/workflows/auto_sync.yaml
+++ b/.github/workflows/auto_sync.yaml
@@ -24,9 +24,9 @@ jobs:
         with:
           openapi-url: ${{ steps.seturl.outputs.value}}
 
-      - uses: devops-infra/action-pull-request@v0.5.5
+      - uses: peter-evans/create-pull-request@v5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          target_branch: main
+          draft: true
           title: New version of openapi.yaml
           body: "**Automated pull request** New version of openapi found on https://search.dip.bundestag.de/api/v1/openapi.yaml"
+          base: main

--- a/.github/workflows/auto_sync.yaml
+++ b/.github/workflows/auto_sync.yaml
@@ -1,6 +1,6 @@
 on:
-  schedule:
-    - cron: '0 4 * * 0' # At 04:00 on Sunday.
+  #schedule:
+  #  - cron: '0 4 * * 0' # At 04:00 on Sunday.
   workflow_dispatch:
     inputs:
       openapi-url:
@@ -35,4 +35,3 @@ jobs:
           draft: true
           title: New version of openapi.yaml
           body: "**Automated pull request** New version of openapi found on https://search.dip.bundestag.de/api/v1/openapi.yaml"
-          base: main

--- a/.github/workflows/auto_sync.yaml
+++ b/.github/workflows/auto_sync.yaml
@@ -16,13 +16,19 @@ jobs:
         id: seturl
         run: |
           USER_INPUT=${{ github.event.inputs.openapi-url }}
-          echo "::set-output openapi-url=value::${USER_INPUT:-"https://search.dip.bundestag.de/api/v1/openapi.yaml"}"
+          echo "OPENAPI_URL=${USER_INPUT:-"https://search.dip.bundestag.de/api/v1/openapi.yaml"}"  >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v3
 
+      - name: print # If action not triggered manually, set Url
+        id: print
+        run: |
+          echo ${{steps.seturl.outputs.OPENAPI_URL}}
+
+
       - uses: maximiliancw/openapi-sync-action@latest
         with:
-          openapi-url: ${{ steps.seturl.outputs.value}}
+          openapi-url: ${{ steps.seturl.outputs.OPENAPI_URL}}
 
       - uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
@maximiliancw 

Initial PR of your sync action.

It will be triggered using the cron job and run every Sunday at 4:00 (Not sure which timezone, maybe UTC?)

Also, I added the option to trigger it manually pointing to another url if needed.

Instead of committing it directly, I think opening an PR is the right way since manual checking is required (e.g. the current version does not pass our linter.)