### PR TITLE
Update contact email for API key requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Bundestag: Dokumentations- und Informationssystem für Parlamentsmaterialien
 ### Authentifizierung
 Zur Nutzung der API wird ein API-Schlüssel benötigt:
 
-- Ein individueller Schlüssel kann per Mail an infoline.id3@bundestag.de beantragt werden
+- Ein individueller Schlüssel kann per Mail an parlamentsdokumentation@bundestag.de beantragt werden
 - Es steht ein temporärer, öffentlicher Schlüssel zur Verfügung ([Quelle](https://dip.bundestag.de/%C3%BCber-dip/hilfe/api#content)). Der aktuelle Schlüssel ist gültig bis Ende 05/2026: `OSOegLs.PR2lwJ1dwCeje9vTj7FPOt3hvpYKtwKkhw`
 
 Der API-Schlüssel kann sowohl als HTTP-Header sowie als GET-Parameter eingesetzt werden:


### PR DESCRIPTION
It seems that the current mail is different now, based on https://dip.bundestag.de/%C3%BCber-dip/hilfe/api